### PR TITLE
(feat) Util: Provide `invokeIn...()` and `waitFor...()` methods.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/loadui/testfx/utils/InvokeWaitUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/loadui/testfx/utils/InvokeWaitUtils.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the Licence for the specific language governing permissions
+ * and limitations under the Licence.
+ */
+package org.loadui.testfx.utils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javafx.application.Platform;
+import javafx.beans.value.ObservableBooleanValue;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.util.concurrent.SettableFuture;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class InvokeWaitUtils {
+
+    //---------------------------------------------------------------------------------------------
+    // CONSTANTS.
+    //---------------------------------------------------------------------------------------------
+
+    public final static long CONDITION_SLEEP_IN_MILLIS = 10;
+    public final static long SEMAPHORE_SLEEP_IN_MILLIS = 10;
+    public final static int SEMAPHORE_LOOPS_COUNT = 5;
+
+    //---------------------------------------------------------------------------------------------
+    // STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    public static Future invokeInThread(Callable<Void> callable) {
+        SettableFuture<Void> future = SettableFuture.create();
+        runInThread(() -> callCallableAndSetFuture(callable, future));
+        return future;
+    }
+
+    public static Future invokeInThread(Runnable runnable) {
+        Callable<Void> callable = Executors.callable(runnable, null);
+        return invokeInThread(callable);
+    }
+
+    // Run on the JavaFX Application Thread at some unspecified time in the future.
+    public static Future invokeInApplicationThread(Callable<Void> callable) {
+        SettableFuture<Void> future = SettableFuture.create();
+        runInApplicationThread(() -> callCallableAndSetFuture(callable, future));
+        return future;
+    }
+
+    public static Future invokeInApplicationThread(Runnable runnable) {
+        Callable<Void> callable = Executors.callable(runnable, null);
+        return invokeInApplicationThread(callable);
+    }
+
+    public static void waitFor(Future future,
+                               long timeout,
+                               TimeUnit timeUnit) throws TimeoutException {
+        try {
+            future.get(timeout, timeUnit);
+        }
+        catch (InterruptedException ignore) {}
+        catch (ExecutionException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public static void waitFor(Callable<Boolean> condition,
+                               long timeout,
+                               TimeUnit timeUnit) throws TimeoutException {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start();
+        while (true) {
+            if (callCondition(condition)) {
+                break;
+            }
+            sleep(CONDITION_SLEEP_IN_MILLIS, MILLISECONDS);
+            if (stopwatch.elapsed(timeUnit) > timeout) {
+                throw new TimeoutException();
+            }
+        }
+    }
+
+    public static void waitFor(ObservableBooleanValue booleanValue,
+                               long timeout,
+                               TimeUnit timeUnit) throws TimeoutException {
+        if (booleanValue.get()) { return; }
+        SettableFuture<Void> future = SettableFuture.create();
+        booleanValue.addListener((observable, oldValue, newValue) -> {
+            if (newValue) {
+                future.set(null);
+            }
+        });
+        waitFor(future, timeout, timeUnit);
+    }
+
+    public static void waitForApplicationThread() {
+        waitForApplicationThread(SEMAPHORE_LOOPS_COUNT);
+    }
+
+    public static void waitForApplicationThread(int loopsCount) {
+        for (int loop = 0; loop < loopsCount; loop++) {
+            waitForSemaphore();
+            sleep(SEMAPHORE_SLEEP_IN_MILLIS, MILLISECONDS);
+        }
+    }
+
+    public static void sleep(long duration,
+                             TimeUnit timeUnit) {
+        try {
+            Thread.sleep(timeUnit.toMillis(duration));
+        }
+        catch (InterruptedException ignore) {}
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // PRIVATE STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    private static void runInThread(Runnable runnable) {
+        new Thread(runnable).start();
+    }
+
+    private static void runInApplicationThread(Runnable runnable) {
+        Platform.runLater(runnable);
+    }
+
+    private static void callCallableAndSetFuture(Callable<Void> callable,
+                                                 SettableFuture<Void> future) {
+        try {
+            callable.call();
+            future.set(null);
+        }
+        catch (Throwable exception) {
+            future.setException(exception);
+        }
+    }
+
+    private static boolean callCondition(Callable<Boolean> condition) {
+        try {
+            return condition.call();
+        }
+        catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    private static void waitForSemaphore() {
+        Semaphore semaphore = new Semaphore(0);
+        runInApplicationThread(semaphore::release);
+        try {
+            semaphore.acquire();
+        }
+        catch (InterruptedException ignore) {}
+
+    }
+
+}

--- a/subprojects/testfx-core/src/test/java/org/loadui/testfx/utils/InvokeWaitUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/loadui/testfx/utils/InvokeWaitUtilsTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the Licence for the specific language governing permissions
+ * and limitations under the Licence.
+ */
+package org.loadui.testfx.utils;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class InvokeWaitUtilsTest {
+
+    //---------------------------------------------------------------------------------------------
+    // FIELDS.
+    //---------------------------------------------------------------------------------------------
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Test(timeout=1000)
+    public void invokeInThread() {
+        // when:
+        Future future = InvokeWaitUtils.invokeInThread(() -> {
+        });
+
+        // then:
+        InvokeWaitUtils.sleep(10, MILLISECONDS);
+        assertThat(future.isDone(), Matchers.is(true));
+    }
+
+    @Test(timeout=1000)
+    public void invokeInThread_with_sleep() {
+        // when:
+        Future future = InvokeWaitUtils.invokeInThread(() -> {
+            InvokeWaitUtils.sleep(50, MILLISECONDS);
+        });
+
+        // then:
+        assertThat(future.isDone(), Matchers.is(false));
+        InvokeWaitUtils.sleep(100, MILLISECONDS);
+        assertThat(future.isDone(), Matchers.is(true));
+    }
+
+    @Test(timeout=1000)
+    public void waitFor_with_future() throws Exception {
+        // given:
+        Future future = InvokeWaitUtils.invokeInThread(() -> {
+        });
+
+        // expect:
+        InvokeWaitUtils.waitFor(future, 50, MILLISECONDS);
+    }
+
+    @Test(timeout=1000)
+    public void waitFor_with_future_with_sleep() throws Exception {
+        // given:
+        Future future = InvokeWaitUtils.invokeInThread(() -> {
+            InvokeWaitUtils.sleep(100, MILLISECONDS);
+        });
+
+        // expect:
+        thrown.expect(TimeoutException.class);
+        InvokeWaitUtils.waitFor(future, 50, MILLISECONDS);
+    }
+
+    @Test(timeout=1000)
+    public void waitFor_with_booleanCallable() throws Exception {
+        // expect:
+        InvokeWaitUtils.waitFor(() -> true, 250, MILLISECONDS);
+    }
+
+    @Test(timeout=1000)
+    public void waitFor_with_booleanCallable_with_sleep() throws Exception {
+        // expect:
+        InvokeWaitUtils.waitFor(() -> {
+            InvokeWaitUtils.sleep(50, MILLISECONDS);
+            return true;
+        }, 250, MILLISECONDS);
+    }
+
+    @Test(timeout=1000)
+    public void waitFor_with_booleanCallable_with_false() throws Exception {
+        // expect:
+        thrown.expect(TimeoutException.class);
+        InvokeWaitUtils.waitFor(() -> false, 250, MILLISECONDS);
+    }
+
+    @Test(timeout=1000)
+    public void waitFor_with_booleanValue() throws Exception {
+        // given:
+        BooleanProperty property = new SimpleBooleanProperty(false);
+        InvokeWaitUtils.invokeInThread(() -> {
+            InvokeWaitUtils.sleep(50, MILLISECONDS);
+            property.set(true);
+        });
+
+        // expect:
+        InvokeWaitUtils.waitFor(property, 250, MILLISECONDS);
+    }
+
+    @Test(timeout=1000)
+    public void waitFor_with_booleanValue_with_false() throws Exception {
+        // given:
+        BooleanProperty property = new SimpleBooleanProperty(false);
+        InvokeWaitUtils.invokeInThread(() -> {
+            InvokeWaitUtils.sleep(50, MILLISECONDS);
+            property.set(false);
+        });
+
+        // expect:
+        thrown.expect(TimeoutException.class);
+        InvokeWaitUtils.waitFor(property, 250, MILLISECONDS);
+    }
+
+}


### PR DESCRIPTION
_This PR adds the class `InvokeWaitUtils` that handles concurrency. It provides the groundwork for a more flexible setup and cleanup process for JavaFX fixtures._

The class `InvokeWaitUtils` contains the static methods:
- `invokeInThread(Callable<Void> | Runnable)`:<br>Invokes given callable or runnable in a new `Thread` and returns a `Future` that is set on finish or error.
- `invokeInApplicationThread(Callable<Void> | Runnable)`:<br>Invokes given callable or runnable in the `JavaFX Application Thread` and returns a `Future` that is set on finish or error.
- `waitFor(Future, long, TimeUnit)`:<br>Waits (push) for given future to be set, or times out with `TimeoutException`.
- `waitFor(Callable<Boolean>, long, TimeUnit)`:<br>Waits (pull) for given condition to return `true`,  or times out with `TimeoutException`.
- `waitFor(ObservableBooleanValue, long, TimeUnit)`:<br>Waits (push) for given observable value to return `true`,  or times out with `TimeoutException`.
- `waitForApplicationThread(int)`:<br>Waits the given times for `JavaFX Application Thread`.
- `sleep(long, TimeUnit)`:<br>Sleeps the given duration.

Examples:

``` java
// Launch the Toolkit and retrieve the primary Stage:
if (!ToolkitApplication.primaryStageFuture.isDone()) {
    invokeInThread(() -> Application.launch(ToolkitApplication.class));
}
primaryStage = waitFor(ToolkitApplication.primaryStageFuture, 30, SECONDS);

// Setup a Stage or owned Stages:
waitFor(invokeInApplicationThread(() -> setupStageConsumer(stage)), 30, SECONDS);

// Setup Stages, Scenes and Nodes:
waitFor(invokeInApplicationThread(setupCallable), 30, SECONDS);

// Start an Application that calls stage.show():
invokeInApplicationThread(() -> startApplicationConsumer(stage));
waitFor(stage.showingProperty(), 30, SECONDS);

// Start an Application or setup a Scene that require another condition.
invokeInApplicationThread(() -> startApplicationConsumer(stage));
waitFor(() -> stage.isShowing(), 30, SECONDS);
```

cc: #148
