### PR TITLE
(chore) Travis: Allow jobs without framebuffer to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ env:
   - USE_FRAMEBUFFER=true
   - USE_FRAMEBUFFER=false _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
 
+# allow job to fail without framebuffer
+matrix:
+  allow_failures:
+  - env: USE_FRAMEBUFFER=false _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
+
 # run on xvfb screen.
 before_install:
   - if [ $USE_FRAMEBUFFER = "true" ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start; fi


### PR DESCRIPTION
Recently, @hastebrot added a framebuffer-less job to the Travis build.
Since there still seems to be some instability with this job, this
changes `.travis.yml` to allow the job to fail without failing the
build.