### PR TITLE
(refactor) `NodeQuery`: Rename methods to `match()`, `nth()` and `query()`.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
@@ -166,7 +166,7 @@ public final class FxAssert {
     }
 
     private static <T extends Node> T toNode(NodeQuery nodeQuery) {
-        return nodeQuery.queryFirst();
+        return nodeQuery.query();
     }
 
     private static <T extends Node> Set<T> toNodeSet(NodeQuery nodeQuery) {

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -44,7 +44,7 @@ import org.testfx.service.locator.PointLocator;
 import org.testfx.service.query.NodeQuery;
 import org.testfx.service.query.PointQuery;
 
-import static org.testfx.service.query.impl.NodeQueryUtils.isVisible;
+import static org.testfx.util.NodeQueryUtils.isVisible;
 import static org.testfx.util.WaitForAsyncUtils.asyncFx;
 import static org.testfx.util.WaitForAsyncUtils.waitFor;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
@@ -148,7 +148,7 @@ public class FxRobot implements FxRobotInterface {
     @Unstable(reason = "is missing apidocs")
     public PointQuery point(String query) {
         NodeQuery nodeQuery = lookup(query);
-        Node node = queryFirstNode(nodeQuery, "the query \"" + query + "\"");
+        Node node = queryNode(nodeQuery, "the query \"" + query + "\"");
         return point(node).atPosition(context.getPointPosition());
     }
 
@@ -156,7 +156,7 @@ public class FxRobot implements FxRobotInterface {
     @Unstable(reason = "is missing apidocs; might change to accept all objects")
     public <T extends Node> PointQuery point(Matcher<T> matcher) {
         NodeQuery nodeQuery = lookup(matcher);
-        Node node = queryFirstNode(nodeQuery, "the matcher \"" + matcher.toString() + "\"");
+        Node node = queryNode(nodeQuery, "the matcher \"" + matcher.toString() + "\"");
         return point(node).atPosition(context.getPointPosition());
     }
 
@@ -164,7 +164,7 @@ public class FxRobot implements FxRobotInterface {
     @Unstable(reason = "is missing apidocs")
     public <T extends Node> PointQuery point(Predicate<T> predicate) {
         NodeQuery nodeQuery = lookup(predicate);
-        Node node = queryFirstNode(nodeQuery, "the predicate");
+        Node node = queryNode(nodeQuery, "the predicate");
         return point(node).atPosition(context.getPointPosition());
     }
 
@@ -1081,25 +1081,25 @@ public class FxRobot implements FxRobotInterface {
 
     private PointQuery pointOfVisibleNode(String query) {
         NodeQuery nodeQuery = lookup(query);
-        Node node = queryFirstVisibleNode(nodeQuery, "the query \"" + query + "\"");
+        Node node = queryVisibleNode(nodeQuery, "the query \"" + query + "\"");
         return point(node);
     }
 
     private <T extends Node> PointQuery pointOfVisibleNode(Matcher<T> matcher) {
         NodeQuery nodeQuery = lookup(matcher);
-        Node node = queryFirstVisibleNode(nodeQuery, "the matcher \"" + matcher.toString() + "\"");
+        Node node = queryVisibleNode(nodeQuery, "the matcher \"" + matcher.toString() + "\"");
         return point(node);
     }
 
     private <T extends Node> PointQuery pointOfVisibleNode(Predicate<T> predicate) {
         NodeQuery nodeQuery = lookup(predicate);
-        Node node = queryFirstVisibleNode(nodeQuery, "the predicate");
+        Node node = queryVisibleNode(nodeQuery, "the predicate");
         return point(node);
     }
 
-    private Node queryFirstNode(NodeQuery nodeQuery,
-                                String queryDescription) {
-        Optional<Node> resultNode = nodeQuery.tryQueryFirst();
+    private Node queryNode(NodeQuery nodeQuery,
+                           String queryDescription) {
+        Optional<Node> resultNode = nodeQuery.tryQuery();
         if (!resultNode.isPresent()) {
             String message = queryDescription + " returned no nodes.";
             throw new FxRobotException(message);
@@ -1107,14 +1107,14 @@ public class FxRobot implements FxRobotInterface {
         return resultNode.get();
     }
 
-    private Node queryFirstVisibleNode(NodeQuery nodeQuery,
-                                       String queryDescription) {
+    private Node queryVisibleNode(NodeQuery nodeQuery,
+                                  String queryDescription) {
         Set<Node> resultNodes = nodeQuery.queryAll();
         if (resultNodes.isEmpty()) {
             String message = queryDescription + " returned no nodes.";
             throw new FxRobotException(message);
         }
-        Optional<Node> resultNode = from(resultNodes).select(isVisible()).tryQueryFirst();
+        Optional<Node> resultNode = from(resultNodes).match(isVisible()).tryQuery();
         if (!resultNode.isPresent()) {
             String message = queryDescription + " returned " + resultNodes.size() + " nodes" +
                 ", but no nodes were visible.";

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
@@ -66,8 +66,8 @@ public class ListViewMatchers {
         NodeFinder nodeFinder = FxAssert.assertContext().getNodeFinder();
         NodeQuery nodeQuery = nodeFinder.from(listView);
         return nodeQuery.lookup(SELECTOR_LIST_CELL)
-            .<Cell>select(cell -> hasCellValue(cell, value))
-            .tryQueryFirst().isPresent();
+            .<Cell>match(cell -> hasCellValue(cell, value))
+            .tryQuery().isPresent();
     }
 
     private static boolean hasItems(ListView listView,

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
@@ -67,8 +67,8 @@ public class TableViewMatchers {
         NodeFinder nodeFinder = FxAssert.assertContext().getNodeFinder();
         NodeQuery nodeQuery = nodeFinder.from(tableView);
         return nodeQuery.lookup(SELECTOR_TABLE_CELL)
-            .<Cell>select(cell -> hasCellValue(cell, value))
-            .tryQueryFirst().isPresent();
+            .<Cell>match(cell -> hasCellValue(cell, value))
+            .tryQuery().isPresent();
     }
 
     private static boolean hasItems(TableView tableView,

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
@@ -31,7 +31,7 @@ import org.testfx.service.finder.WindowFinder;
 import org.testfx.service.query.NodeQuery;
 import org.testfx.service.query.NodeQueryFactory;
 import org.testfx.service.query.impl.NodeQueryFactoryImpl;
-import org.testfx.service.query.impl.NodeQueryUtils;
+import org.testfx.util.NodeQueryUtils;
 
 @Unstable
 public class NodeFinderImpl implements NodeFinder {

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
@@ -39,12 +39,12 @@ public interface NodeQuery {
     <T extends Node> NodeQuery lookup(Predicate<T> predicate);
     NodeQuery lookup(Function<Node, Set<Node>> function);
 
-    <T> NodeQuery select(Matcher<T> matcher);
-    <T extends Node> NodeQuery select(Predicate<T> predicate);
-    NodeQuery selectAt(int index);
+    <T> NodeQuery match(Matcher<T> matcher);
+    <T extends Node> NodeQuery match(Predicate<T> predicate);
+    NodeQuery nth(int index);
 
-    <T extends Node> T queryFirst();
-    <T extends Node> Optional<T> tryQueryFirst();
+    <T extends Node> T query();
+    <T extends Node> Optional<T> tryQuery();
     <T extends Node> Set<T> queryAll();
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.query.NodeQuery;
+import org.testfx.util.NodeQueryUtils;
 
 @Unstable
 public class NodeQueryImpl implements NodeQuery {
@@ -97,7 +98,7 @@ public class NodeQueryImpl implements NodeQuery {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> NodeQuery select(Matcher<T> matcher) {
+    public <T> NodeQuery match(Matcher<T> matcher) {
         FluentIterable<Node> query = FluentIterable.from(parentNodes);
         query = query.filter(NodeQueryUtils.matchesMatcher((Matcher<Node>) matcher));
         parentNodes = query.toSet();
@@ -106,7 +107,7 @@ public class NodeQueryImpl implements NodeQuery {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends Node> NodeQuery select(Predicate<T> predicate) {
+    public <T extends Node> NodeQuery match(Predicate<T> predicate) {
         FluentIterable<Node> query = FluentIterable.from(parentNodes);
         query = query.filter((Predicate<Node>) predicate);
         parentNodes = query.toSet();
@@ -114,7 +115,7 @@ public class NodeQueryImpl implements NodeQuery {
     }
 
     @Override
-    public NodeQuery selectAt(int index) {
+    public NodeQuery nth(int index) {
         FluentIterable<Node> query = FluentIterable.from(parentNodes);
         query = query.skip(index).limit(1);
         parentNodes = query.toSet();
@@ -123,14 +124,14 @@ public class NodeQueryImpl implements NodeQuery {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends Node> T queryFirst() {
+    public <T extends Node> T query() {
         FluentIterable<Node> query = FluentIterable.from(parentNodes);
         return (T) query.first().orNull();
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends Node> Optional<T> tryQueryFirst() {
+    public <T extends Node> Optional<T> tryQuery() {
         FluentIterable<Node> query = FluentIterable.from(parentNodes);
         return (Optional<T>) query.first();
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
@@ -14,7 +14,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-package org.testfx.service.query.impl;
+package org.testfx.util;
 
 import java.util.Collection;
 import java.util.List;

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -73,7 +73,7 @@ public class FxAssertBasicTest extends TestCaseBase {
     public void button_is_disabled() {
         // when:
         interact(() -> {
-            lookup("#button").queryFirst().setDisable(true);
+            lookup("#button").query().setDisable(true);
         });
 
         // then:
@@ -90,7 +90,7 @@ public class FxAssertBasicTest extends TestCaseBase {
     public void button_is_invisible() {
         // when:
         interact(() -> {
-            lookup("#button").queryFirst().setVisible(false);
+            lookup("#button").query().setVisible(false);
         });
 
         // then:

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
@@ -94,7 +94,7 @@ public class NodeAndPointQueryTest {
         NodeQuery query = fx.lookup(".button");
 
         // then:
-        assertThat(query.queryFirst(), is(button0));
+        assertThat(query.query(), is(button0));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class NodeAndPointQueryTest {
         NodeQuery query = fx.lookup(".missing");
 
         // then:
-        assertThat(query.queryFirst(), nullValue());
+        assertThat(query.query(), nullValue());
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
@@ -67,7 +67,7 @@ public class NodeMatchersTest extends FxRobot {
         });
 
         // expect:
-        assertThat(from(nodes).select(NodeMatchers.anything()).queryAll(),
+        assertThat(from(nodes).match(NodeMatchers.anything()).queryAll(),
             hasItem(NodeMatchers.hasText("bar")));
     }
 
@@ -118,11 +118,11 @@ public class NodeMatchersTest extends FxRobot {
         });
 
         // expect:
-        NodeQuery query1 = from(nodes).select(NodeMatchers.hasText("foo"));
+        NodeQuery query1 = from(nodes).match(NodeMatchers.hasText("foo"));
         assertThat(query1.queryAll(), contains(nodes.get(1)));
 
         // and:
-        NodeQuery query2 = from(nodes).select(NodeMatchers.hasText("bar"));
+        NodeQuery query2 = from(nodes).match(NodeMatchers.hasText("bar"));
         assertThat(query2.queryAll(), contains(nodes.get(2)));
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
@@ -166,18 +166,18 @@ public class NodeFinderImplTest {
     @Test
     public void node_string_cssQuery() {
         // expect:
-        assertThat(nodeFinder.lookup("#firstId").queryFirst(), is(firstIdLabel));
-        assertThat(nodeFinder.lookup("#secondId").queryFirst(), is(secondIdLabel));
-        assertThat(nodeFinder.lookup(".thirdClass").queryFirst(), is(thirdClassLabel));
+        assertThat(nodeFinder.lookup("#firstId").query(), is(firstIdLabel));
+        assertThat(nodeFinder.lookup("#secondId").query(), is(secondIdLabel));
+        assertThat(nodeFinder.lookup(".thirdClass").query(), is(thirdClassLabel));
     }
 
     @Test
     public void node_string_labelQuery() {
 
         // expect:
-        assertThat(nodeFinder.lookup("first").queryFirst(), is(firstIdLabel));
-        assertThat(nodeFinder.lookup("second").queryFirst(), is(secondIdLabel));
-        assertThat(nodeFinder.lookup("third").queryFirst(), is(thirdClassLabel));
+        assertThat(nodeFinder.lookup("first").query(), is(firstIdLabel));
+        assertThat(nodeFinder.lookup("second").query(), is(secondIdLabel));
+        assertThat(nodeFinder.lookup("third").query(), is(thirdClassLabel));
     }
 
     @Test
@@ -186,7 +186,7 @@ public class NodeFinderImplTest {
         // expect:
         thrown.expect(NodeFinderException.class);
         thrown.expectMessage("No matching nodes were found.");
-        assertThat(nodeFinder.lookup("#nonExistentNode").queryFirst(), is(nullValue()));
+        assertThat(nodeFinder.lookup("#nonExistentNode").query(), is(nullValue()));
     }
 
     @Test
@@ -195,7 +195,7 @@ public class NodeFinderImplTest {
         // expect:
         thrown.expect(NodeFinderException.class);
         thrown.expectMessage("Matching nodes were found, but none of them are visible.");
-        assertThat(nodeFinder.lookup("#invisibleNode").queryFirst(), is(nullValue()));
+        assertThat(nodeFinder.lookup("#invisibleNode").query(), is(nullValue()));
     }
 
     //@Test
@@ -210,7 +210,7 @@ public class NodeFinderImplTest {
         // expect:
         thrown.expect(NodeFinderException.class);
         thrown.expectMessage("No matching nodes were found.");
-        assertThat(nodeFinder.lookup("nonExistent").queryFirst(), is(nullValue()));
+        assertThat(nodeFinder.lookup("nonExistent").query(), is(nullValue()));
     }
 
     @Test
@@ -219,7 +219,7 @@ public class NodeFinderImplTest {
         // expect:
         thrown.expect(NodeFinderException.class);
         thrown.expectMessage("Matching nodes were found, but none of them are visible.");
-        assertThat(nodeFinder.lookup("invisible").queryFirst(), is(nullValue()));
+        assertThat(nodeFinder.lookup("invisible").query(), is(nullValue()));
     }
 
     @Test
@@ -228,7 +228,7 @@ public class NodeFinderImplTest {
         Predicate<Node> predicate = createNodePredicate(createLabelTextPredicate("first"));
 
         // expect:
-        assertThat(nodeFinder.lookup(predicate).queryFirst(), is(firstIdLabel));
+        assertThat(nodeFinder.lookup(predicate).query(), is(firstIdLabel));
     }
 
     @Test
@@ -237,7 +237,7 @@ public class NodeFinderImplTest {
         Matcher<Object> matcher = createObjectMatcher(createLabelTextMatcher("first"));
 
         // expect:
-        assertThat(nodeFinder.lookup(matcher).queryFirst(), is(firstIdLabel));
+        assertThat(nodeFinder.lookup(matcher).query(), is(firstIdLabel));
     }
 
     @Test
@@ -252,7 +252,7 @@ public class NodeFinderImplTest {
         // expect:
         thrown.expect(NodeFinderException.class);
         thrown.expectMessage("No matching nodes were found.");
-        assertThat(nodeFinder.lookup("#nonExistentNode").queryFirst(), is(nullValue()));
+        assertThat(nodeFinder.lookup("#nonExistentNode").query(), is(nullValue()));
     }
 
     @Test
@@ -261,7 +261,7 @@ public class NodeFinderImplTest {
         // expect:
         thrown.expect(NodeFinderException.class);
         thrown.expectMessage("Matching nodes were found, but none of them are visible.");
-        assertThat(nodeFinder.lookup("#invisibleNode").queryFirst(), is(nullValue()));
+        assertThat(nodeFinder.lookup("#invisibleNode").query(), is(nullValue()));
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
@@ -38,10 +38,10 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.testfx.service.query.impl.NodeQueryUtils.bySelector;
-import static org.testfx.service.query.impl.NodeQueryUtils.combine;
-import static org.testfx.service.query.impl.NodeQueryUtils.hasId;
-import static org.testfx.service.query.impl.NodeQueryUtils.rootOfScene;
+import static org.testfx.util.NodeQueryUtils.bySelector;
+import static org.testfx.util.NodeQueryUtils.combine;
+import static org.testfx.util.NodeQueryUtils.hasId;
+import static org.testfx.util.NodeQueryUtils.rootOfScene;
 
 public class NodeQueryImplTest {
 
@@ -104,7 +104,7 @@ public class NodeQueryImplTest {
         // when:
         Node result = nodeQuery
             .from(label0, label1, label2)
-            .queryFirst();
+            .query();
 
         // then:
         assertThat(result, is(label0));
@@ -114,7 +114,7 @@ public class NodeQueryImplTest {
     public void queryFirst_is_null() {
         // when:
         Node result = nodeQuery
-            .queryFirst();
+            .query();
 
         // then:
         assertThat(result, is(nullValue()));
@@ -125,7 +125,7 @@ public class NodeQueryImplTest {
         // when:
         Optional<Node> result = nodeQuery
             .from(label0, label1, label2)
-            .tryQueryFirst();
+            .tryQuery();
 
         // then:
         assertThat(result, is(Optional.of(label0)));
@@ -135,7 +135,7 @@ public class NodeQueryImplTest {
     public void tryQueryFirst_is_absent() {
         // when:
         Optional<Node> result = nodeQuery
-            .tryQueryFirst();
+            .tryQuery();
 
         // then:
         assertThat(result, is(Optional.absent()));
@@ -260,7 +260,7 @@ public class NodeQueryImplTest {
         Set<Node> result = nodeQuery
             .from(labels)
             .lookup(bySelector(".label"))
-            .selectAt(1)
+            .nth(1)
             .queryAll();
 
         // then:
@@ -273,9 +273,9 @@ public class NodeQueryImplTest {
         Set<Node> result = nodeQuery
             .from(rootOfScene(scene))
             .lookup(bySelector("#labels"))
-            .selectAt(0)
+            .nth(0)
             .lookup(bySelector(".label"))
-            .selectAt(2)
+            .nth(2)
             .queryAll();
 
         // then:
@@ -288,7 +288,7 @@ public class NodeQueryImplTest {
         Set<Node> result = nodeQuery
             .from(labels)
             .lookup(bySelector(".label"))
-            .selectAt(99)
+            .nth(99)
             .queryAll();
 
         // then:
@@ -301,9 +301,9 @@ public class NodeQueryImplTest {
         Set<Node> result = nodeQuery
             .from(rootOfScene(scene))
             .lookup(bySelector("#labels"))
-            .selectAt(0)
+            .nth(0)
             .lookup(bySelector(".label"))
-            .selectAt(99)
+            .nth(99)
             .queryAll();
 
         // then:
@@ -316,7 +316,7 @@ public class NodeQueryImplTest {
         Set<Node> result = nodeQuery
             .from(rootOfScene(scene))
             .lookup(bySelector(".button"))
-            .select(hasId("button1"))
+            .match(hasId("button1"))
             .queryAll();
 
         // then:

--- a/subprojects/testfx-legacy/src/main/java/org/loadui/testfx/GuiTest.java
+++ b/subprojects/testfx-legacy/src/main/java/org/loadui/testfx/GuiTest.java
@@ -75,7 +75,7 @@ public abstract class GuiTest extends FxRobot {
 
     public static <T extends Node> T find(String query) {
         try {
-            return nodeFinder.lookup(query).queryFirst();
+            return nodeFinder.lookup(query).query();
         }
         catch (NodeFinderException exception) {
             throw buildNodeQueryException(exception);
@@ -93,7 +93,7 @@ public abstract class GuiTest extends FxRobot {
 
     public static <T extends Node> T find(Predicate<T> predicate) {
         try {
-            return nodeFinder.lookup(predicate).queryFirst();
+            return nodeFinder.lookup(predicate).query();
         }
         catch (NodeFinderException exception) {
             throw buildNodeQueryException(exception);
@@ -102,7 +102,7 @@ public abstract class GuiTest extends FxRobot {
 
     public static <T extends Node> T find(Matcher<Object> matcher) {
         try {
-            return nodeFinder.lookup(matcher).queryFirst();
+            return nodeFinder.lookup(matcher).query();
         }
         catch (NodeFinderException exception) {
             throw buildNodeQueryException(exception);
@@ -111,7 +111,7 @@ public abstract class GuiTest extends FxRobot {
 
     public static <T extends Node> T find(String query, Node parent) {
         try {
-            return nodeFinder.from(parent).lookup(query).queryFirst();
+            return nodeFinder.from(parent).lookup(query).query();
         }
         catch (NodeFinderException exception) {
             throw buildNodeQueryException(exception);


### PR DESCRIPTION
Breaking changes:

- [x] Rename `select()` to `match()` in `NodeQuery`.
- [x] Rename `selectAt()` to `nth()` in `NodeQuery`.
- [x] Rename `queryFirst()` to `query()` in `NodeQuery`.
- [x] Rename `tryQueryFirst()` to `tryQuery()` in `NodeQuery`.
- [x] Move `NodeQueryUtils` from `org.testfx.service.query.impl` to `org.testfx.util`.
