### PR TITLE
(feature) Added ApplicationRule

### DIFF
--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit;
+
+import javafx.stage.Stage;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.toolkit.ApplicationFixture;
+
+import java.util.function.Consumer;
+
+public class ApplicationRule extends FxRobot
+        implements ApplicationFixture, TestRule {
+
+    private final Consumer<Stage> start;
+
+    public ApplicationRule(Consumer<Stage> start) {
+        this.start = start;
+    }
+
+    @Override
+    public void init() throws Exception {
+        // do nothing
+    }
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        start.accept(stage);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        // do nothing
+    }
+
+    private void before() throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.setupApplication(this);
+    }
+
+    private void after() throws Exception {
+        FxToolkit.cleanupApplication(this);
+    }
+
+    private Statement externalResource(final Statement base) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                before();
+                try {
+                    base.evaluate();
+                } finally {
+                    after();
+                }
+            }
+        };
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return externalResource(base);
+    }
+
+}

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.testfx.api.FxAssert.verifyThat;
+import static org.testfx.matcher.base.NodeMatchers.hasText;
+
+public class ApplicationRuleTest {
+
+    @Rule
+    public ApplicationRule robot = new ApplicationRule(stage -> {
+        Button button = new Button("click me!");
+        button.setOnAction(actionEvent -> button.setText("clicked!"));
+        stage.setScene(new Scene(new StackPane(button), 100, 100));
+        stage.show();
+    });
+
+    @Test
+    public void should_contain_button() {
+        // expect:
+        verifyThat(".button", hasText("click me!"));
+    }
+
+    @Test
+    public void should_click_on_button() {
+        // when:
+        robot.clickOn(".button");
+
+        // then:
+        verifyThat(".button", hasText("clicked!"));
+    }
+
+}


### PR DESCRIPTION
Added `ApplicationRule`, a utility to allow rule-style integration with JUnit. The primary advantage of choosing this class over `ApplicationTest` is that using a rule doesn't preclude the user from integrating other test utilities, whether rules or base classes.