### PR TITLE
Respect headless mode instead of enforcing it

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/loadui/testfx/GuiTest.java
+++ b/subprojects/testfx-core/src/main/java/org/loadui/testfx/GuiTest.java
@@ -23,6 +23,7 @@ import javafx.stage.Stage;
 import javafx.stage.Window;
 import org.hamcrest.Matcher;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.loadui.testfx.framework.app.StageSetupCallback;
 import org.loadui.testfx.framework.junit.AppRobotTestBase;
 import org.loadui.testfx.robots.impl.ScreenRobotImpl;
@@ -33,12 +34,14 @@ import org.loadui.testfx.service.finder.impl.WindowFinderImpl;
 import org.loadui.testfx.service.support.CaptureSupport;
 import org.loadui.testfx.service.support.WaitUntilSupport;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
-import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+
+import static org.junit.Assume.assumeFalse;
 
 public abstract class GuiTest extends AppRobotTestBase implements StageSetupCallback {
 
@@ -164,6 +167,13 @@ public abstract class GuiTest extends AppRobotTestBase implements StageSetupCall
     //---------------------------------------------------------------------------------------------
     // METHODS.
     //---------------------------------------------------------------------------------------------
+
+    @BeforeClass
+    public static void checkHeadless() {
+        assumeFalse(
+                "Cannot run JavaFX in headless environment",
+                GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance());
+    }
 
     @Before
     public void setupGuiTest() throws Exception {

--- a/subprojects/testfx-core/src/main/java/org/loadui/testfx/robots/impl/ScreenRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/loadui/testfx/robots/impl/ScreenRobotImpl.java
@@ -15,7 +15,18 @@
  */
 package org.loadui.testfx.robots.impl;
 
+import com.google.common.collect.ImmutableMap;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.image.Image;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import org.loadui.testfx.robots.ScreenRobot;
+import org.loadui.testfx.utils.FXTestUtils;
+
 import java.awt.AWTException;
+import java.awt.GraphicsEnvironment;
 import java.awt.MouseInfo;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -24,16 +35,6 @@ import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.image.BufferedImage;
 import java.util.Map;
-import javafx.embed.swing.SwingFXUtils;
-import javafx.geometry.Point2D;
-import javafx.geometry.Rectangle2D;
-import javafx.scene.image.Image;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.MouseButton;
-
-import com.google.common.collect.ImmutableMap;
-import org.loadui.testfx.robots.ScreenRobot;
-import org.loadui.testfx.utils.FXTestUtils;
 
 public class ScreenRobotImpl implements ScreenRobot {
 
@@ -58,7 +59,10 @@ public class ScreenRobotImpl implements ScreenRobot {
     //---------------------------------------------------------------------------------------------
 
     public ScreenRobotImpl() {
-        System.setProperty("java.awt.headless", "false");
+        if (GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance()) {
+            awtRobot = null;
+            return;
+        }
         Toolkit.getDefaultToolkit();
         awtRobot = createAwtRobot();
     }


### PR DESCRIPTION
We have a mix of vanilla unit tests, TestFX-3.2 based tests and some legacy hand-crafted JavaFX tests in the project. Our main CI build is running on a Linux server, where we have not got a graphic environment, and our target JavaFX platform is Windows anyway. We tried to segregate unit tests that could be run in a headless mode from the JavaFX tests, but that proved to be a challenge. I know there is a @Category(TestFX.class) available, but category activation/deactivation is rather clumsily implemented in Junit and Maven, and also it does not play well with custom JUnit Runners. We ended up improving one of our custom Runners to automatically mark all JavaFX tests as "ignored" in headless mode, but it would be good if TestFX looked after it itself. Also, the current forcing off of headless mode is also rather non-obvious and deprives us of control during build time.
