### PR TITLE
(feat) Introduce `FxRobot::bounds()` and `BoundsQuery`.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -41,8 +41,10 @@ import com.google.common.base.Predicate;
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.locator.PointLocator;
+import org.testfx.service.query.BoundsQuery;
 import org.testfx.service.query.NodeQuery;
 import org.testfx.service.query.PointQuery;
+import org.testfx.util.BoundsQueryUtils;
 
 import static org.testfx.util.NodeQueryUtils.isVisible;
 import static org.testfx.util.WaitForAsyncUtils.asyncFx;
@@ -261,47 +263,47 @@ public class FxRobot implements FxRobotInterface {
                               double minY,
                               double width,
                               double height) {
-        return null;
+        return () -> BoundsQueryUtils.bounds(minX, minY, width, height);
     }
 
     @Override
     public BoundsQuery bounds(Point2D point) {
-        return null;
+        return () -> BoundsQueryUtils.bounds(point);
     }
 
     @Override
     public BoundsQuery bounds(Bounds bounds) {
-        return null;
+        return () -> bounds;
     }
 
     @Override
     public BoundsQuery bounds(Node node) {
-        return null;
+        return () -> BoundsQueryUtils.boundsOnScreen(node);
     }
 
     @Override
     public BoundsQuery bounds(Scene scene) {
-        return null;
+        return () -> BoundsQueryUtils.boundsOnScreen(BoundsQueryUtils.bounds(scene), scene);
     }
 
     @Override
     public BoundsQuery bounds(Window window) {
-        return null;
+        return () -> BoundsQueryUtils.boundsOnScreen(BoundsQueryUtils.bounds(window), window);
     }
 
     @Override
     public BoundsQuery bounds(String query) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public <T extends Node> BoundsQuery bounds(Matcher<T> matcher) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public <T extends Node> BoundsQuery bounds(Predicate<T> predicate) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     //---------------------------------------------------------------------------------------------
@@ -325,7 +327,7 @@ public class FxRobot implements FxRobotInterface {
                             double y) {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
-        return pointLocator.pointFor(new Point2D(x, y)).atPosition(pointPosition);
+        return pointLocator.point(new Point2D(x, y)).atPosition(pointPosition);
     }
 
     @Override
