### PR TITLE
(refactor) ApplicationService: Use Application instead of ApplicationFixture.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
@@ -31,11 +31,9 @@ import javafx.stage.Window;
 
 import com.google.common.collect.ImmutableSet;
 import org.testfx.api.annotation.Unstable;
-import org.testfx.toolkit.ApplicationFixture;
 import org.testfx.toolkit.ApplicationLauncher;
 import org.testfx.toolkit.ApplicationService;
 import org.testfx.toolkit.ToolkitService;
-import org.testfx.toolkit.impl.ApplicationAdapter;
 import org.testfx.toolkit.impl.ApplicationLauncherImpl;
 import org.testfx.toolkit.impl.ApplicationServiceImpl;
 import org.testfx.toolkit.impl.ToolkitServiceImpl;
@@ -171,25 +169,13 @@ public final class FxToolkit {
         );
     }
 
-    //@Unstable(reason = "is missing apidocs")
-    //public static Application setupApplication(Application application,
-    //                                           String... applicationArgs)
-    //                                    throws TimeoutException {
-    //    return waitForSetup(
-    //        service.setupApplication(
-    //            () -> context.getRegisteredStage(),
-    //            new ApplicationAdapter(application)
-    //        )
-    //    );
-    //}
-
     @Unstable(reason = "is missing apidocs")
