### PR TITLE
Fixed generics, fixed some warnings

### DIFF
--- a/src/main/java/org/loadui/testfx/GuiTest.java
+++ b/src/main/java/org/loadui/testfx/GuiTest.java
@@ -21,21 +21,20 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.SettableFuture;
+
 import javafx.application.Application;
 import javafx.geometry.*;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.SceneBuilder;
-import javafx.scene.control.Labeled;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
-import javafx.scene.layout.VBox;
-import javafx.scene.text.Text;
 import javafx.stage.PopupWindow;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
+
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.loadui.testfx.exceptions.NoNodesFoundException;
@@ -45,6 +44,7 @@ import org.loadui.testfx.utils.KeyCodeUtils;
 import org.loadui.testfx.utils.TestUtils;
 
 import javax.imageio.ImageIO;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -60,13 +60,11 @@ import static org.loadui.testfx.controls.Commons.hasText;
 import static org.loadui.testfx.utils.FXTestUtils.flattenSets;
 import static org.loadui.testfx.utils.FXTestUtils.intersection;
 import static org.loadui.testfx.utils.FXTestUtils.isVisible;
-import static org.loadui.testfx.controls.Commons.hasLabel;
 
 public abstract class GuiTest
 {
 	private static final SettableFuture<Stage> stageFuture = SettableFuture.create();
 	protected static Stage stage;
-	private static String stylesheet = null;
 
 	public static class TestFxApp extends Application
 	{
@@ -104,8 +102,7 @@ public abstract class GuiTest
 
 	private void showNodeInStage( final String stylesheet )
 	{
-		GuiTest.stylesheet = stylesheet;
-
+	    // TODO: Do something with the stylesheet?
 		if( stage == null )
 		{
 			FXTestUtils.launchApp(TestFxApp.class);
@@ -150,10 +147,6 @@ public abstract class GuiTest
 
 	public static <T extends Window> T targetWindow( T window )
 	{
-		if( window instanceof Stage )
-		{
-			Stage stage = ( Stage )window;
-		}
 		lastSeenWindow = window;
 		return window;
 	}
@@ -432,7 +425,8 @@ public abstract class GuiTest
         }, timeoutInSeconds );
     }
 
-	private static <T extends Node> T findByCssSelector( final String selector )
+	@SuppressWarnings("unchecked")
+    private static <T extends Node> T findByCssSelector( final String selector )
 	{
 		Set<Node> locallyFound = findAll( selector );
 		Iterable<Node> globallyFound = concat( transform( getWindows(),
@@ -452,7 +446,8 @@ public abstract class GuiTest
 		return ( T )getFirst( visibleNodes, null );
 	}
 
-	public static <T extends Node> T find( final Matcher<Object> matcher )
+	@SuppressWarnings("unchecked")
+    public static <T extends Node> T find( final Matcher<Object> matcher )
 	{
 		Iterable<Set<Node>> found = transform( getWindows(),
 				new Function<Window, Set<Node>>()
@@ -504,7 +499,7 @@ public abstract class GuiTest
 
     private static Set<Node> findAllRecursively( Matcher<Object> matcher, Node parent)
     {
-        Set<Node> found = new HashSet();
+        Set<Node> found = new HashSet<Node>();
 		if( matcher.matches( parent ) )
 		{
             found.add(parent);
@@ -528,8 +523,9 @@ public abstract class GuiTest
 
     private static <T extends Node> Set<T> findAllRecursively( Predicate<T> predicate, Node parent)
     {
-        Set<T> found = new HashSet();
+        Set<T> found = new HashSet<T>();
         try {
+            @SuppressWarnings("unchecked")
             T node = (T) parent;
             if( predicate.apply( node ) )
             {
@@ -1183,11 +1179,11 @@ public abstract class GuiTest
 		}
 		else if( target instanceof Matcher )
 		{
-			return pointFor( find( ( Matcher )target ) );
+			return pointFor( find( ( Matcher<Object> )target ) );
 		}
         else if( target instanceof Predicate )
         {
-            return pointFor( find( (Predicate) target ) );
+            return pointFor( find( (Predicate<Node>) target ) );
         }
 		else if( target instanceof Iterable<?> )
 		{

--- a/src/main/java/org/loadui/testfx/controls/ListViews.java
+++ b/src/main/java/org/loadui/testfx/controls/ListViews.java
@@ -2,6 +2,7 @@ package org.loadui.testfx.controls;
 
 import javafx.scene.Node;
 import javafx.scene.control.ListView;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
@@ -33,8 +34,9 @@ public class ListViews {
         return table.getItems().size();
     }
 
+    @SuppressWarnings("unchecked")
     @Factory
-    public static org.hamcrest.Matcher containsRow(Object rowValue)
+    public static <S> org.hamcrest.Matcher<S> containsRow(Object rowValue)
     {
         return new ListContainsMatcher(rowValue);
     }
@@ -58,6 +60,7 @@ public class ListViews {
         return (ListView<?>) node;
     }
 
+    @SuppressWarnings("rawtypes")
     private static class ListContainsMatcher extends BaseMatcher {
         private Object valueToMatch;
 

--- a/src/main/java/org/loadui/testfx/controls/TableViews.java
+++ b/src/main/java/org/loadui/testfx/controls/TableViews.java
@@ -1,12 +1,14 @@
 package org.loadui.testfx.controls;
 
 import com.google.common.base.Predicate;
+
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
@@ -50,15 +52,16 @@ public class TableViews
         return table.getItems().size();
     }
 
+    @SuppressWarnings("unchecked")
     @Factory
-    public static Matcher containsCell(Object cellValue)
+    public static <S> Matcher<S> containsCell(Object cellValue)
     {
         return new TableContainsMatcher(cellValue);
     }
 
     static boolean containsCell(TableView<?> table, Predicate<String> cellPredicate)
     {
-        for( TableColumn column : table.getColumns() )
+        for( TableColumn<?, ?> column : table.getColumns() )
         {
             for(int i=0; i<table.getItems().size(); i++ )
             {
@@ -72,7 +75,7 @@ public class TableViews
 
     static boolean containsCell(TableView<?> table, Object cellValue)
     {
-        for( TableColumn column : table.getColumns() )
+        for( TableColumn<?, ?> column : table.getColumns() )
         {
             for(int i=0; i<table.getItems().size(); i++ )
             {
@@ -154,6 +157,7 @@ public class TableViews
         }
     }
 
+    @SuppressWarnings("rawtypes")
     private static class TableContainsMatcher extends BaseMatcher
     {
         private Object valueToMatch;
@@ -163,6 +167,7 @@ public class TableViews
             this.valueToMatch = valueToMatch;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public boolean matches(Object o) {
             if( o instanceof String)

--- a/src/main/java/org/loadui/testfx/controls/impl/HasLabelMatcher.java
+++ b/src/main/java/org/loadui/testfx/controls/impl/HasLabelMatcher.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 import org.junit.internal.matchers.TypeSafeMatcher;
 
 import static org.loadui.testfx.GuiTest.find;
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class HasLabelMatcher extends TypeSafeMatcher<Object>
 {

--- a/src/main/java/org/loadui/testfx/exceptions/NoNodesFoundException.java
+++ b/src/main/java/org/loadui/testfx/exceptions/NoNodesFoundException.java
@@ -2,7 +2,9 @@ package org.loadui.testfx.exceptions;
 
 public class NoNodesFoundException extends NodeQueryException
 {
-	public NoNodesFoundException(String message)
+    private static final long serialVersionUID = 1L;
+
+    public NoNodesFoundException(String message)
 	{
 		super(message);
 	}

--- a/src/main/java/org/loadui/testfx/exceptions/NoNodesVisibleException.java
+++ b/src/main/java/org/loadui/testfx/exceptions/NoNodesVisibleException.java
@@ -1,6 +1,8 @@
 package org.loadui.testfx.exceptions;
 
 public class NoNodesVisibleException extends NodeQueryException {
+    private static final long serialVersionUID = 1L;
+
     public NoNodesVisibleException(String message)
     {
         super(message);

--- a/src/main/java/org/loadui/testfx/exceptions/NodeQueryException.java
+++ b/src/main/java/org/loadui/testfx/exceptions/NodeQueryException.java
@@ -2,6 +2,8 @@ package org.loadui.testfx.exceptions;
 
 public abstract class NodeQueryException extends RuntimeException
 {
+    private static final long serialVersionUID = 1L;
+
     public NodeQueryException(String message)
     {
         super(message);

--- a/src/main/java/org/loadui/testfx/utils/FXTestUtils.java
+++ b/src/main/java/org/loadui/testfx/utils/FXTestUtils.java
@@ -24,9 +24,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.BoundingBox;
@@ -37,6 +37,7 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 import com.google.common.util.concurrent.SettableFuture;
+
 import org.loadui.testfx.GuiTest;
 
 public class FXTestUtils
@@ -233,6 +234,7 @@ public class FXTestUtils
         }
     };
 
+    @SuppressWarnings("deprecation")
     public static boolean isNodeVisible(Node node)
     {
         if(!node.isVisible() || !node.impl_isTreeVisible())

--- a/src/test/java/org/loadui/testfx/DragDropTest.java
+++ b/src/test/java/org/loadui/testfx/DragDropTest.java
@@ -96,7 +96,6 @@ public class DragDropTest extends GuiTest {
         return HBoxBuilder.create().children(list1, list2).build();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(timeout=10000)
     public void shouldMoveElements() throws Exception {
 

--- a/src/test/java/org/loadui/testfx/ListViewsTest.java
+++ b/src/test/java/org/loadui/testfx/ListViewsTest.java
@@ -15,17 +15,9 @@
  */
 package org.loadui.testfx;
 
-import com.google.common.base.Predicate;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ObservableValue;
-import javafx.scene.Node;
 import javafx.scene.Parent;
-import javafx.scene.control.Button;
 import javafx.scene.control.ListView;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
 import javafx.scene.layout.VBoxBuilder;
-import javafx.util.Callback;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.loadui.testfx.GuiTest;

--- a/src/test/java/org/loadui/testfx/TableViewsTest.java
+++ b/src/test/java/org/loadui/testfx/TableViewsTest.java
@@ -9,10 +9,6 @@ import javafx.scene.control.TableView;
 import javafx.scene.layout.VBoxBuilder;
 import javafx.util.Callback;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.loadui.testfx.categories.TestFX;
-import org.loadui.testfx.controls.Commons;
-import org.loadui.testfx.controls.TableViews;
 
 import static javafx.collections.FXCollections.observableArrayList;
 import static org.hamcrest.CoreMatchers.is;
@@ -68,7 +64,7 @@ public class TableViewsTest extends GuiTest
 			@Override
 			public ObservableValue<Integer> call( TableColumn.CellDataFeatures<Integer, Integer> f )
 			{
-				return new SimpleObjectProperty( f.getValue() * 3 );
+				return new SimpleObjectProperty<Integer>( f.getValue() * 3 );
 			}
 		} );
 		table.getColumns().add( column );


### PR DESCRIPTION
I fixed some warnings, most of them by verifying that they're not too bad and suppressing them ...

The more important part (why I actually started this commit) is the generics. I changed the Matcher factories in the classes TableViews and ListViews to return generic instead of raw matchers, which avoids warnings in the test-code that uses TestFX.