@@ -333,7 +335,7 @@ public class FxRobot implements FxRobotInterface {
     public PointQuery point(Point2D point) {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
-        return pointLocator.pointFor(point).atPosition(pointPosition);
+        return pointLocator.point(point).atPosition(pointPosition);
     }
 
     @Override
@@ -341,7 +343,7 @@ public class FxRobot implements FxRobotInterface {
     public PointQuery point(Bounds bounds) {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
-        return pointLocator.pointFor(bounds).atPosition(pointPosition);
+        return pointLocator.point(bounds).atPosition(pointPosition);
     }
 
     @Override
@@ -350,7 +352,7 @@ public class FxRobot implements FxRobotInterface {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
         targetWindow(node.getScene().getWindow());
-        return pointLocator.pointFor(node).atPosition(pointPosition);
+        return pointLocator.point(node).atPosition(pointPosition);
     }
 
     @Override
@@ -359,7 +361,7 @@ public class FxRobot implements FxRobotInterface {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
         targetWindow(scene.getWindow());
-        return pointLocator.pointFor(scene).atPosition(pointPosition);
+        return pointLocator.point(scene).atPosition(pointPosition);
     }
 
     @Override
@@ -368,7 +370,7 @@ public class FxRobot implements FxRobotInterface {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
         targetWindow(window);
-        return pointLocator.pointFor(window).atPosition(pointPosition);
+        return pointLocator.point(window).atPosition(pointPosition);
     }
 
     @Override

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -78,165 +78,6 @@ public class FxRobot implements FxRobotInterface {
     }
 
     //---------------------------------------------------------------------------------------------
-    // METHODS FOR POINT POSITION.
-    //---------------------------------------------------------------------------------------------
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public FxRobot targetPos(Pos pointPosition) {
-        context.setPointPosition(pointPosition);
-        return this;
-    }
-
-    //---------------------------------------------------------------------------------------------
-    // METHODS FOR POINT LOCATION.
-    //---------------------------------------------------------------------------------------------
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery point(double x,
-                            double y) {
-        PointLocator pointLocator = context.getPointLocator();
-        Pos pointPosition = context.getPointPosition();
-        return pointLocator.pointFor(new Point2D(x, y)).atPosition(pointPosition);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery point(Point2D point) {
-        PointLocator pointLocator = context.getPointLocator();
-        Pos pointPosition = context.getPointPosition();
-        return pointLocator.pointFor(point).atPosition(pointPosition);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery point(Bounds bounds) {
-        PointLocator pointLocator = context.getPointLocator();
-        Pos pointPosition = context.getPointPosition();
-        return pointLocator.pointFor(bounds).atPosition(pointPosition);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery point(Node node) {
-        PointLocator pointLocator = context.getPointLocator();
-        Pos pointPosition = context.getPointPosition();
-        targetWindow(node.getScene().getWindow());
-        return pointLocator.pointFor(node).atPosition(pointPosition);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery point(Scene scene) {
-        PointLocator pointLocator = context.getPointLocator();
-        Pos pointPosition = context.getPointPosition();
-        targetWindow(scene.getWindow());
-        return pointLocator.pointFor(scene).atPosition(pointPosition);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery point(Window window) {
-        PointLocator pointLocator = context.getPointLocator();
-        Pos pointPosition = context.getPointPosition();
-        targetWindow(window);
-        return pointLocator.pointFor(window).atPosition(pointPosition);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery point(String query) {
-        NodeQuery nodeQuery = lookup(query);
-        Node node = queryNode(nodeQuery, "the query \"" + query + "\"");
-        return point(node).atPosition(context.getPointPosition());
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs; might change to accept all objects")
-    public <T extends Node> PointQuery point(Matcher<T> matcher) {
-        NodeQuery nodeQuery = lookup(matcher);
-        Node node = queryNode(nodeQuery, "the matcher \"" + matcher.toString() + "\"");
-        return point(node).atPosition(context.getPointPosition());
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public <T extends Node> PointQuery point(Predicate<T> predicate) {
-        NodeQuery nodeQuery = lookup(predicate);
-        Node node = queryNode(nodeQuery, "the predicate");
-        return point(node).atPosition(context.getPointPosition());
-    }
-
-    //---------------------------------------------------------------------------------------------
-    // METHODS FOR POINT OFFSET.
-    //---------------------------------------------------------------------------------------------
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery offset(Point2D point,
-                             double offsetX,
-                             double offsetY) {
-        return point(point).atOffset(offsetX, offsetY);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery offset(Bounds bounds,
-                             double offsetX,
-                             double offsetY) {
-        return point(bounds).atOffset(offsetX, offsetY);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery offset(Node node,
-                             double offsetX,
-                             double offsetY) {
-        return point(node).atOffset(offsetX, offsetY);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery offset(Scene scene,
-                             double offsetX,
-                             double offsetY) {
-        return point(scene).atOffset(offsetX, offsetY);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery offset(Window window,
-                             double offsetX,
-                             double offsetY) {
-        return point(window).atOffset(offsetX, offsetY);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public PointQuery offset(String query,
-                             double offsetX,
-                             double offsetY) {
-        return point(query).atOffset(offsetX, offsetY);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs; might change to accept all objects")
-    public <T extends Node> PointQuery offset(Matcher<T> matcher,
-                                              double offsetX,
-                                              double offsetY) {
-        return point(matcher).atOffset(offsetX, offsetY);
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public <T extends Node> PointQuery offset(Predicate<T> predicate,
-                                              double offsetX,
-                                              double offsetY) {
-        return point(predicate).atOffset(offsetX, offsetY);
-    }
-
-    //---------------------------------------------------------------------------------------------
     // METHODS FOR WINDOW TARGETING.
     //---------------------------------------------------------------------------------------------
 
@@ -409,6 +250,217 @@ public class FxRobot implements FxRobotInterface {
     @Unstable(reason = "is missing apidocs")
     public Node rootNode(Node node) {
         return context.getNodeFinder().rootNode(node);
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR BOUNDS LOCATION.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    public BoundsQuery bounds(double minX,
+                              double minY,
+                              double width,
+                              double height) {
+        return null;
+    }
+
+    @Override
+    public BoundsQuery bounds(Point2D point) {
+        return null;
+    }
+
+    @Override
+    public BoundsQuery bounds(Bounds bounds) {
+        return null;
+    }
+
+    @Override
+    public BoundsQuery bounds(Node node) {
+        return null;
+    }
+
+    @Override
+    public BoundsQuery bounds(Scene scene) {
+        return null;
+    }
+
+    @Override
+    public BoundsQuery bounds(Window window) {
+        return null;
+    }
+
+    @Override
+    public BoundsQuery bounds(String query) {
+        return null;
+    }
+
+    @Override
+    public <T extends Node> BoundsQuery bounds(Matcher<T> matcher) {
+        return null;
+    }
+
+    @Override
+    public <T extends Node> BoundsQuery bounds(Predicate<T> predicate) {
+        return null;
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR POINT POSITION.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public FxRobot targetPos(Pos pointPosition) {
+        context.setPointPosition(pointPosition);
+        return this;
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR POINT LOCATION.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery point(double x,
+                            double y) {
+        PointLocator pointLocator = context.getPointLocator();
+        Pos pointPosition = context.getPointPosition();
+        return pointLocator.pointFor(new Point2D(x, y)).atPosition(pointPosition);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery point(Point2D point) {
+        PointLocator pointLocator = context.getPointLocator();
+        Pos pointPosition = context.getPointPosition();
+        return pointLocator.pointFor(point).atPosition(pointPosition);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery point(Bounds bounds) {
+        PointLocator pointLocator = context.getPointLocator();
+        Pos pointPosition = context.getPointPosition();
+        return pointLocator.pointFor(bounds).atPosition(pointPosition);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery point(Node node) {
+        PointLocator pointLocator = context.getPointLocator();
+        Pos pointPosition = context.getPointPosition();
+        targetWindow(node.getScene().getWindow());
+        return pointLocator.pointFor(node).atPosition(pointPosition);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery point(Scene scene) {
+        PointLocator pointLocator = context.getPointLocator();
+        Pos pointPosition = context.getPointPosition();
+        targetWindow(scene.getWindow());
+        return pointLocator.pointFor(scene).atPosition(pointPosition);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery point(Window window) {
+        PointLocator pointLocator = context.getPointLocator();
+        Pos pointPosition = context.getPointPosition();
+        targetWindow(window);
+        return pointLocator.pointFor(window).atPosition(pointPosition);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery point(String query) {
+        NodeQuery nodeQuery = lookup(query);
+        Node node = queryNode(nodeQuery, "the query \"" + query + "\"");
+        return point(node).atPosition(context.getPointPosition());
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs; might change to accept all objects")
+    public <T extends Node> PointQuery point(Matcher<T> matcher) {
+        NodeQuery nodeQuery = lookup(matcher);
+        Node node = queryNode(nodeQuery, "the matcher \"" + matcher.toString() + "\"");
+        return point(node).atPosition(context.getPointPosition());
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public <T extends Node> PointQuery point(Predicate<T> predicate) {
+        NodeQuery nodeQuery = lookup(predicate);
+        Node node = queryNode(nodeQuery, "the predicate");
+        return point(node).atPosition(context.getPointPosition());
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR POINT OFFSET.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery offset(Point2D point,
+                             double offsetX,
+                             double offsetY) {
+        return point(point).atOffset(offsetX, offsetY);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery offset(Bounds bounds,
+                             double offsetX,
+                             double offsetY) {
+        return point(bounds).atOffset(offsetX, offsetY);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery offset(Node node,
+                             double offsetX,
+                             double offsetY) {
+        return point(node).atOffset(offsetX, offsetY);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery offset(Scene scene,
+                             double offsetX,
+                             double offsetY) {
+        return point(scene).atOffset(offsetX, offsetY);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery offset(Window window,
+                             double offsetX,
+                             double offsetY) {
+        return point(window).atOffset(offsetX, offsetY);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public PointQuery offset(String query,
+                             double offsetX,
+                             double offsetY) {
+        return point(query).atOffset(offsetX, offsetY);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs; might change to accept all objects")
+    public <T extends Node> PointQuery offset(Matcher<T> matcher,
+                                              double offsetX,
+                                              double offsetY) {
+        return point(matcher).atOffset(offsetX, offsetY);
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public <T extends Node> PointQuery offset(Predicate<T> predicate,
+                                              double offsetX,
+                                              double offsetY) {
+        return point(predicate).atOffset(offsetX, offsetY);
     }
 
     //---------------------------------------------------------------------------------------------

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -44,6 +44,75 @@ import org.testfx.service.query.PointQuery;
 public interface FxRobotInterface {
 
     //---------------------------------------------------------------------------------------------
+    // METHODS FOR WINDOW TARGETING.
+    //---------------------------------------------------------------------------------------------
+
+    public Window targetWindow();
+    public FxRobotInterface targetWindow(Window window);
+    public FxRobotInterface targetWindow(Predicate<Window> predicate);
+
+    // Convenience methods:
+    public FxRobotInterface targetWindow(int windowIndex);
+    public FxRobotInterface targetWindow(String stageTitleRegex);
+    public FxRobotInterface targetWindow(Pattern stageTitlePattern);
+    public FxRobotInterface targetWindow(Scene scene);
+    public FxRobotInterface targetWindow(Node node);
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR WINDOW LOOKUP.
+    //---------------------------------------------------------------------------------------------
+
+    public List<Window> listWindows();
+    public List<Window> listTargetWindows();
+    public Window window(Predicate<Window> predicate);
+
+    // Convenience methods:
+    public Window window(int windowIndex);
+    public Window window(String stageTitleRegex);
+    public Window window(Pattern stageTitlePattern);
+    public Window window(Scene scene);
+    public Window window(Node node);
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR NODE LOOKUP.
+    //---------------------------------------------------------------------------------------------
+
+    public NodeQuery fromAll();
+    public NodeQuery from(Node... parentNodes);
+    public NodeQuery from(Collection<Node> parentNodes);
+
+    public Node rootNode(Window window);
+    public Node rootNode(Scene scene);
+    public Node rootNode(Node node);
+
+    // Convenience methods:
+    public NodeQuery lookup(String query);
+    public <T extends Node> NodeQuery lookup(Matcher<T> matcher);
+    public <T extends Node> NodeQuery lookup(Predicate<T> predicate);
+    public NodeQuery from(NodeQuery nodeQuery);
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR BOUNDS LOCATION.
+    //---------------------------------------------------------------------------------------------
+
+    public BoundsQuery bounds(double minX,
+                              double minY,
+                              double width,
+                              double height);
+    public BoundsQuery bounds(Point2D point);
+    public BoundsQuery bounds(Bounds bounds);
+    public BoundsQuery bounds(Node node);
+    public BoundsQuery bounds(Scene scene);
+    public BoundsQuery bounds(Window window);
+
+    // Convenience methods:
+    public BoundsQuery bounds(String query);
+    public <T extends Node> BoundsQuery bounds(Matcher<T> matcher);
+    public <T extends Node> BoundsQuery bounds(Predicate<T> predicate);
+
+    static interface BoundsQuery {}
+
+    //---------------------------------------------------------------------------------------------
     // METHODS FOR POINT POSITION.
     //---------------------------------------------------------------------------------------------
 
@@ -99,54 +168,6 @@ public interface FxRobotInterface {
                                               double offsetY);
 
     //---------------------------------------------------------------------------------------------
-    // METHODS FOR WINDOW TARGETING.
-    //---------------------------------------------------------------------------------------------
-
-    public Window targetWindow();
-    public FxRobotInterface targetWindow(Window window);
-    public FxRobotInterface targetWindow(Predicate<Window> predicate);
-
-    // Convenience methods:
-    public FxRobotInterface targetWindow(int windowIndex);
-    public FxRobotInterface targetWindow(String stageTitleRegex);
-    public FxRobotInterface targetWindow(Pattern stageTitlePattern);
-    public FxRobotInterface targetWindow(Scene scene);
-    public FxRobotInterface targetWindow(Node node);
-
-    //---------------------------------------------------------------------------------------------
-    // METHODS FOR WINDOW LOOKUP.
-    //---------------------------------------------------------------------------------------------
-
-    public List<Window> listWindows();
-    public List<Window> listTargetWindows();
-    public Window window(Predicate<Window> predicate);
-
-    // Convenience methods:
-    public Window window(int windowIndex);
-    public Window window(String stageTitleRegex);
-    public Window window(Pattern stageTitlePattern);
-    public Window window(Scene scene);
-    public Window window(Node node);
-
-    //---------------------------------------------------------------------------------------------
-    // METHODS FOR NODE LOOKUP.
-    //---------------------------------------------------------------------------------------------
-
-    public NodeQuery fromAll();
-    public NodeQuery from(Node... parentNodes);
-    public NodeQuery from(Collection<Node> parentNodes);
-
-    public Node rootNode(Window window);
-    public Node rootNode(Scene scene);
-    public Node rootNode(Node node);
-
-    // Convenience methods:
-    public NodeQuery lookup(String query);
-    public <T extends Node> NodeQuery lookup(Matcher<T> matcher);
-    public <T extends Node> NodeQuery lookup(Predicate<T> predicate);
-    public NodeQuery from(NodeQuery nodeQuery);
-
-    //---------------------------------------------------------------------------------------------
     // METHODS FOR SCREEN CAPTURING.
     //---------------------------------------------------------------------------------------------
 
@@ -163,6 +184,14 @@ public interface FxRobotInterface {
 
     public FxRobotInterface interrupt();
     public FxRobotInterface interrupt(int attemptsCount);
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS FOR SLEEPING.
+    //---------------------------------------------------------------------------------------------
+
+    public FxRobotInterface sleep(long milliseconds);
+    public FxRobotInterface sleep(long duration,
+                                  TimeUnit timeUnit);
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR CLICKING.
@@ -324,14 +353,6 @@ public interface FxRobotInterface {
 
     // Convenience methods:
     public FxRobotInterface scroll(VerticalDirection direction);
-
-    //---------------------------------------------------------------------------------------------
-    // METHODS FOR SLEEPING.
-    //---------------------------------------------------------------------------------------------
-
-    public FxRobotInterface sleep(long milliseconds);
-    public FxRobotInterface sleep(long duration,
-                                  TimeUnit timeUnit);
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR TYPING.

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -37,6 +37,7 @@ import javafx.stage.Window;
 import com.google.common.base.Predicate;
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
+import org.testfx.service.query.BoundsQuery;
 import org.testfx.service.query.NodeQuery;
 import org.testfx.service.query.PointQuery;
 
@@ -109,8 +110,6 @@ public interface FxRobotInterface {
     public BoundsQuery bounds(String query);
     public <T extends Node> BoundsQuery bounds(Matcher<T> matcher);
     public <T extends Node> BoundsQuery bounds(Predicate<T> predicate);
-
-    static interface BoundsQuery {}
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR POINT POSITION.

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
@@ -53,30 +53,30 @@ public class PointLocatorImpl implements PointLocator {
     //---------------------------------------------------------------------------------------------
 
     @Override
-    public PointQuery pointFor(Bounds bounds) {
+    public PointQuery point(Bounds bounds) {
         return new BoundsPointQuery(bounds);
     }
 
     @Override
-    public PointQuery pointFor(Point2D point) {
+    public PointQuery point(Point2D point) {
         Bounds bounds = new BoundingBox(point.getX(), point.getY(), 0, 0);
         return new BoundsPointQuery(bounds);
     }
 
     @Override
-    public PointQuery pointFor(Node node) {
+    public PointQuery point(Node node) {
         Callable<Bounds> callable = callableBoundsFor(node);
         return new CallableBoundsPointQuery(callable);
     }
 
     @Override
-    public PointQuery pointFor(Scene scene) {
+    public PointQuery point(Scene scene) {
         Callable<Bounds> callable = callableBoundsFor(scene);
         return new CallableBoundsPointQuery(callable);
     }
 
     @Override
-    public PointQuery pointFor(Window window) {
+    public PointQuery point(Window window) {
         Callable<Bounds> callable = callableBoundsFor(window);
         return new CallableBoundsPointQuery(callable);
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
@@ -14,24 +14,12 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-package org.testfx.service.locator;
+package org.testfx.service.query;
 
 import javafx.geometry.Bounds;
-import javafx.geometry.Point2D;
-import javafx.scene.Node;
-import javafx.scene.Scene;
-import javafx.stage.Window;
 
-import org.testfx.service.query.PointQuery;
+public interface BoundsQuery {
 
-public interface PointLocator {
-    PointQuery point(Bounds bounds);
+    public Bounds query();
 
-    PointQuery point(Point2D point);
-
-    PointQuery point(Node node);
-
-    PointQuery point(Scene scene);
-
-    PointQuery point(Window window);
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
@@ -20,7 +20,7 @@ import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 
 import org.testfx.api.annotation.Unstable;
-import org.testfx.util.BoundsUtils;
+import org.testfx.util.PointQueryUtils;
 
 @Unstable
 public class BoundsPointQuery extends PointQueryBase {
@@ -55,6 +55,7 @@ public class BoundsPointQuery extends PointQueryBase {
     // METHODS.
     //---------------------------------------------------------------------------------------------
 
+    @Override
     public Point2D query() {
         Point2D point = pointAtPosition(this.bounds, this.getPosition());
         Point2D offset = getOffset();
@@ -65,8 +66,9 @@ public class BoundsPointQuery extends PointQueryBase {
     // PRIVATE METHODS.
     //---------------------------------------------------------------------------------------------
 
-    private Point2D pointAtPosition(Bounds bounds, Point2D position) {
-        return BoundsUtils.atPositionFactors(bounds, position);
+    private Point2D pointAtPosition(Bounds bounds,
+                                    Point2D position) {
+        return PointQueryUtils.atPositionFactors(bounds, position);
     }
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
@@ -21,7 +21,7 @@ import javafx.geometry.Pos;
 
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.query.PointQuery;
-import org.testfx.util.BoundsUtils;
+import org.testfx.util.PointQueryUtils;
 
 @Unstable
 abstract public class PointQueryBase implements PointQuery {
@@ -38,27 +38,34 @@ abstract public class PointQueryBase implements PointQuery {
     // METHODS.
     //---------------------------------------------------------------------------------------------
 
+    @Override
     public Point2D getPosition() {
         return position;
     }
 
+    @Override
     public Point2D getOffset() {
         return offset;
     }
 
+    @Override
     public PointQuery atPosition(Point2D position) {
         this.position = position;
         return this;
     }
 
-    public PointQuery atPosition(double positionX, double positionY) {
+    @Override
+    public PointQuery atPosition(double positionX,
+                                 double positionY) {
         return atPosition(new Point2D(positionX, positionY));
     }
 
+    @Override
     public PointQuery atPosition(Pos position) {
-        return atPosition(BoundsUtils.computePositionFactors(position));
+        return atPosition(PointQueryUtils.computePositionFactors(position));
     }
 
+    @Override
     public PointQuery atOffset(Point2D offset) {
         this.offset = new Point2D(
             this.offset.getX() + offset.getX(),
@@ -67,7 +74,9 @@ abstract public class PointQueryBase implements PointQuery {
         return this;
     }
 
-    public PointQuery atOffset(double offsetX, double offsetY) {
+    @Override
+    public PointQuery atOffset(double offsetX,
+                               double offsetY) {
         return atOffset(new Point2D(offsetX, offsetY));
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsQueryUtils.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.util;
+
+import javafx.geometry.BoundingBox;
+import javafx.geometry.Bounds;
+import javafx.geometry.Dimension2D;
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.stage.Window;
+
+import org.testfx.api.annotation.Unstable;
+
+@Unstable
+public final class BoundsQueryUtils {
+
+    //---------------------------------------------------------------------------------------------
+    // CONSTRUCTORS.
+    //---------------------------------------------------------------------------------------------
+
+    private BoundsQueryUtils() {
+        throw new UnsupportedOperationException();
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    public static Bounds bounds(double minX,
+                                double minY,
+                                double width,
+                                double height) {
+        return new BoundingBox(minX, minY, width, height);
+    }
+
+    public static Bounds bounds(Point2D point) {
+        return bounds(point.getX(), point.getY(), 0, 0);
+    }
+
+    public static Bounds bounds(Dimension2D dimension) {
+        return bounds(0, 0, dimension.getWidth(), dimension.getHeight());
+    }
+
+    public static Bounds bounds(Rectangle2D region) {
+        return bounds(region.getMinX(), region.getMinY(),
+                      region.getWidth(), region.getHeight());
+    }
+
+    /**
+     * Bounds of Scene in Window.
+     */
+    public static Bounds bounds(Scene scene) {
+        return bounds(scene.getX(), scene.getY(),
+                      scene.getWidth(), scene.getHeight());
+    }
+
+    /**
+     * Bounds of Window on Screen.
+     */
+    public static Bounds bounds(Window window) {
+        return bounds(window.getX(), window.getY(),
+                      window.getWidth(), window.getHeight());
+    }
+
+    // BOUNDS FOR NODE.
+
+    /**
+     * Retrieve the logical bounds (geom) of a Node.
+     */
+    public static Bounds nodeBounds(Node node) {
+        return node.getLayoutBounds();
+    }
+
+    /**
+     * Retrieve the physical untransformed bounds (geom + effect + clip) of a Node.
+     */
+    public static Bounds nodeBoundsInLocal(Node node) {
+        return node.getBoundsInLocal();
+    }
+
+    /**
+     * Retrieve the physical transformed bounds (geom + effect + clip + transform) of a Node.
+     */
+    public static Bounds nodeBoundsInParent(Node node) {
+        return node.getBoundsInParent();
+    }
+
+    public static Bounds nodeBoundsInScene(Node node) {
+        return node.localToScene(node.getBoundsInLocal());
+    }
+
+    // BOUNDS ON SCREEN.
+
+    public static Bounds boundsOnScreen(Node node) {
+        Bounds boundsInScene = nodeBoundsInScene(node);
+//        Bounds visibleBoundsInScene = limitToVisibleBounds(boundsInScene, node.getScene());
+        return boundsOnScreen(boundsInScene, node.getScene());
+    }
+
+    public static Bounds boundsOnScreen(Bounds boundsInScene,
+                                        Scene scene) {
+        Bounds sceneBoundsInWindow = bounds(scene);
+        Bounds windowBoundsOnScreen = bounds(scene.getWindow());
+        return translateBounds(boundsInScene, byOffset(
+            sceneBoundsInWindow.getMinX() + windowBoundsOnScreen.getMinX(),
+            sceneBoundsInWindow.getMinY() + windowBoundsOnScreen.getMinY()
+        ));
+    }
+
+    public static Bounds boundsOnScreen(Bounds boundsInWindow,
+                                        Window window) {
+        Bounds windowBoundsOnScreen = bounds(window);
+        return translateBounds(boundsInWindow, byOffset(
+            windowBoundsOnScreen.getMinX(),
+            windowBoundsOnScreen.getMinY()
+        ));
+    }
+
+    public static Bounds boundsOnScreen(Bounds boundsOnScreen,
+                                        Rectangle2D screenRegion) {
+        return translateBounds(boundsOnScreen, byOffset(
+            screenRegion.getMinX(),
+            screenRegion.getMinY()
+        ));
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // PRIVATE STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    private static Bounds limitToVisibleBounds(Bounds boundsInScene,
+                                               Scene scene) {
+        Bounds sceneBounds = makeSceneBounds(scene);
+        Bounds visibleBounds = intersectBounds(boundsInScene, sceneBounds);
+        if (!areBoundsVisible(visibleBounds)) {
+            throw new RuntimeException("Bounds are not visible in Scene.");
+        }
+        return visibleBounds;
+    }
+
+    private static Bounds makeSceneBounds(Scene scene) {
+        return new BoundingBox(0, 0, scene.getWidth(), scene.getHeight());
+    }
+
+    private static Bounds intersectBounds(Bounds a,
+                                          Bounds b) {
+        double minX = Math.max(a.getMinX(), b.getMinX());
+        double minY = Math.max(a.getMinY(), b.getMinY());
+        double maxX = Math.min(a.getMaxX(), b.getMaxX());
+        double maxY = Math.min(a.getMaxY(), b.getMaxY());
+        double width = maxX - minX;
+        double height = maxY - minY;
+        return new BoundingBox(minX, minY, width, height);
+    }
+
+    private static boolean areBoundsVisible(Bounds bounds) {
+        return !bounds.isEmpty();
+    }
+
+    private static Bounds translateBounds(Bounds bounds,
+                                          Point2D offset) {
+        return new BoundingBox(
+            bounds.getMinX() + offset.getX(),
+            bounds.getMinY() + offset.getY(),
+            bounds.getWidth(),
+            bounds.getHeight()
+        );
+    }
+
+    private static Point2D byOffset(double x,
+                                    double y) {
+        return new Point2D(x, y);
+    }
+
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsUtils.java
@@ -39,11 +39,13 @@ public final class BoundsUtils {
     // STATIC METHODS.
     //---------------------------------------------------------------------------------------------
 
-    public static Point2D atPosition(Bounds bounds, Pos position) {
+    public static Point2D atPosition(Bounds bounds,
+                                     Pos position) {
         return atPositionFactors(bounds, computePositionFactors(position));
     }
 
-    public static Point2D atPositionFactors(Bounds bounds, Point2D positionFactors) {
+    public static Point2D atPositionFactors(Bounds bounds,
+                                            Point2D positionFactors) {
         double pointX = lerp(bounds.getMinX(), bounds.getMaxX(), positionFactors.getX());
         double pointY = lerp(bounds.getMinY(), bounds.getMaxY(), positionFactors.getY());
         return new Point2D(pointX, pointY);
@@ -59,7 +61,9 @@ public final class BoundsUtils {
     // PRIVATE STATIC METHODS.
     //---------------------------------------------------------------------------------------------
 
-    private static double lerp(double start, double end, double factor) {
+    private static double lerp(double start,
+                               double end,
+                               double factor) {
         return start + ((end - start) * factor);
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
@@ -25,13 +25,13 @@ import javafx.geometry.VPos;
 import org.testfx.api.annotation.Unstable;
 
 @Unstable
-public final class BoundsUtils {
+public final class PointQueryUtils {
 
     //---------------------------------------------------------------------------------------------
     // CONSTRUCTORS.
     //---------------------------------------------------------------------------------------------
 
-    private BoundsUtils() {
+    private PointQueryUtils() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
@@ -104,7 +104,7 @@ public class AwtRobotAdapterTest {
         });
 
         PointLocator pointLocator = new PointLocatorImpl(new BoundsLocatorImpl());
-        regionPoint = pointLocator.pointFor(region).atPosition(Pos.CENTER).query();
+        regionPoint = pointLocator.point(region).atPosition(Pos.CENTER).query();
     }
 
     @After

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
@@ -103,7 +103,7 @@ public class GlassRobotAdapterTest {
         });
 
         PointLocator pointLocator = new PointLocatorImpl(new BoundsLocatorImpl());
-        regionPoint = pointLocator.pointFor(region).atPosition(Pos.CENTER).query();
+        regionPoint = pointLocator.point(region).atPosition(Pos.CENTER).query();
     }
 
     @After

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
@@ -72,7 +72,7 @@ public class PointLocatorImplTest {
     @Test
     public void pointFor_Bounds_atOffset() {
         // given:
-        PointQuery pointQuery = pointLocator.pointFor(new BoundingBox(100, 100, 50, 50));
+        PointQuery pointQuery = pointLocator.point(new BoundingBox(100, 100, 50, 50));
 
         // when:
         Point2D point = pointQuery.atOffset(0, 0).query();
@@ -85,7 +85,7 @@ public class PointLocatorImplTest {
     public void pointFor_Point2D_atOffset() {
         // given:
         boundsLocatorStub.bounds = nodeBounds;
-        PointQuery pointQuery = pointLocator.pointFor(new Point2D(100, 100));
+        PointQuery pointQuery = pointLocator.point(new Point2D(100, 100));
 
         // when:
         Point2D point = pointQuery.atOffset(0, 0).query();
@@ -98,7 +98,7 @@ public class PointLocatorImplTest {
     public void pointFor_Node_atOffset() {
         // given:
         boundsLocatorStub.bounds = nodeBounds;
-        PointQuery pointQuery = pointLocator.pointFor((Node) null);
+        PointQuery pointQuery = pointLocator.point((Node) null);
 
         // when:
         Point2D point = pointQuery.atOffset(0, 0).query();
@@ -111,7 +111,7 @@ public class PointLocatorImplTest {
     public void pointFor_Node_atOffset_afterChange() {
         // given:
         boundsLocatorStub.bounds = nodeBounds;
-        PointQuery pointQuery = pointLocator.pointFor((Node) null);
+        PointQuery pointQuery = pointLocator.point((Node) null);
 
         // when:
         boundsLocatorStub.bounds = nodeBoundsAfterChange;
@@ -125,7 +125,7 @@ public class PointLocatorImplTest {
     public void pointFor_Scene_atOffset() {
         // given:
         boundsLocatorStub.bounds = sceneBounds;
-        PointQuery pointQuery = pointLocator.pointFor((Scene) null);
+        PointQuery pointQuery = pointLocator.point((Scene) null);
 
         // when:
         Point2D point = pointQuery.atOffset(0, 0).query();
@@ -138,7 +138,7 @@ public class PointLocatorImplTest {
     public void pointFor_Scene_atOffset_afterChange() {
         // given:
         boundsLocatorStub.bounds = sceneBounds;
-        PointQuery pointQuery = pointLocator.pointFor((Scene) null);
+        PointQuery pointQuery = pointLocator.point((Scene) null);
 
         // when:
         boundsLocatorStub.bounds = sceneBoundsAfterChange;
@@ -152,7 +152,7 @@ public class PointLocatorImplTest {
     public void pointFor_Window_atOffset() {
         // given:
         boundsLocatorStub.bounds = windowBounds;
-        PointQuery pointQuery = pointLocator.pointFor((Window) null);
+        PointQuery pointQuery = pointLocator.point((Window) null);
 
         // when:
         Point2D point = pointQuery.atOffset(0, 0).query();
@@ -165,7 +165,7 @@ public class PointLocatorImplTest {
     public void pointFor_Window_atOffset_afterChange() {
         // given:
         boundsLocatorStub.bounds = windowBounds;
-        PointQuery pointQuery = pointLocator.pointFor((Window) null);
+        PointQuery pointQuery = pointLocator.point((Window) null);
 
         // when:
         boundsLocatorStub.bounds = windowBoundsAfterChange;

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.util;
+
+import javafx.geometry.BoundingBox;
+import javafx.geometry.Bounds;
+import javafx.geometry.Dimension2D;
+import javafx.geometry.Insets;
+import javafx.geometry.Point2D;
+import javafx.geometry.Pos;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Scene;
+import javafx.scene.effect.BoxBlur;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderStroke;
+import javafx.scene.layout.BorderStrokeStyle;
+import javafx.scene.layout.BorderWidths;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.Shape;
+import javafx.scene.shape.StrokeType;
+import javafx.scene.transform.Translate;
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxToolkit;
+
+import static org.testfx.api.FxAssert.verifyThat;
+
+public class BoundsQueryUtilsTest {
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURES.
+    //---------------------------------------------------------------------------------------------
+
+    private static Shape shape;
+    private static Region region;
+    private static Scene scene;
+    private static Stage stage;
+
+    private static final double shapeWidth = 200;
+    private static final double clipWidth = 100;
+    private static final double translateX = 50;
+    private static final double layoutX = 25;
+
+    private static final double paddingLeft = 200;
+    private static final double borderLeft = 100;
+    private static final double marginLeft = 50;
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.setupFixture(() -> {
+            setupShape();
+            setupRegion();
+            setupScene();
+            setupStage();
+        });
+    }
+
+    private static void setupShape() {
+        shape = new Rectangle(0, 0, shapeWidth, 0); // nodeBounds()
+        shape.setClip(new Rectangle(0, 0, clipWidth, 0)); // nodeBoundsInLocal()
+        shape.getTransforms().add(new Translate(translateX, 0)); // nodeBoundsInParent()
+
+        Shape altShape = new Rectangle(0, 0, shapeWidth, 0); // nodeBounds()
+        altShape.setFill(Color.GREEN);
+        altShape.setStroke(Color.BLACK);
+        altShape.setStrokeType(StrokeType.OUTSIDE);
+        altShape.setStrokeWidth(5); // nodeBounds(), nodeBoundsInParent()
+        altShape.setEffect(new BoxBlur(10, 10, 1)); // nodeBoundsInLocal()
+    }
+
+    private static void setupRegion() {
+        region = new Region();
+        region.setMaxSize(0, 0);
+        region.setBackground(new Background(new BackgroundFill(Color.RED, null, null)));
+        region.setPadding(new Insets(0, 0, 0, paddingLeft)); // nodeBounds(), nodeBoundsInLocal()
+        region.setBorder(new Border(new BorderStroke(Color.BLUE, BorderStrokeStyle.SOLID, null,
+                new BorderWidths(0, 0, 0, borderLeft)))); // nodeBounds(), nodeBoundsInLocal()
+        StackPane.setMargin(region, new Insets(0, 0, 0, marginLeft)); // nodeBoundsInParent()
+    }
+
+    private static void setupScene() {
+        StackPane sceneRoot = new StackPane(shape, region);
+        sceneRoot.setAlignment(Pos.TOP_LEFT);
+        sceneRoot.setLayoutX(layoutX); // bounds(Scene)
+        sceneRoot.setLayoutY(0);
+        scene = new Scene(sceneRoot, 1, 1);
+    }
+
+    private static void setupStage() {
+        // XXX: the real x and y are not set immediately. they are managed by the operating system.
+        stage = new Stage(StageStyle.UNDECORATED);
+//        stage.setX(0); // bounds(Window)
+//        stage.setY(0);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Test
+    public void bounds_doubles() {
+        // expect:
+        verifyThat(BoundsQueryUtils.bounds(1, 2, 3, 4),
+                   hasBounds(1, 2, 3, 4));
+    }
+
+    @Test
+    public void bounds_point() {
+        // expect:
+        verifyThat(BoundsQueryUtils.bounds(new Point2D(1, 2)),
+                   hasBounds(1, 2, 0, 0));
+    }
+
+    @Test
+    public void bounds_dimension() {
+        // expect:
+        verifyThat(BoundsQueryUtils.bounds(new Dimension2D(1, 2)),
+                   hasBounds(0, 0, 1, 2));
+    }
+
+    @Test
+    public void bounds_rectangle() {
+        // expect:
+        verifyThat(BoundsQueryUtils.bounds(new Rectangle2D(1, 2, 3, 4)),
+                   hasBounds(1, 2, 3, 4));
+    }
+
+    @Test
+    public void bounds_scene() {
+        // expect:
+        verifyThat(BoundsQueryUtils.bounds(scene),
+                   hasBounds(0, 0, 1, 1));
+    }
+
+    @Test
+    public void bounds_window() {
+        // expect:
+        verifyThat(BoundsQueryUtils.bounds(stage),
+                   hasBounds(stage.getX(), stage.getY(), 1, 1));
+    }
+
+    @Test
+    public void nodeBounds_shape() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.nodeBounds(shape);
+        verifyThat(bounds, hasBounds(
+            0, 0,
+            shapeWidth, 0
+        ));
+    }
+
+    @Test
+    public void nodeBoundsInLocal_shape() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.nodeBoundsInLocal(shape);
+        verifyThat(bounds, hasBounds(
+            0, 0,
+            clipWidth, 0
+        ));
+    }
+
+    @Test
+    public void nodeBoundsInParent_shape() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.nodeBoundsInParent(shape);
+        verifyThat(bounds, hasBounds(
+            translateX, 0,
+            clipWidth, 0
+        ));
+    }
+
+    @Test
+    public void nodeBoundsInScene_shape() {
+        // expect:
+        Bounds Bounds = BoundsQueryUtils.nodeBoundsInScene(shape);
+        verifyThat(Bounds, hasBounds(
+            layoutX + translateX, 0,
+            clipWidth, 0
+        ));
+    }
+
+    @Test
+    public void nodeBounds_region() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.nodeBounds(region);
+        verifyThat(bounds, hasBounds(
+            0, 0,
+            borderLeft + paddingLeft, 0
+        ));
+    }
+
+    @Test
+    public void nodeBoundsInLocal_region() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.nodeBoundsInLocal(region);
+        verifyThat(bounds, hasBounds(
+            0, 0,
+            borderLeft + paddingLeft, 0
+        ));
+    }
+
+    @Test
+    public void nodeBoundsInParent_region() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.nodeBoundsInParent(region);
+        verifyThat(bounds, hasBounds(
+            marginLeft, 0,
+            borderLeft + paddingLeft, 0
+        ));
+    }
+
+    @Test
+    public void nodeBoundsInScene_region() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.nodeBoundsInScene(region);
+        verifyThat(bounds, hasBounds(
+            layoutX + marginLeft, 0,
+            borderLeft + paddingLeft, 0
+        ));
+    }
+
+    // TODO: boundsOnScreen() with node.getScene() == null
+    // TODO: boundsOnScreen() with node.getScene().getWindow() == null
+
+    @Test
+    public void boundsOnScreen_screen() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.boundsOnScreen(
+            new BoundingBox(1, 2, 3, 4),
+            Screen.getPrimary().getBounds()
+        );
+        verifyThat(bounds, hasBounds(1, 2, 3, 4));
+    }
+
+    @Test
+    public void boundsOnScreen_window() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.boundsOnScreen(
+            new BoundingBox(1, 2, 3, 4),
+            stage
+        );
+        verifyThat(bounds, hasBounds(
+            stage.getX() + 1, stage.getY() + 2,
+            3, 4
+        ));
+    }
+
+    @Test
+    public void boundsOnScreen_scene() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.boundsOnScreen(
+            new BoundingBox(1, 2, 3, 4),
+            scene
+        );
+        verifyThat(bounds, hasBounds(
+            stage.getX() + 1, stage.getY() + 2,
+            3, 4
+        ));
+    }
+
+    @Test
+    public void boundsOnScreen_shape() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.boundsOnScreen(shape);
+        verifyThat(bounds, hasBounds(
+            stage.getX() + layoutX + translateX, stage.getY(),
+            clipWidth, 0
+        ));
+    }
+
+    @Test
+    public void boundsOnScreen_region() {
+        // expect:
+        Bounds bounds = BoundsQueryUtils.boundsOnScreen(region);
+        verifyThat(bounds, hasBounds(
+            stage.getX() + layoutX + marginLeft, stage.getY(),
+            borderLeft + paddingLeft, 0
+        ));
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // HELPER METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    private Matcher<Bounds> hasBounds(double minX,
+                                      double minY,
+                                      double width,
+                                      double height) {
+        return Matchers.is(new BoundingBox(minX, minY, width, height));
+    }
+
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
@@ -24,11 +24,11 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.testfx.util.BoundsUtils.atPosition;
-import static org.testfx.util.BoundsUtils.atPositionFactors;
-import static org.testfx.util.BoundsUtils.computePositionFactors;
+import static org.testfx.util.PointQueryUtils.atPosition;
+import static org.testfx.util.PointQueryUtils.atPositionFactors;
+import static org.testfx.util.PointQueryUtils.computePositionFactors;
 
-public class BoundsUtilsTest {
+public class PointQueryUtilsTest {
 
     //---------------------------------------------------------------------------------------------
     // FEATURE METHODS.


### PR DESCRIPTION
First very simple iteration of `BoundsQuery`. `BoundsQuery::query()` only returns bounds on desktop screen, for now. In the future it should also support bounds for `Node`s (layout, in local, in parent, in scene, in window) and bounds relative to other kinds of screen objects.

~~~java
public interface BoundsQuery {
    public Bounds query();
}
~~~

This includes the new `FxRobot::bounds()` methods.

~~~java
public interface FxRobotInterface {
    public BoundsQuery bounds(double minX,
                              double minY,
                              double width,
                              double height);
    public BoundsQuery bounds(Point2D point);
    public BoundsQuery bounds(Bounds bounds);
    public BoundsQuery bounds(Node node);
    public BoundsQuery bounds(Scene scene);
    public BoundsQuery bounds(Window window);

    // Convenience methods:
    public BoundsQuery bounds(String query);
    public <T extends Node> BoundsQuery bounds(Matcher<T> matcher);
    public <T extends Node> BoundsQuery bounds(Predicate<T> predicate);
}
~~~