### PR TITLE
(feat) TableViewMatchers: Add containsRow().

### DIFF
--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -127,4 +127,61 @@ public class TableViewMatchersTest extends FxRobot {
         assertThat(tableView, TableViewMatchers.hasItems(0));
     }
 
+    @Test
+    public void containsRow() {
+        tableView.setItems(observableArrayList(
+                ImmutableMap.of("name", "alice", "age", 30),
+                ImmutableMap.of("name", "bob", "age", 31),
+                ImmutableMap.of("name", "carol", "age", 42),
+                ImmutableMap.of("name", "dave", "age", 55)
+        ));
+
+        // expect:
+        assertThat(tableView, TableViewMatchers.containsRow(0, "alice", 30));
+        assertThat(tableView, TableViewMatchers.containsRow(1, "bob", 31));
+        assertThat(tableView, TableViewMatchers.containsRow(2, "carol", 42));
+        assertThat(tableView, TableViewMatchers.containsRow(3, "dave", 55));
+    }
+
+    @Test
+    public void containsRow_with_empty_cells() {
+        tableView.setItems(observableArrayList(
+                ImmutableMap.of("name", "alice", "age", 30),
+                ImmutableMap.of("name", "bob", "age", 31),
+                ImmutableMap.of("name", "carol"),
+                ImmutableMap.of("name", "dave")
+        ));
+        // expect:
+        assertThat(tableView, TableViewMatchers.containsRow(0, "alice", 30));
+        assertThat(tableView, TableViewMatchers.containsRow(1, "bob", 31));
+        assertThat(tableView, TableViewMatchers.containsRow(2, "carol", null));
+        assertThat(tableView, TableViewMatchers.containsRow(3, "dave", null));
+    }
+
+    @Test
+    public void containsRow_no_such_row_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TableView has row: [jerry, 29]\n");
+
+        assertThat(tableView, TableViewMatchers.containsRow(0, "jerry", 29));
+    }
+
+    @Test
+    public void containsRow_out_of_bounds_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TableView has row: [tom, 54]\n");
+
+        assertThat(tableView, TableViewMatchers.containsRow(4, "tom", 54));
+    }
+
+    @Test
+    public void containsRow_wrong_types_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TableView has row: [63, deedee]\n");
+
+        assertThat(tableView, TableViewMatchers.containsRow(1, 63, "deedee"));
+    }
 }


### PR DESCRIPTION
This allows for testing that a TableView contains a given row at
a given row index. As an example, consider a Person class that has
three properties, name (StringProperty), age (IntegerProperty) and
birth-date (ObjectProperty<Instant>):

````java
TableView<Person> peopleTable = new TableView<>();
Person bob = new Person("Bob", 42, Instant.ofEpochSecond(139061613));
Person andy = new Person("Andy", 13, Instant.ofEpochSecond(1061260323));
Person jill = new Person("Jill", 5, Instant.ofEpochSecond(1320430636));
ObservableList<Person> people = FXCollections.observableArrayList(bob, andy, jill);

peopleTable.setItems(people);

// then:

assertThat(peopleTable, containsRow(0, "Bob", 42, Instant.parse("1974-05-29T12:13:33+00:00Z")));
assertThat(peopleTable, containsRow(1, "Andy" 13, Instant.parse("2003-08-19T02:32:03+00:00Z")));
assertThat(peopleTable, containsRow(2, "Jill", 5, Instant.parse("2011-11-04T18:17:16+00:00Z")));

// would all be true
````