### PR TITLE
(feat) ListViewMatchers: Add hasPlaceholder(Node placeholder).

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
@@ -19,6 +19,7 @@ package org.testfx.matcher.control;
 import java.util.Objects;
 import javafx.scene.Node;
 import javafx.scene.control.Cell;
+import javafx.scene.control.Labeled;
 import javafx.scene.control.ListView;
 
 import org.hamcrest.Factory;
@@ -64,6 +65,36 @@ public class ListViewMatchers {
         return typeSafeMatcher(ListView.class, descriptionText, ListViewMatchers::isListEmpty);
     }
 
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Node> hasPlaceholder(Node placeHolder) {
+        String descriptionText = "has ";
+        // better description messages for Labeled nodes
+        if (Labeled.class.isAssignableFrom(placeHolder.getClass())) {
+            descriptionText += "labeled placeholder containing text: \""
+                    + ((Labeled) placeHolder).getText() + "\"";
+        } else {
+            descriptionText += "placeholder " + placeHolder;
+        }
+        return typeSafeMatcher(ListView.class, descriptionText,
+                node -> hasPlaceholder(node, placeHolder));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Node> hasVisiblePlaceholder(Node placeHolder) {
+        String descriptionText = "has visible";
+        // better description messages for Labeled nodes
+        if (Labeled.class.isAssignableFrom(placeHolder.getClass())) {
+            descriptionText += "labeled placeholder containing text: \""
+                    + ((Labeled) placeHolder).getText() + "\"";
+        } else {
+            descriptionText += "placeholder " + placeHolder;
+        }
+        return typeSafeMatcher(ListView.class, descriptionText,
+                node -> hasVisiblePlaceholder(node, placeHolder));
+    }
+
     //---------------------------------------------------------------------------------------------
     // PRIVATE STATIC METHODS.
     //---------------------------------------------------------------------------------------------
@@ -91,4 +122,20 @@ public class ListViewMatchers {
         return listView.getItems().isEmpty();
     }
 
+    private static boolean hasPlaceholder(ListView listView,
+                                          Node placeHolder) {
+        if (Labeled.class.isAssignableFrom(placeHolder.getClass())
+                && Labeled.class.isAssignableFrom(listView.getPlaceholder().getClass())) {
+            return ((Labeled) listView.getPlaceholder()).getText()
+                    .equals(((Labeled) placeHolder).getText());
+        } else {
+            return Objects.equals(listView.getPlaceholder(), placeHolder);
+        }
+    }
+
+    private static boolean hasVisiblePlaceholder(ListView listView,
+                                                 Node placeHolder) {
+        return listView.getPlaceholder().isVisible()
+                && hasPlaceholder(listView, placeHolder);
+    }
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
@@ -16,6 +16,7 @@
  */
 package org.testfx.matcher.control;
 
+import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.StackPane;
 
@@ -55,6 +56,7 @@ public class ListViewMatchersTest extends FxRobot {
         FxToolkit.setupSceneRoot(() -> {
             listView = new ListView<>();
             listView.setItems(observableArrayList("alice", "bob", "carol", "dave"));
+            listView.setPlaceholder(new Label("Empty!"));
             return new StackPane(listView);
         });
         FxToolkit.showStage();
@@ -103,4 +105,18 @@ public class ListViewMatchersTest extends FxRobot {
         assertThat(listView, ListViewMatchers.hasItems(0));
     }
 
+    @Test
+    public void hasPlaceholder() {
+        // expect:
+        assertThat(listView, ListViewMatchers.hasPlaceholder(new Label("Empty!")));
+    }
+
+    @Test
+    public void hasPlaceholder_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: ListView has labeled placeholder containing text: \"foobar\"\n");
+
+        assertThat(listView, ListViewMatchers.hasPlaceholder(new Label("foobar")));
+    }
 }


### PR DESCRIPTION
Ideal usage:

````java
FxAssert.verifyThat(lookup("#someListView"), ListViewMatchers.hasPlaceholder(new Label("List is empty!")));
````