### PR TITLE
Fix NP in containsCell in TableViews

### DIFF
--- a/src/main/java/org/loadui/testfx/controls/TableViews.java
+++ b/src/main/java/org/loadui/testfx/controls/TableViews.java
@@ -15,6 +15,8 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.loadui.testfx.exceptions.NoNodesFoundException;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.loadui.testfx.GuiTest.find;
@@ -59,9 +61,29 @@ public class TableViews
         return new TableContainsMatcher(cellValue);
     }
 
+    static List<TableColumn> flatten(TableColumn col) {
+        if (col.getColumns().size() == 0) {
+            return Arrays.asList(col);
+        } else {
+            List<TableColumn> l = new ArrayList<TableColumn>();
+            for (Object xa : col.getColumns()) {
+                l.addAll(flatten((TableColumn)xa));
+            }
+            return l;
+        }
+    }
+
+    static List<TableColumn> getFlattenedColumns(TableView<?> table)  {
+        List<TableColumn> l = new ArrayList<TableColumn>();
+        for(TableColumn c : table.getColumns()) {
+            l.addAll(flatten(c));
+        }
+        return l;
+    }
+
     static boolean containsCell(TableView<?> table, Predicate<String> cellPredicate)
     {
-        for( TableColumn<?, ?> column : table.getColumns() )
+        for( TableColumn<?, ?> column : getFlattenedColumns(table) )
         {
             for(int i=0; i<table.getItems().size(); i++ )
             {
@@ -75,7 +97,7 @@ public class TableViews
 
     static boolean containsCell(TableView<?> table, Object cellValue)
     {
-        for( TableColumn<?, ?> column : table.getColumns() )
+        for( TableColumn<?, ?> column : getFlattenedColumns(table) )
         {
             for(int i=0; i<table.getItems().size(); i++ )
             {


### PR DESCRIPTION
This pull request addresses a nullpointer if you use containsCell("...") and there is no match in the table.

TableView.fxml:

```
<TableView fx:id="entryTableView" prefHeight="199.0" prefWidth="290.0">
              <columns>
                <TableColumn prefWidth="140.0" text="Entry" fx:id="entryColumn" />
                <TableColumn maxWidth="5000.0" minWidth="10.0" prefWidth="55.0" text="Default" fx:id="defaultColumn" />
                <TableColumn prefWidth="75.0" text="Navigation">
                  <columns>
                    <TableColumn prefWidth="50.0" text="UP" fx:id="upColumn" />
                    <TableColumn prefWidth="50.0" text="DOWN" fx:id="downColumn" />
                    <TableColumn prefWidth="50.0" style="" text="DEL." fx:id="removeColumn" />
                  </columns>
                </TableColumn>
              </columns>
            </TableView>
```

Test code:

```
  verifyThat(GuiTest.find("#entryTableView"), containsCell("item0"))
```

Stacktrace:

```
java.lang.NullPointerException
    at org.loadui.testfx.controls.TableViews.containsCell(TableViews.java:83)
    at org.loadui.testfx.controls.TableViews$TableContainsMatcher.matches(TableViews.java:184)
    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:12)
    at org.loadui.testfx.Assertions.verifyThat(Assertions.java:32)
    at org.loadui.testfx.Assertions.verifyThat(Assertions.java:25)
    at ....
```
