### PR TITLE
(feat) `hasTableCell()`: Match the string value of cell item.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
@@ -78,7 +78,12 @@ public class TableViewMatchers {
 
     private static boolean hasCellValue(Cell cell,
                                         Object value) {
-        return !cell.isEmpty() && Objects.equals(cell.getItem(), value);
+        return !cell.isEmpty() && hasItemValue(cell.getItem(), value);
+    }
+
+    private static boolean hasItemValue(Object item,
+                                        Object value) {
+        return Objects.equals(item, value) || Objects.equals(item.toString(), value);
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -59,14 +59,16 @@ public class TableViewMatchersTest extends FxRobot {
         FxToolkit.setupSceneRoot(() -> {
             tableView = new TableView<>();
             tableView.setItems(observableArrayList(
-                ImmutableMap.of("name", "alice"),
-                ImmutableMap.of("name", "bob"),
-                ImmutableMap.of("name", "carol"),
-                ImmutableMap.of("name", "dave")
-            ));
+                    ImmutableMap.of("name", "alice", "age", 30),
+                    ImmutableMap.of("name", "bob", "age", 31),
+                    ImmutableMap.of("name", "carol"),
+                    ImmutableMap.of("name", "dave")
+                    ));
             TableColumn<Map, String> tableColumn0 = new TableColumn<>("name");
             tableColumn0.setCellValueFactory(new MapValueFactory<>("name"));
-            tableView.getColumns().add(tableColumn0);
+            TableColumn<Map, Integer> tableColumn1 = new TableColumn<>("age");
+            tableColumn1.setCellValueFactory(new MapValueFactory<>("age"));
+            tableView.getColumns().setAll(tableColumn0, tableColumn1);
             return new StackPane(tableView);
         });
         FxToolkit.showStage();
@@ -80,15 +82,7 @@ public class TableViewMatchersTest extends FxRobot {
     public void hasTableCell() {
         // expect:
         assertThat(tableView, TableViewMatchers.hasTableCell("alice"));
-    }
-
-    @Test
-    public void hasTableCell_with_null_fails() {
-        // expect:
-        exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: TableView has table cell \"null\"\n");
-
-        assertThat(tableView, TableViewMatchers.hasTableCell(null));
+        assertThat(tableView, TableViewMatchers.hasTableCell("bob"));
     }
 
     @Test
@@ -98,6 +92,24 @@ public class TableViewMatchersTest extends FxRobot {
         exception.expectMessage("Expected: TableView has table cell \"foobar\"\n");
 
         assertThat(tableView, TableViewMatchers.hasTableCell("foobar"));
+    }
+
+    @Test
+    public void hasTableCell_with_toString() {
+        // expect:
+        assertThat(tableView, TableViewMatchers.hasTableCell("30"));
+
+        // and:
+        assertThat(tableView, TableViewMatchers.hasTableCell(31));
+    }
+
+    @Test
+    public void hasTableCell_with_null_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TableView has table cell \"null\"\n");
+
+        assertThat(tableView, TableViewMatchers.hasTableCell(null));
     }
 
     @Test


### PR DESCRIPTION
In some cases, it is useful to match a string value against a table
cell's value, regardless of type. For example, when testing a table
of doubles, the string comparison might allow for small discrepancies
in the digital representation that are imperceptible to the user.
This is consistent with BDD principles: implementation details aren't
relevant in testing.

In testfx-legacy, this functionality is provided in the
containsCell method. Without adding a suitable replacement in
testfx-core, it will be more difficult for some developers to
migrate to TestFX 4.