### PR TITLE
Update HasLabelStringMatcher.java

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/loadui/testfx/controls/impl/HasLabelStringMatcher.java
+++ b/subprojects/testfx-core/src/main/java/org/loadui/testfx/controls/impl/HasLabelStringMatcher.java
@@ -50,8 +50,8 @@ public class HasLabelStringMatcher extends TypeSafeMatcher<Object> {
         if (target instanceof String) {
             return nodeHasLabel(find((String) target));
         }
-        else if (target instanceof Labeled) {
-            return nodeHasLabel((Labeled) target);
+        else if (target instanceof Labeled || target instanceof TextInputControl) {
+            return nodeHasLabel((Node) target);
         }
         return false;
     }


### PR DESCRIPTION
Class name suggests this matcher should match only Labeled but the private nodeHasLabel also handles TextInputControl. If this is the intended behavior I think matchesSafetly should be changed to accept TextInputControl as well