-    public static ApplicationFixture setupApplication(ApplicationFixture applicationFixture)
-                                               throws TimeoutException {
+    public static Application setupApplication(Supplier<Application> applicationSupplier)
+                                        throws TimeoutException {
         return waitForSetup(
             service.setupApplication(
                 () -> context.getRegisteredStage(),
-                applicationFixture
+                applicationSupplier
             )
         );
     }
@@ -198,15 +184,7 @@ public final class FxToolkit {
     public static void cleanupApplication(Application application)
                                    throws TimeoutException {
         waitForSetup(
-            service.cleanupApplication(new ApplicationAdapter(application))
-        );
-    }
-
-    @Unstable(reason = "is missing apidocs")
-    public static void cleanupApplication(ApplicationFixture applicationFixture)
-                                   throws TimeoutException {
-        waitForSetup(
-            service.cleanupApplication(applicationFixture)
+            service.cleanupApplication(application)
         );
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationService.java
@@ -16,20 +16,20 @@
  */
 package org.testfx.toolkit;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import javafx.application.Application;
 import javafx.stage.Stage;
 
 public interface ApplicationService {
 
-    Future<Application> create(Class<? extends Application> appClass,
-                               String... appArgs);
+    Future<Application> create(Callable<Application> applicationCallable);
 
-    Future<Void> init(ApplicationFixture applicationFixture);
+    Future<Void> init(Application application);
 
-    Future<Void> start(ApplicationFixture applicationFixture,
+    Future<Void> start(Application application,
                        Stage targetStage);
 
-    Future<Void> stop(ApplicationFixture applicationFixture);
+    Future<Void> stop(Application application);
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ToolkitService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ToolkitService.java
@@ -48,9 +48,10 @@ public interface ToolkitService {
                                          Class<? extends Application> applicationClass,
                                          String... applicationArgs);
 
-    Future<ApplicationFixture> setupApplication(Supplier<Stage> stageSupplier,
-                                                ApplicationFixture applicationFixture);
+    Future<Application> setupApplication(Supplier<Stage> stageSupplier,
+                                         Supplier<Application> applicationSupplier,
+                                         String... applicationArgs);
 
-    Future<Void> cleanupApplication(ApplicationFixture applicationFixture);
+    Future<Void> cleanupApplication(Application application);
 
 }

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationAdapter.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationAdapter.java
@@ -14,29 +14,28 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-package org.testfx.toolkit.impl;
+package org.testfx.framework.junit;
 
 import javafx.application.Application;
 import javafx.stage.Stage;
 
 import org.testfx.api.annotation.Unstable;
-import org.testfx.toolkit.ApplicationFixture;
 
 @Unstable(reason = "needs more tests")
-public final class ApplicationAdapter implements ApplicationFixture {
+public final class ApplicationAdapter extends Application {
 
     //---------------------------------------------------------------------------------------------
     // PRIVATE FIELDS.
     //---------------------------------------------------------------------------------------------
 
-    private Application application;
+    private ApplicationFixture applicationFixture;
 
     //---------------------------------------------------------------------------------------------
     // CONSTRUCTORS.
     //---------------------------------------------------------------------------------------------
 
-    public ApplicationAdapter(Application application) {
-        this.application = application;
+    public ApplicationAdapter(ApplicationFixture applicationFixture) {
+        this.applicationFixture = applicationFixture;
     }
 
     //---------------------------------------------------------------------------------------------
@@ -44,18 +43,21 @@ public final class ApplicationAdapter implements ApplicationFixture {
     //---------------------------------------------------------------------------------------------
 
     @Override
-    public void init() throws Exception {
-        application.init();
+    public void init()
+              throws Exception {
+        applicationFixture.init();
     }
 
     @Override
-    public void start(Stage stage) throws Exception {
-        application.start(stage);
+    public void start(Stage primaryStage)
+               throws Exception {
+        applicationFixture.start(primaryStage);
     }
 
     @Override
-    public void stop() throws Exception {
-        application.stop();
+    public void stop()
+              throws Exception {
+        applicationFixture.stop();
     }
 
 }

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationFixture.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationFixture.java
@@ -14,7 +14,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-package org.testfx.toolkit;
+package org.testfx.framework.junit;
 
 import javafx.stage.Stage;
 

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
@@ -22,7 +22,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
-import org.testfx.toolkit.ApplicationFixture;
 
 import java.util.function.Consumer;
 
@@ -52,11 +51,11 @@ public class ApplicationRule extends FxRobot
 
     private void before() throws Exception {
         FxToolkit.registerPrimaryStage();
-        FxToolkit.setupApplication(this);
+        FxToolkit.setupApplication(() -> new ApplicationAdapter(this));
     }
 
     private void after() throws Exception {
-        FxToolkit.cleanupApplication(this);
+        FxToolkit.cleanupApplication(new ApplicationAdapter(this));
     }
 
     private Statement externalResource(final Statement base) {

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 import org.testfx.api.annotation.Unstable;
-import org.testfx.toolkit.ApplicationFixture;
 
 @Unstable(reason = "might be renamed to ApplicationTestBase")
 public abstract class ApplicationTest extends FxRobot implements ApplicationFixture {
@@ -52,14 +51,14 @@ public abstract class ApplicationTest extends FxRobot implements ApplicationFixt
     public final void internalBefore()
                               throws Exception {
         FxToolkit.registerPrimaryStage();
-        FxToolkit.setupApplication(this);
+        FxToolkit.setupApplication(() -> new ApplicationAdapter(this));
     }
 
     @After
     @Unstable(reason = "is missing apidocs")
     public final void internalAfter()
                              throws Exception {
-        FxToolkit.cleanupApplication(this);
+        FxToolkit.cleanupApplication(new ApplicationAdapter(this));
     }
 
     @Override

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
@@ -19,6 +19,7 @@ package org.testfx.framework.junit;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.StackPane;
+
 import org.junit.Rule;
 import org.junit.Test;
 


### PR DESCRIPTION
- Use `Application` (instead of `ApplicationFixture`) in `ApplicationService` and `FxToolkit`. 
- Move `ApplicationFixture` and `ApplicationAdapter` from `testfx-core` to `testfx-junit`.

This changes `ApplicationAdapter` to extend `Application` instead of implementing `ApplicationFixture`. We need a `ApplicationFixture` interface in `testfx-junit` to let `ApplicationRule` extend `FxRobot` (single inheritance of Java).

~~~java
// before.
class ApplicationAdapter implements ApplicationFixture {}

// after.
class ApplicationAdapter extends Application {}
~~~

cc: @johnzeringue (this should not affect the behaviour of `ApplicationRule`).