### PR TITLE
(refactor) Rename window methods to `targetWindow()`, `listWindows()`, and `window()`.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -17,9 +17,11 @@
 package org.testfx.api;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
@@ -78,7 +80,7 @@ public class FxRobot implements FxRobotInterface {
 
     @Override
     @Unstable(reason = "is missing apidocs")
-    public FxRobot pos(Pos pointPosition) {
+    public FxRobot targetPos(Pos pointPosition) {
         context.setPointPosition(pointPosition);
         return this;
     }
@@ -117,7 +119,7 @@ public class FxRobot implements FxRobotInterface {
     public PointQuery point(Node node) {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
-        target(node.getScene().getWindow());
+        targetWindow(node.getScene().getWindow());
         return pointLocator.pointFor(node).atPosition(pointPosition);
     }
 
@@ -126,7 +128,7 @@ public class FxRobot implements FxRobotInterface {
     public PointQuery point(Scene scene) {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
-        target(scene.getWindow());
+        targetWindow(scene.getWindow());
         return pointLocator.pointFor(scene).atPosition(pointPosition);
     }
 
@@ -135,7 +137,7 @@ public class FxRobot implements FxRobotInterface {
     public PointQuery point(Window window) {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
-        target(window);
+        targetWindow(window);
         return pointLocator.pointFor(window).atPosition(pointPosition);
     }
 
@@ -218,8 +220,8 @@ public class FxRobot implements FxRobotInterface {
     @Override
     @Unstable(reason = "is missing apidocs; might change to accept all objects")
     public <T extends Node> PointQuery offset(Matcher<T> matcher,
-                                 double offsetX,
-                                 double offsetY) {
+                                              double offsetX,
+                                              double offsetY) {
         return point(matcher).atOffset(offsetX, offsetY);
     }
 
@@ -237,30 +239,109 @@ public class FxRobot implements FxRobotInterface {
 
     @Override
     @Unstable(reason = "is missing apidocs")
-    public FxRobot target(Window window) {
-        context.getWindowFinder().target(window);
+    public Window targetWindow() {
+        return context.getWindowFinder().targetWindow();
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public FxRobot targetWindow(Window window) {
+        context.getWindowFinder().targetWindow(window);
         return this;
     }
 
     @Override
     @Unstable(reason = "is missing apidocs")
-    public FxRobot target(int windowNumber) {
-        context.getWindowFinder().target(windowNumber);
+    public FxRobotInterface targetWindow(Predicate<Window> predicate) {
+        context.getWindowFinder().targetWindow(predicate);
         return this;
     }
 
     @Override
     @Unstable(reason = "is missing apidocs")
-    public FxRobot target(String stageTitleRegex) {
-        context.getWindowFinder().target(stageTitleRegex);
+    public FxRobot targetWindow(int windowNumber) {
+        context.getWindowFinder().targetWindow(windowNumber);
         return this;
     }
 
     @Override
     @Unstable(reason = "is missing apidocs")
-    public FxRobot target(Scene scene) {
-        context.getWindowFinder().target(scene);
+    public FxRobot targetWindow(String stageTitleRegex) {
+        context.getWindowFinder().targetWindow(stageTitleRegex);
         return this;
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public FxRobotInterface targetWindow(Pattern stageTitlePattern) {
+        context.getWindowFinder().targetWindow(stageTitlePattern);
+        return this;
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public FxRobot targetWindow(Scene scene) {
+        context.getWindowFinder().targetWindow(scene);
+        return this;
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public FxRobotInterface targetWindow(Node node) {
+        context.getWindowFinder().targetWindow(node);
+        return this;
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR WINDOW LOOKUP.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public List<Window> listWindows() {
+        return context.getWindowFinder().listWindows();
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public List<Window> listTargetWindows() {
+        return context.getWindowFinder().listTargetWindows();
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public Window window(Predicate<Window> predicate) {
+        return context.getWindowFinder().window(predicate);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public Window window(int windowIndex) {
+        return context.getWindowFinder().window(windowIndex);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public Window window(String stageTitleRegex) {
+        return context.getWindowFinder().window(stageTitleRegex);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public Window window(Pattern stageTitlePattern) {
+        return context.getWindowFinder().window(stageTitlePattern);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public Window window(Scene scene) {
+        return context.getWindowFinder().window(scene);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public Window window(Node node) {
+        return context.getWindowFinder().window(node);
     }
 
     //---------------------------------------------------------------------------------------------

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -17,8 +17,10 @@
 package org.testfx.api;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
@@ -43,7 +45,7 @@ public interface FxRobotInterface {
     // METHODS FOR POINT POSITION.
     //---------------------------------------------------------------------------------------------
 
-    public FxRobotInterface pos(Pos pointPosition);
+    public FxRobotInterface targetPos(Pos pointPosition);
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR POINT LOCATION.
@@ -98,25 +100,31 @@ public interface FxRobotInterface {
     // METHODS FOR WINDOW TARGETING.
     //---------------------------------------------------------------------------------------------
 
-    public FxRobotInterface target(Window window);
-    public FxRobotInterface target(int windowNumber);
-    public FxRobotInterface target(String stageTitleRegex);
+    public Window targetWindow();
+    public FxRobotInterface targetWindow(Window window);
+    public FxRobotInterface targetWindow(Predicate<Window> predicate);
 
     // Convenience methods:
-    public FxRobotInterface target(Scene scene);
+    public FxRobotInterface targetWindow(int windowIndex);
+    public FxRobotInterface targetWindow(String stageTitleRegex);
+    public FxRobotInterface targetWindow(Pattern stageTitlePattern);
+    public FxRobotInterface targetWindow(Scene scene);
+    public FxRobotInterface targetWindow(Node node);
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR WINDOW LOOKUP.
     //---------------------------------------------------------------------------------------------
 
-    //public List<Window> listWindows();
-    //public List<Window> listTargetWindows();
-
-    //public Window window(int windowIndex);
-    //public Window window(String stageTitleRegex);
+    public List<Window> listWindows();
+    public List<Window> listTargetWindows();
+    public Window window(Predicate<Window> predicate);
 
     // Convenience methods:
-    //public Window window(Scene scene);
+    public Window window(int windowIndex);
+    public Window window(String stageTitleRegex);
+    public Window window(Pattern stageTitlePattern);
+    public Window window(Scene scene);
+    public Window window(Node node);
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR NODE LOOKUP.

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/WriteRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/WriteRobotImpl.java
@@ -77,7 +77,7 @@ public class WriteRobotImpl implements WriteRobot {
     //---------------------------------------------------------------------------------------------
 
     private void pushCharacter(char character) {
-        Scene scene = windowFinder.target().getScene();
+        Scene scene = windowFinder.targetWindow().getScene();
         KeyCode key = determineKeyCode(character);
         baseRobot.typeKeyboard(scene, key, Character.toString(character));
         baseRobot.awaitEvents();

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
@@ -17,22 +17,43 @@
 package org.testfx.service.finder;
 
 import java.util.List;
+import java.util.regex.Pattern;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.Window;
 
+import com.google.common.base.Predicate;
+
 public interface WindowFinder {
-    public Window target();
-    public void target(Window window);
-    public void target(int windowIndex);
-    public void target(String stageTitleRegex);
-    public void target(Scene scene);
-    //public void target(Node node);
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR WINDOW TARGETING.
+    //---------------------------------------------------------------------------------------------
+
+    public Window targetWindow();
+    public void targetWindow(Window window);
+    public void targetWindow(Predicate<Window> predicate);
+
+    // Convenience methods:
+    public void targetWindow(int windowIndex);
+    public void targetWindow(String stageTitleRegex);
+    public void targetWindow(Pattern stageTitlePattern);
+    public void targetWindow(Scene scene);
+    public void targetWindow(Node node);
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR WINDOW LOOKUP.
+    //---------------------------------------------------------------------------------------------
 
     public List<Window> listWindows();
-    public List<Window> listOrderedWindows();
+    public List<Window> listTargetWindows();
+    public Window window(Predicate<Window> predicate);
 
+    // Convenience methods:
     public Window window(int windowIndex);
     public Window window(String stageTitleRegex);
+    public Window window(Pattern stageTitlePattern);
     public Window window(Scene scene);
-    //public Window window(Node node);
+    public Window window(Node node);
+
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
@@ -112,7 +112,7 @@ public class NodeFinderImpl implements NodeFinder {
     //---------------------------------------------------------------------------------------------
 
     private Set<Node> rootsOfWindows() {
-        List<Window> windows = windowFinder.listOrderedWindows();
+        List<Window> windows = windowFinder.listTargetWindows();
         return NodeQueryUtils.rootsOfWindows(windows);
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
@@ -17,6 +17,8 @@
 package org.testfx.service.finder.impl;
 
 import java.util.List;
+import java.util.regex.Pattern;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.PopupWindow;
 import javafx.stage.Stage;
@@ -28,14 +30,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import org.testfx.api.annotation.Unstable;
 import org.testfx.service.finder.WindowFinder;
 
-@Unstable
 public class WindowFinderImpl implements WindowFinder {
 
     //---------------------------------------------------------------------------------------------
-    // FIELDS.
+    // PRIVATE FIELDS.
     //---------------------------------------------------------------------------------------------
 
     private Window lastTargetWindow;
@@ -45,54 +45,77 @@ public class WindowFinderImpl implements WindowFinder {
     //---------------------------------------------------------------------------------------------
 
     @Override
-    public Window target() {
+    public Window targetWindow() {
         return lastTargetWindow;
     }
 
     @Override
-    public void target(Window window) {
+    public void targetWindow(Window window) {
         lastTargetWindow = window;
     }
 
     @Override
-    public void target(int windowIndex) {
-        target(window(windowIndex));
+    public void targetWindow(Predicate<Window> predicate) {
+        targetWindow(window(predicate));
     }
 
     @Override
-    public void target(String stageTitleRegex) {
-        target(window(stageTitleRegex));
-    }
-
-    @Override
-    public void target(Scene scene) {
-        target(window(scene));
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
     public List<Window> listWindows() {
-        List<Window> windows = Lists.newArrayList(Window.impl_getWindows());
-        return ImmutableList.copyOf(Lists.reverse(windows));
+        return fetchWindowsInQueue();
     }
 
     @Override
-    public List<Window> listOrderedWindows() {
-        List<Window> windows = listWindows();
-        List<Window> orderedWindows = orderWindowsByProximityTo(lastTargetWindow, windows);
-        return orderedWindows;
+    public List<Window> listTargetWindows() {
+        return fetchWindowsByProximityTo(lastTargetWindow);
+    }
+
+    @Override
+    public Window window(Predicate<Window> predicate) {
+        List<Window> windows = fetchWindowsByProximityTo(lastTargetWindow);
+        return Iterables.find(windows, predicate);
+    }
+
+    // Convenience methods:
+
+    @Override
+    public void targetWindow(int windowIndex) {
+        targetWindow(window(windowIndex));
+    }
+
+    @Override
+    public void targetWindow(String stageTitleRegex) {
+        targetWindow(window(stageTitleRegex));
+    }
+
+    @Override
+    public void targetWindow(Pattern stageTitlePattern) {
+        targetWindow(window(stageTitlePattern));
+    }
+
+    @Override
+    public void targetWindow(Scene scene) {
+        targetWindow(window(scene));
+    }
+
+    @Override
+    public void targetWindow(Node node) {
+        targetWindow(window(node));
     }
 
     @Override
     public Window window(int windowIndex) {
-        List<Window> windows = listWindows();
+        List<Window> windows = fetchWindowsByProximityTo(lastTargetWindow);
         return windows.get(windowIndex);
     }
 
     @Override
     public Window window(String stageTitleRegex) {
-        List<Window> windows = listWindows();
-        return Iterables.find(windows, hasStageTitlePredicate(stageTitleRegex));
+        return window(hasStageTitlePredicate(stageTitleRegex));
+    }
+
+    @Override
+    public Window window(Pattern stageTitlePattern) {
+        return window(hasStageTitlePredicate(stageTitlePattern.toString()));
     }
 
     @Override
@@ -100,21 +123,40 @@ public class WindowFinderImpl implements WindowFinder {
         return scene.getWindow();
     }
 
+    @Override
+    public Window window(Node node) {
+        return window(node.getScene());
+    }
+
     //---------------------------------------------------------------------------------------------
     // PRIVATE METHODS.
     //---------------------------------------------------------------------------------------------
 
-    private List<Window> orderWindowsByProximityTo(Window targetWindow, List<Window> windows) {
+    @SuppressWarnings("deprecation")
+    private List<Window> fetchWindowsInQueue() {
+        List<Window> windows = Lists.newArrayList(Window.impl_getWindows());
+        return ImmutableList.copyOf(Lists.reverse(windows));
+    }
+
+    private List<Window> fetchWindowsByProximityTo(Window targetWindow) {
+        List<Window> windows = fetchWindowsInQueue();
+        List<Window> windowsByProximity = orderWindowsByProximityTo(targetWindow, windows);
+        return windowsByProximity;
+    }
+
+    private List<Window> orderWindowsByProximityTo(Window targetWindow,
+                                                   List<Window> windows) {
         return Ordering.natural()
             .onResultOf(calculateWindowProximityFunction(targetWindow))
             .immutableSortedCopy(windows);
     }
 
-    private Function<Window, Integer> calculateWindowProximityFunction(final Window targetWindow) {
+    private Function<Window, Integer> calculateWindowProximityFunction(Window targetWindow) {
         return window -> calculateWindowProximityTo(targetWindow, window);
     }
 
-    private int calculateWindowProximityTo(Window targetWindow, Window window) {
+    private int calculateWindowProximityTo(Window targetWindow,
+                                           Window window) {
         if (window == targetWindow) {
             return 0;
         }
@@ -124,7 +166,8 @@ public class WindowFinderImpl implements WindowFinder {
         return 2;
     }
 
-    private boolean isOwnerOf(Window window, Window targetWindow) {
+    private boolean isOwnerOf(Window window,
+                              Window targetWindow) {
         Window ownerWindow = retrieveOwnerOf(window);
         if (ownerWindow == targetWindow) {
             return true;
@@ -142,12 +185,13 @@ public class WindowFinderImpl implements WindowFinder {
         return null;
     }
 
-    private Predicate<Window> hasStageTitlePredicate(final String stageTitleRegex) {
+    private Predicate<Window> hasStageTitlePredicate(String stageTitleRegex) {
         return window -> window instanceof Stage &&
             hasStageTitle((Stage) window, stageTitleRegex);
     }
 
-    private boolean hasStageTitle(Stage stage, String stageTitleRegex) {
+    private boolean hasStageTitle(Stage stage,
+                                  String stageTitleRegex) {
         return stage.getTitle() != null && stage.getTitle().matches(stageTitleRegex);
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryUtils.java
@@ -177,12 +177,12 @@ public final class NodeQueryUtils {
     }
 
     private static boolean hasNodeId(Node node,
-                                     String id) {
+                                       String id) {
         return Objects.equals(node.getId(), id);
     }
 
     private static boolean hasNodeText(Node node,
-                                       String text) {
+                                         String text) {
         // TODO: Test cases with node.getText() == null.
         if (node instanceof Labeled) {
             return Objects.equals(((Labeled) node).getText(), text);
@@ -194,7 +194,7 @@ public final class NodeQueryUtils {
     }
 
     private static boolean matchesNodeMatcher(Node node,
-                                              Matcher matcher) {
+                                                Matcher matcher) {
         // TODO: Test cases with ClassCastException.
         return matcher.matches(node);
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/WriteRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/WriteRobotImplTest.java
@@ -77,7 +77,7 @@ public final class WriteRobotImplTest {
     @Test
     public void write_char() {
         // given:
-        given(windowFinder.target()).willReturn(stage);
+        given(windowFinder.targetWindow()).willReturn(stage);
 
         // when:
         writeRobot.write('a');
@@ -89,7 +89,7 @@ public final class WriteRobotImplTest {
     @Test
     public void write_char_with_whitespace() {
         // given:
-        given(windowFinder.target()).willReturn(stage);
+        given(windowFinder.targetWindow()).willReturn(stage);
 
         // when:
         writeRobot.write('\t');
@@ -103,7 +103,7 @@ public final class WriteRobotImplTest {
     @Test
     public void write_string() {
         // given:
-        given(windowFinder.target()).willReturn(stage);
+        given(windowFinder.targetWindow()).willReturn(stage);
 
         // when:
         writeRobot.write("ae");

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
@@ -17,6 +17,7 @@
 package org.testfx.service.finder.impl;
 
 import java.util.List;
+import java.util.regex.Pattern;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -180,7 +181,7 @@ public class NodeFinderImplTest {
     }
 
     @Test
-    @Ignore
+    @Ignore("error is only used for robots")
     public void node_string_cssQuery_nonExistentNode() {
         // expect:
         thrown.expect(NodeFinderException.class);
@@ -189,7 +190,7 @@ public class NodeFinderImplTest {
     }
 
     @Test
-    @Ignore
+    @Ignore("error is only used for robots")
     public void node_string_cssQuery_invisibleNode() {
         // expect:
         thrown.expect(NodeFinderException.class);
@@ -204,7 +205,7 @@ public class NodeFinderImplTest {
     //}
 
     @Test
-    @Ignore
+    @Ignore("error is only used for robots")
     public void node_string_labelQuery_nonExistentNode() {
         // expect:
         thrown.expect(NodeFinderException.class);
@@ -213,7 +214,7 @@ public class NodeFinderImplTest {
     }
 
     @Test
-    @Ignore
+    @Ignore("error is only used for robots")
     public void node_string_labelQuery_invisibleNode() {
         // expect:
         thrown.expect(NodeFinderException.class);
@@ -246,7 +247,7 @@ public class NodeFinderImplTest {
     }
 
     @Test
-    @Ignore
+    @Ignore("error is only used for robots")
     public void nodes_string_cssQuery_nonExistentNode() {
         // expect:
         thrown.expect(NodeFinderException.class);
@@ -255,7 +256,7 @@ public class NodeFinderImplTest {
     }
 
     @Test
-    @Ignore
+    @Ignore("error is only used for robots")
     public void nodes_string_cssQuery_invisibleNode() {
         // expect:
         thrown.expect(NodeFinderException.class);
@@ -333,28 +334,13 @@ public class NodeFinderImplTest {
         public List<Window> windows;
 
         @Override
-        public Window target() {
+        public Window targetWindow() {
             return targetWindow;
         }
 
         @Override
-        public void target(Window window) {
+        public void targetWindow(Window window) {
             targetWindow = window;
-        }
-
-        @Override
-        public void target(int windowIndex) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void target(String stageTitleRegex) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void target(Scene scene) {
-            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -363,23 +349,56 @@ public class NodeFinderImplTest {
         }
 
         @Override
-        public List<Window> listOrderedWindows() {
+        public List<Window> listTargetWindows() {
             return windows;
         }
 
         @Override
+        public void targetWindow(Predicate<Window> predicate) {}
+
+        @Override
+        public void targetWindow(int windowIndex) {}
+
+        @Override
+        public void targetWindow(String stageTitleRegex) {}
+
+        @Override
+        public void targetWindow(Pattern stageTitlePattern) {}
+
+        @Override
+        public void targetWindow(Scene scene) {}
+
+        @Override
+        public void targetWindow(Node node) {}
+
+        @Override
+        public Window window(Predicate<Window> predicate) {
+            return null;
+        }
+
+        @Override
         public Window window(int windowIndex) {
-            throw new UnsupportedOperationException();
+            return null;
         }
 
         @Override
         public Window window(String stageTitleRegex) {
-            throw new UnsupportedOperationException();
+            return null;
+        }
+
+        @Override
+        public Window window(Pattern stageTitlePattern) {
+            return null;
         }
 
         @Override
         public Window window(Scene scene) {
-            throw new UnsupportedOperationException();
+            return null;
+        }
+
+        @Override
+        public Window window(Node node) {
+            return null;
         }
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
@@ -22,11 +22,11 @@ import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
+import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.hamcrest.Matchers;
 import org.testfx.api.FxToolkit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -52,6 +52,7 @@ public class WindowFinderImplTest {
     @BeforeClass
     public static void setupSpec() throws Exception {
         FxToolkit.registerPrimaryStage();
+        FxToolkit.showStage();
         FxToolkit.setupScene(() -> new Scene(new Region(), 600, 400));
         FxToolkit.setupFixture(() -> setupStagesClass());
     }
@@ -114,10 +115,10 @@ public class WindowFinderImplTest {
     }
 
     @Test
-    public void listOrderedWindows() {
+    public void listTargetWindows() {
         // TODO: Assert that ordering of windows is correct.
         // when:
-        List<Window> orderedWindows = windowFinder.listOrderedWindows();
+        List<Window> orderedWindows = windowFinder.listTargetWindows();
 
         // then:
         assertThat(orderedWindows, Matchers.hasItems((Window) window));
@@ -127,39 +128,39 @@ public class WindowFinderImplTest {
     }
 
     @Test
-    public void target_window() {
+    public void targetWindow_window() {
         // when:
-        windowFinder.target(window);
+        windowFinder.targetWindow(window);
 
         // then:
-        assertThat(windowFinder.target(), Matchers.is((Window) window));
+        assertThat(windowFinder.targetWindow(), Matchers.is((Window) window));
     }
 
     @Test
-    public void target_windowIndex() {
+    public void targetWindow_windowIndex() {
         // when:
-        windowFinder.target(1);
+        windowFinder.targetWindow(1);
 
         // then:
-        assertThat(windowFinder.target(), Matchers.is((Window) window));
+        assertThat(windowFinder.targetWindow(), Matchers.is((Window) window));
     }
 
     @Test
-    public void target_stageTitleRegex() {
+    public void targetWindow_stageTitle() {
         // when:
-        windowFinder.target("window");
+        windowFinder.targetWindow("window");
 
         // then:
-        assertThat(windowFinder.target(), Matchers.is((Window) window));
+        assertThat(windowFinder.targetWindow(), Matchers.is((Window) window));
     }
 
     @Test
-    public void target_scene() {
+    public void targetWindow_scene() {
         // when:
-        windowFinder.target(scene);
+        windowFinder.targetWindow(scene);
 
         // then:
-        assertThat(windowFinder.target(), Matchers.is((Window) otherWindow));
+        assertThat(windowFinder.targetWindow(), Matchers.is((Window) otherWindow));
     }
 
     @Test
@@ -173,7 +174,7 @@ public class WindowFinderImplTest {
     }
 
     @Test
-    public void window_stageTitleRegex() {
+    public void window_stageTitle() {
         // TODO: Assert that it thrown an exception of stage title regex does not match.
         // TODO: Assert that stages without title do not throw a NPE.
         // expect:

--- a/subprojects/testfx-legacy/src/main/java/org/loadui/testfx/GuiTest.java
+++ b/subprojects/testfx-legacy/src/main/java/org/loadui/testfx/GuiTest.java
@@ -52,13 +52,13 @@ public abstract class GuiTest extends FxRobot {
     // STATIC METHODS.
     //---------------------------------------------------------------------------------------------
 
-    public static <T extends Window> T targetWindow(T window) {
-        windowFinder.target(window);
+    public static <T extends Window> T _targetWindow(T window) {
+        windowFinder.targetWindow(window);
         return window;
     }
 
     public static List<Window> getWindows() {
-        return windowFinder.listWindows();
+        return windowFinder.listTargetWindows();
     }
 
     public static Window getWindowByIndex(int windowIndex) {
@@ -230,7 +230,7 @@ public abstract class GuiTest extends FxRobot {
 
     @Before
     public void internalSetup() throws Exception {
-        target(FxToolkit.registerPrimaryStage());
+        targetWindow(FxToolkit.registerPrimaryStage());
         FxToolkit.setupSceneRoot(() -> getRootNode());
         WaitForAsyncUtils.waitForFxEvents();
         FxToolkit.setupStage((stage) -> {


### PR DESCRIPTION
Changes:

- Add all missing window finder methods to `FxRobot`.
- Rename `pos()` to `targetPos()`.
- Rename `target()` to `targetWindow()` to emphasize that it is a window-related method.
- Rename `listOrderedWindows()` to `listTargetWindows()` to emphasize the relationship to `targetWindow()`.
- Add `window()` variants with parameter `Predicate<Window>`, `Stage`, and `Node`.

Interface:

~~~java
interface WindowFinder {
    Window targetWindow();
    void targetWindow(Window window);
    void targetWindow(Predicate<Window> predicate);

    List<Window> listWindows();
    List<Window> listTargetWindows();
    Window window(Predicate<Window> predicate);
	
    // Convenience methods:
    void targetWindow(int windowIndex);
    void targetWindow(String stageTitleRegex);
    void targetWindow(Pattern stageTitlePattern);
    void targetWindow(Scene scene);
    void targetWindow(Node node);

    Window window(int windowIndex);
    Window window(String stageTitleRegex);
    Window window(Pattern stageTitlePattern);
    Window window(Scene scene);
    Window window(Node node);
}
~~~