### PR TITLE
(feat) TextFlowMatchers: Add matchers for the text of a TextFlow.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.matcher.control;
+
+import static org.testfx.matcher.base.GeneralMatchers.typeSafeMatcher;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import javafx.scene.Node;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.testfx.api.annotation.Unstable;
+import org.testfx.util.ColorUtils;
+
+@Unstable(reason = "needs more tests")
+public class TextFlowMatchers {
+
+    //---------------------------------------------------------------------------------------------
+    // STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Node> hasText(String string) {
+        String descriptionText = "has text \"" + string + "\"";
+        return typeSafeMatcher(TextFlow.class, descriptionText, node -> hasText(node, string));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Node> hasColoredText(String string) {
+        String descriptionText = "has colored text \"" + string + "\"";
+        return typeSafeMatcher(TextFlow.class, descriptionText, node -> hasColoredText(node, string));
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // PRIVATE STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    private static boolean hasText(TextFlow textFlow, String string) {
+        StringBuilder textBuilder = new StringBuilder();
+
+        for (Node child : textFlow.getChildren()) {
+            if (Text.class.isAssignableFrom(child.getClass())) {
+                textBuilder.append(((Text) child).getText());
+            }
+        }
+        return Objects.equals(string, textBuilder.toString());
+    }
+
+    private static boolean hasColoredText(TextFlow textFlow, String string) {
+        StringBuilder textBuilder = new StringBuilder();
+
+        for (Node child : textFlow.getChildren()) {
+            if (Text.class.isAssignableFrom(child.getClass())) {
+                Text text = ((Text) child);
+                String color = ColorUtils.getColorNameFromHex(text.getFill().toString()
+                        .substring(2, 8)).toUpperCase(Locale.US);
+
+                if (!color.equals("BLACK")) {
+                    textBuilder.append("<").append(color).append(">");
+                }
+                textBuilder.append(text.getText());
+
+                if (!color.equals("BLACK")) {
+                    textBuilder.append("</").append(color).append(">");
+                }
+            }
+        }
+        return Objects.equals(string, textBuilder.toString());
+    }
+
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
@@ -45,6 +45,34 @@ public class TextFlowMatchers {
         return typeSafeMatcher(TextFlow.class, descriptionText, node -> hasText(node, string));
     }
 
+    /**
+     * Allows one to verify both the content and color of the text that makes
+     * up a TextFlow. The color is matched by using the closest named color,
+     * as described further on.
+     * <p>
+     * Colors are specified using the following markup:
+     *
+     * <pre><code><COLOR>text</COLOR></code></pre>
+     * <p>
+     * Where {@literal COLOR} is one of JavaFX's named colors.
+     * <p>
+     * Here is an example for verifying that a TextFlow contains the text
+     * "hello" and that the named color that has the closest value to the
+     * color of the text is {@literal Colors.RED}:
+     * <p>
+     * <pre><code>
+     *   Text text = new Text("hello");
+     *   text.setFill(Colors.RED);
+     *   TextFlow textFlow = new TextFlow(text);
+     *   assertThat(textFlow, TextFlowMatchers.hasColoredText("<RED>hello</RED>"));
+     * </code></pre>
+     *
+     * @param string the text contained in the TextFlow with color markup that
+     * specifies the expected color of the text
+     * @return a match if the text contained in the TextFlow has the same content
+     * and colors that match by the "closest named color" criteria
+     * @see <a href="https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#typecolor">Named Colors</a>
+     */
     @Factory
     @Unstable(reason = "is missing apidocs")
     public static Matcher<Node> hasColoredText(String string) {
@@ -52,6 +80,34 @@ public class TextFlowMatchers {
         return typeSafeMatcher(TextFlow.class, descriptionText, node -> hasColoredText(node, string, false));
     }
 
+    /**
+     * Allows one to verify both the content and color of the text that makes
+     * up a TextFlow. The color is matched in an exact way, as described fruther
+     * on.
+     * <p>
+     * Colors are specified using the following markup:
+     * <p>
+     * <pre><code><COLOR>text</COLOR></code></pre>
+     * <p>
+     * Where {@literal COLOR} is one of JavaFX's named colors.
+     * <p>
+     * Here is an example for verifying that a TextFlow contains the text
+     * "hello" and that the color of the text is *exactly* {@literal Colors.BLUE}
+     * (that is, it has an RGB value of (0, 0, 255)).
+     *
+     * <pre><code>
+     *   Text text = new Text("hello");
+     *   text.setFill(Colors.BLUE); // or: text.setFill(Colors.rgb(0, 0, 255));
+     *   TextFlow textFlow = new TextFlow(text);
+     *   assertThat(textFlow, TextFlowMatchers.hasExactlyColoredText("<BLUE>hello</BLUE>"));
+     * </code></pre>
+     *
+     * @param string the text contained in the TextFlow with color markup that
+     * specifies the expected color of the text
+     * @return a match if the text contained in the TextFlow has the same content
+     * and the exactly matching colors
+     * @see <a href="https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#typecolor">Named Colors</a>
+     */
     @Factory
     @Unstable(reason = "is missing apidocs")
     public static Matcher<Node> hasExactlyColoredText(String string) {
@@ -82,8 +138,8 @@ public class TextFlowMatchers {
                 Text text = ((Text) child);
                 final String color;
                 if (exact) {
-                    Optional<String> colorOptional = ColorUtils.getNamedColor(text.getFill().toString()
-                            .substring(2, 8));
+                    Optional<String> colorOptional = ColorUtils.getNamedColor(
+                            text.getFill().toString().substring(2, 8));
                     if (colorOptional.isPresent()) {
                         color = colorOptional.get().toUpperCase(Locale.US);
                     } else {

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
@@ -21,6 +21,7 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
 
 import org.testfx.service.support.PixelMatcher;
+import org.testfx.util.ColorUtils;
 
 public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
 
@@ -56,11 +57,11 @@ public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
     @Override
     public boolean matchColors(Color color0, Color color1) {
         if (minColorDistSq == Double.MIN_VALUE) {
-            double maxColorDistSq = calculateColorDistSq(Color.BLACK, Color.WHITE);
+            double maxColorDistSq = ColorUtils.calculateColorDistSq(Color.BLACK, Color.WHITE);
             minColorDistSq = maxColorDistSq * (minColorDistFactor * minColorDistFactor);
         }
 
-        double colorDistSq = calculateColorDistSq(color0, color1);
+        double colorDistSq = ColorUtils.calculateColorDistSq(color0, color1);
         return colorDistSq < minColorDistSq;
     }
 
@@ -86,14 +87,6 @@ public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
     //---------------------------------------------------------------------------------------------
     // PRIVATE METHODS.
     //---------------------------------------------------------------------------------------------
-
-    private double calculateColorDistSq(Color color0,
-                                        Color color1) {
-        double diffRed = color0.getRed() - color1.getRed();
-        double diffGreen = color0.getGreen() - color1.getGreen();
-        double diffBlue = color0.getBlue() - color1.getBlue();
-        return (diffRed * diffRed) + (diffGreen * diffGreen) + (diffBlue * diffBlue);
-    }
 
     private double blendToWhite(double gray,
                                 double factor) {

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
@@ -16,7 +16,10 @@
  */
 package org.testfx.util;
 
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import javafx.scene.paint.Color;
 
@@ -27,185 +30,220 @@ import javafx.scene.paint.Color;
  */
 public class ColorUtils
 {
-    private static ArrayList<NamedColor> namedColors = new ArrayList<>();
+    private static Map<RGB, String> namedColors = new HashMap<>();
     static {
-        namedColors.add(new NamedColor("AliceBlue", 0xF0, 0xF8, 0xFF));
-        namedColors.add(new NamedColor("AntiqueWhite", 0xFA, 0xEB, 0xD7));
-        namedColors.add(new NamedColor("Aqua", 0x00, 0xFF, 0xFF));
-        namedColors.add(new NamedColor("Aquamarine", 0x7F, 0xFF, 0xD4));
-        namedColors.add(new NamedColor("Azure", 0xF0, 0xFF, 0xFF));
-        namedColors.add(new NamedColor("Beige", 0xF5, 0xF5, 0xDC));
-        namedColors.add(new NamedColor("Bisque", 0xFF, 0xE4, 0xC4));
-        namedColors.add(new NamedColor("Black", 0x00, 0x00, 0x00));
-        namedColors.add(new NamedColor("BlanchedAlmond", 0xFF, 0xEB, 0xCD));
-        namedColors.add(new NamedColor("Blue", 0x00, 0x00, 0xFF));
-        namedColors.add(new NamedColor("BlueViolet", 0x8A, 0x2B, 0xE2));
-        namedColors.add(new NamedColor("Brown", 0xA5, 0x2A, 0x2A));
-        namedColors.add(new NamedColor("BurlyWood", 0xDE, 0xB8, 0x87));
-        namedColors.add(new NamedColor("CadetBlue", 0x5F, 0x9E, 0xA0));
-        namedColors.add(new NamedColor("Chartreuse", 0x7F, 0xFF, 0x00));
-        namedColors.add(new NamedColor("Chocolate", 0xD2, 0x69, 0x1E));
-        namedColors.add(new NamedColor("Coral", 0xFF, 0x7F, 0x50));
-        namedColors.add(new NamedColor("CornflowerBlue", 0x64, 0x95, 0xED));
-        namedColors.add(new NamedColor("Cornsilk", 0xFF, 0xF8, 0xDC));
-        namedColors.add(new NamedColor("Crimson", 0xDC, 0x14, 0x3C));
-        namedColors.add(new NamedColor("Cyan", 0x00, 0xFF, 0xFF));
-        namedColors.add(new NamedColor("DarkBlue", 0x00, 0x00, 0x8B));
-        namedColors.add(new NamedColor("DarkCyan", 0x00, 0x8B, 0x8B));
-        namedColors.add(new NamedColor("DarkGoldenRod", 0xB8, 0x86, 0x0B));
-        namedColors.add(new NamedColor("DarkGray", 0xA9, 0xA9, 0xA9));
-        namedColors.add(new NamedColor("DarkGreen", 0x00, 0x64, 0x00));
-        namedColors.add(new NamedColor("DarkKhaki", 0xBD, 0xB7, 0x6B));
-        namedColors.add(new NamedColor("DarkMagenta", 0x8B, 0x00, 0x8B));
-        namedColors.add(new NamedColor("DarkOliveGreen", 0x55, 0x6B, 0x2F));
-        namedColors.add(new NamedColor("DarkOrange", 0xFF, 0x8C, 0x00));
-        namedColors.add(new NamedColor("DarkOrchid", 0x99, 0x32, 0xCC));
-        namedColors.add(new NamedColor("DarkRed", 0x8B, 0x00, 0x00));
-        namedColors.add(new NamedColor("DarkSalmon", 0xE9, 0x96, 0x7A));
-        namedColors.add(new NamedColor("DarkSeaGreen", 0x8F, 0xBC, 0x8F));
-        namedColors.add(new NamedColor("DarkSlateBlue", 0x48, 0x3D, 0x8B));
-        namedColors.add(new NamedColor("DarkSlateGray", 0x2F, 0x4F, 0x4F));
-        namedColors.add(new NamedColor("DarkTurquoise", 0x00, 0xCE, 0xD1));
-        namedColors.add(new NamedColor("DarkViolet", 0x94, 0x00, 0xD3));
-        namedColors.add(new NamedColor("DeepPink", 0xFF, 0x14, 0x93));
-        namedColors.add(new NamedColor("DeepSkyBlue", 0x00, 0xBF, 0xFF));
-        namedColors.add(new NamedColor("DimGray", 0x69, 0x69, 0x69));
-        namedColors.add(new NamedColor("DodgerBlue", 0x1E, 0x90, 0xFF));
-        namedColors.add(new NamedColor("FireBrick", 0xB2, 0x22, 0x22));
-        namedColors.add(new NamedColor("FloralWhite", 0xFF, 0xFA, 0xF0));
-        namedColors.add(new NamedColor("ForestGreen", 0x22, 0x8B, 0x22));
-        namedColors.add(new NamedColor("Fuchsia", 0xFF, 0x00, 0xFF));
-        namedColors.add(new NamedColor("Gainsboro", 0xDC, 0xDC, 0xDC));
-        namedColors.add(new NamedColor("GhostWhite", 0xF8, 0xF8, 0xFF));
-        namedColors.add(new NamedColor("Gold", 0xFF, 0xD7, 0x00));
-        namedColors.add(new NamedColor("GoldenRod", 0xDA, 0xA5, 0x20));
-        namedColors.add(new NamedColor("Gray", 0x80, 0x80, 0x80));
-        namedColors.add(new NamedColor("Green", 0x00, 0x80, 0x00));
-        namedColors.add(new NamedColor("GreenYellow", 0xAD, 0xFF, 0x2F));
-        namedColors.add(new NamedColor("HoneyDew", 0xF0, 0xFF, 0xF0));
-        namedColors.add(new NamedColor("HotPink", 0xFF, 0x69, 0xB4));
-        namedColors.add(new NamedColor("IndianRed", 0xCD, 0x5C, 0x5C));
-        namedColors.add(new NamedColor("Indigo", 0x4B, 0x00, 0x82));
-        namedColors.add(new NamedColor("Ivory", 0xFF, 0xFF, 0xF0));
-        namedColors.add(new NamedColor("Khaki", 0xF0, 0xE6, 0x8C));
-        namedColors.add(new NamedColor("Lavender", 0xE6, 0xE6, 0xFA));
-        namedColors.add(new NamedColor("LavenderBlush", 0xFF, 0xF0, 0xF5));
-        namedColors.add(new NamedColor("LawnGreen", 0x7C, 0xFC, 0x00));
-        namedColors.add(new NamedColor("LemonChiffon", 0xFF, 0xFA, 0xCD));
-        namedColors.add(new NamedColor("LightBlue", 0xAD, 0xD8, 0xE6));
-        namedColors.add(new NamedColor("LightCoral", 0xF0, 0x80, 0x80));
-        namedColors.add(new NamedColor("LightCyan", 0xE0, 0xFF, 0xFF));
-        namedColors.add(new NamedColor("LightGoldenRodYellow", 0xFA, 0xFA, 0xD2));
-        namedColors.add(new NamedColor("LightGray", 0xD3, 0xD3, 0xD3));
-        namedColors.add(new NamedColor("LightGreen", 0x90, 0xEE, 0x90));
-        namedColors.add(new NamedColor("LightPink", 0xFF, 0xB6, 0xC1));
-        namedColors.add(new NamedColor("LightSalmon", 0xFF, 0xA0, 0x7A));
-        namedColors.add(new NamedColor("LightSeaGreen", 0x20, 0xB2, 0xAA));
-        namedColors.add(new NamedColor("LightSkyBlue", 0x87, 0xCE, 0xFA));
-        namedColors.add(new NamedColor("LightSlateGray", 0x77, 0x88, 0x99));
-        namedColors.add(new NamedColor("LightSteelBlue", 0xB0, 0xC4, 0xDE));
-        namedColors.add(new NamedColor("LightYellow", 0xFF, 0xFF, 0xE0));
-        namedColors.add(new NamedColor("Lime", 0x00, 0xFF, 0x00));
-        namedColors.add(new NamedColor("LimeGreen", 0x32, 0xCD, 0x32));
-        namedColors.add(new NamedColor("Linen", 0xFA, 0xF0, 0xE6));
-        namedColors.add(new NamedColor("Magenta", 0xFF, 0x00, 0xFF));
-        namedColors.add(new NamedColor("Maroon", 0x80, 0x00, 0x00));
-        namedColors.add(new NamedColor("MediumAquaMarine", 0x66, 0xCD, 0xAA));
-        namedColors.add(new NamedColor("MediumBlue", 0x00, 0x00, 0xCD));
-        namedColors.add(new NamedColor("MediumOrchid", 0xBA, 0x55, 0xD3));
-        namedColors.add(new NamedColor("MediumPurple", 0x93, 0x70, 0xDB));
-        namedColors.add(new NamedColor("MediumSeaGreen", 0x3C, 0xB3, 0x71));
-        namedColors.add(new NamedColor("MediumSlateBlue", 0x7B, 0x68, 0xEE));
-        namedColors.add(new NamedColor("MediumSpringGreen", 0x00, 0xFA, 0x9A));
-        namedColors.add(new NamedColor("MediumTurquoise", 0x48, 0xD1, 0xCC));
-        namedColors.add(new NamedColor("MediumVioletRed", 0xC7, 0x15, 0x85));
-        namedColors.add(new NamedColor("MidnightBlue", 0x19, 0x19, 0x70));
-        namedColors.add(new NamedColor("MintCream", 0xF5, 0xFF, 0xFA));
-        namedColors.add(new NamedColor("MistyRose", 0xFF, 0xE4, 0xE1));
-        namedColors.add(new NamedColor("Moccasin", 0xFF, 0xE4, 0xB5));
-        namedColors.add(new NamedColor("NavajoWhite", 0xFF, 0xDE, 0xAD));
-        namedColors.add(new NamedColor("Navy", 0x00, 0x00, 0x80));
-        namedColors.add(new NamedColor("OldLace", 0xFD, 0xF5, 0xE6));
-        namedColors.add(new NamedColor("Olive", 0x80, 0x80, 0x00));
-        namedColors.add(new NamedColor("OliveDrab", 0x6B, 0x8E, 0x23));
-        namedColors.add(new NamedColor("Orange", 0xFF, 0xA5, 0x00));
-        namedColors.add(new NamedColor("OrangeRed", 0xFF, 0x45, 0x00));
-        namedColors.add(new NamedColor("Orchid", 0xDA, 0x70, 0xD6));
-        namedColors.add(new NamedColor("PaleGoldenRod", 0xEE, 0xE8, 0xAA));
-        namedColors.add(new NamedColor("PaleGreen", 0x98, 0xFB, 0x98));
-        namedColors.add(new NamedColor("PaleTurquoise", 0xAF, 0xEE, 0xEE));
-        namedColors.add(new NamedColor("PaleVioletRed", 0xDB, 0x70, 0x93));
-        namedColors.add(new NamedColor("PapayaWhip", 0xFF, 0xEF, 0xD5));
-        namedColors.add(new NamedColor("PeachPuff", 0xFF, 0xDA, 0xB9));
-        namedColors.add(new NamedColor("Peru", 0xCD, 0x85, 0x3F));
-        namedColors.add(new NamedColor("Pink", 0xFF, 0xC0, 0xCB));
-        namedColors.add(new NamedColor("Plum", 0xDD, 0xA0, 0xDD));
-        namedColors.add(new NamedColor("PowderBlue", 0xB0, 0xE0, 0xE6));
-        namedColors.add(new NamedColor("Purple", 0x80, 0x00, 0x80));
-        namedColors.add(new NamedColor("Red", 0xFF, 0x00, 0x00));
-        namedColors.add(new NamedColor("RosyBrown", 0xBC, 0x8F, 0x8F));
-        namedColors.add(new NamedColor("RoyalBlue", 0x41, 0x69, 0xE1));
-        namedColors.add(new NamedColor("SaddleBrown", 0x8B, 0x45, 0x13));
-        namedColors.add(new NamedColor("Salmon", 0xFA, 0x80, 0x72));
-        namedColors.add(new NamedColor("SandyBrown", 0xF4, 0xA4, 0x60));
-        namedColors.add(new NamedColor("SeaGreen", 0x2E, 0x8B, 0x57));
-        namedColors.add(new NamedColor("SeaShell", 0xFF, 0xF5, 0xEE));
-        namedColors.add(new NamedColor("Sienna", 0xA0, 0x52, 0x2D));
-        namedColors.add(new NamedColor("Silver", 0xC0, 0xC0, 0xC0));
-        namedColors.add(new NamedColor("SkyBlue", 0x87, 0xCE, 0xEB));
-        namedColors.add(new NamedColor("SlateBlue", 0x6A, 0x5A, 0xCD));
-        namedColors.add(new NamedColor("SlateGray", 0x70, 0x80, 0x90));
-        namedColors.add(new NamedColor("Snow", 0xFF, 0xFA, 0xFA));
-        namedColors.add(new NamedColor("SpringGreen", 0x00, 0xFF, 0x7F));
-        namedColors.add(new NamedColor("SteelBlue", 0x46, 0x82, 0xB4));
-        namedColors.add(new NamedColor("Tan", 0xD2, 0xB4, 0x8C));
-        namedColors.add(new NamedColor("Teal", 0x00, 0x80, 0x80));
-        namedColors.add(new NamedColor("Thistle", 0xD8, 0xBF, 0xD8));
-        namedColors.add(new NamedColor("Tomato", 0xFF, 0x63, 0x47));
-        namedColors.add(new NamedColor("Turquoise", 0x40, 0xE0, 0xD0));
-        namedColors.add(new NamedColor("Violet", 0xEE, 0x82, 0xEE));
-        namedColors.add(new NamedColor("Wheat", 0xF5, 0xDE, 0xB3));
-        namedColors.add(new NamedColor("White", 0xFF, 0xFF, 0xFF));
-        namedColors.add(new NamedColor("WhiteSmoke", 0xF5, 0xF5, 0xF5));
-        namedColors.add(new NamedColor("Yellow", 0xFF, 0xFF, 0x00));
-        namedColors.add(new NamedColor("YellowGreen", 0x9A, 0xCD, 0x32));
+        namedColors.put(new RGB(0xF0, 0xF8, 0xFF), "AliceBlue");
+        namedColors.put(new RGB(0xFA, 0xEB, 0xD7), "AntiqueWhite");
+        namedColors.put(new RGB(0x00, 0xFF, 0xFF), "Aqua");
+        namedColors.put(new RGB(0x7F, 0xFF, 0xD4), "Aquamarine");
+        namedColors.put(new RGB(0xF0, 0xFF, 0xFF), "Azure");
+        namedColors.put(new RGB(0xF5, 0xF5, 0xDC), "Beige");
+        namedColors.put(new RGB(0xFF, 0xE4, 0xC4), "Bisque");
+        namedColors.put(new RGB(0x00, 0x00, 0x00), "Black");
+        namedColors.put(new RGB(0xFF, 0xEB, 0xCD), "BlanchedAlmond");
+        namedColors.put(new RGB(0x00, 0x00, 0xFF), "Blue");
+        namedColors.put(new RGB(0x8A, 0x2B, 0xE2), "BlueViolet");
+        namedColors.put(new RGB(0xA5, 0x2A, 0x2A), "Brown");
+        namedColors.put(new RGB(0xDE, 0xB8, 0x87), "BurlyWood");
+        namedColors.put(new RGB(0x5F, 0x9E, 0xA0), "CadetBlue");
+        namedColors.put(new RGB(0x7F, 0xFF, 0x00), "Chartreuse");
+        namedColors.put(new RGB(0xD2, 0x69, 0x1E), "Chocolate");
+        namedColors.put(new RGB(0xFF, 0x7F, 0x50), "Coral");
+        namedColors.put(new RGB(0x64, 0x95, 0xED), "CornflowerBlue");
+        namedColors.put(new RGB(0xFF, 0xF8, 0xDC), "Cornsilk");
+        namedColors.put(new RGB(0xDC, 0x14, 0x3C), "Crimson");
+        namedColors.put(new RGB(0x00, 0xFF, 0xFF), "Cyan");
+        namedColors.put(new RGB(0x00, 0x00, 0x8B), "DarkBlue");
+        namedColors.put(new RGB(0x00, 0x8B, 0x8B), "DarkCyan");
+        namedColors.put(new RGB(0xB8, 0x86, 0x0B), "DarkGoldenRod");
+        namedColors.put(new RGB(0xA9, 0xA9, 0xA9), "DarkGray");
+        namedColors.put(new RGB(0x00, 0x64, 0x00), "DarkGreen");
+        namedColors.put(new RGB(0xBD, 0xB7, 0x6B), "DarkKhaki");
+        namedColors.put(new RGB(0x8B, 0x00, 0x8B), "DarkMagenta");
+        namedColors.put(new RGB(0x55, 0x6B, 0x2F), "DarkOliveGreen");
+        namedColors.put(new RGB(0xFF, 0x8C, 0x00), "DarkOrange");
+        namedColors.put(new RGB(0x99, 0x32, 0xCC), "DarkOrchid");
+        namedColors.put(new RGB(0x8B, 0x00, 0x00), "DarkRed");
+        namedColors.put(new RGB(0xE9, 0x96, 0x7A), "DarkSalmon");
+        namedColors.put(new RGB(0x8F, 0xBC, 0x8F), "DarkSeaGreen");
+        namedColors.put(new RGB(0x48, 0x3D, 0x8B), "DarkSlateBlue");
+        namedColors.put(new RGB(0x2F, 0x4F, 0x4F), "DarkSlateGray");
+        namedColors.put(new RGB(0x00, 0xCE, 0xD1), "DarkTurquoise");
+        namedColors.put(new RGB(0x94, 0x00, 0xD3), "DarkViolet");
+        namedColors.put(new RGB(0xFF, 0x14, 0x93), "DeepPink");
+        namedColors.put(new RGB(0x00, 0xBF, 0xFF), "DeepSkyBlue");
+        namedColors.put(new RGB(0x69, 0x69, 0x69), "DimGray");
+        namedColors.put(new RGB(0x1E, 0x90, 0xFF), "DodgerBlue");
+        namedColors.put(new RGB(0xB2, 0x22, 0x22), "FireBrick");
+        namedColors.put(new RGB(0xFF, 0xFA, 0xF0), "FloralWhite");
+        namedColors.put(new RGB(0x22, 0x8B, 0x22), "ForestGreen");
+        namedColors.put(new RGB(0xFF, 0x00, 0xFF), "Fuchsia");
+        namedColors.put(new RGB(0xDC, 0xDC, 0xDC), "Gainsboro");
+        namedColors.put(new RGB(0xF8, 0xF8, 0xFF), "GhostWhite");
+        namedColors.put(new RGB(0xFF, 0xD7, 0x00), "Gold");
+        namedColors.put(new RGB(0xDA, 0xA5, 0x20), "GoldenRod");
+        namedColors.put(new RGB(0x80, 0x80, 0x80), "Gray");
+        namedColors.put(new RGB(0x00, 0x80, 0x00), "Green");
+        namedColors.put(new RGB(0xAD, 0xFF, 0x2F), "GreenYellow");
+        namedColors.put(new RGB(0xF0, 0xFF, 0xF0), "HoneyDew");
+        namedColors.put(new RGB(0xFF, 0x69, 0xB4), "HotPink");
+        namedColors.put(new RGB(0xCD, 0x5C, 0x5C), "IndianRed");
+        namedColors.put(new RGB(0x4B, 0x00, 0x82), "Indigo");
+        namedColors.put(new RGB(0xFF, 0xFF, 0xF0), "Ivory");
+        namedColors.put(new RGB(0xF0, 0xE6, 0x8C), "Khaki");
+        namedColors.put(new RGB(0xE6, 0xE6, 0xFA), "Lavender");
+        namedColors.put(new RGB(0xFF, 0xF0, 0xF5), "LavenderBlush");
+        namedColors.put(new RGB(0x7C, 0xFC, 0x00), "LawnGreen");
+        namedColors.put(new RGB(0xFF, 0xFA, 0xCD), "LemonChiffon");
+        namedColors.put(new RGB(0xAD, 0xD8, 0xE6), "LightBlue");
+        namedColors.put(new RGB(0xF0, 0x80, 0x80), "LightCoral");
+        namedColors.put(new RGB(0xE0, 0xFF, 0xFF), "LightCyan");
+        namedColors.put(new RGB(0xFA, 0xFA, 0xD2), "LightGoldenRodYellow");
+        namedColors.put(new RGB(0xD3, 0xD3, 0xD3), "LightGray");
+        namedColors.put(new RGB(0x90, 0xEE, 0x90), "LightGreen");
+        namedColors.put(new RGB(0xFF, 0xB6, 0xC1), "LightPink");
+        namedColors.put(new RGB(0xFF, 0xA0, 0x7A), "LightSalmon");
+        namedColors.put(new RGB(0x20, 0xB2, 0xAA), "LightSeaGreen");
+        namedColors.put(new RGB(0x87, 0xCE, 0xFA), "LightSkyBlue");
+        namedColors.put(new RGB(0x77, 0x88, 0x99), "LightSlateGray");
+        namedColors.put(new RGB(0xB0, 0xC4, 0xDE), "LightSteelBlue");
+        namedColors.put(new RGB(0xFF, 0xFF, 0xE0), "LightYellow");
+        namedColors.put(new RGB(0x00, 0xFF, 0x00), "Lime");
+        namedColors.put(new RGB(0x32, 0xCD, 0x32), "LimeGreen");
+        namedColors.put(new RGB(0xFA, 0xF0, 0xE6), "Linen");
+        namedColors.put(new RGB(0xFF, 0x00, 0xFF), "Magenta");
+        namedColors.put(new RGB(0x80, 0x00, 0x00), "Maroon");
+        namedColors.put(new RGB(0x66, 0xCD, 0xAA), "MediumAquaMarine");
+        namedColors.put(new RGB(0x00, 0x00, 0xCD), "MediumBlue");
+        namedColors.put(new RGB(0xBA, 0x55, 0xD3), "MediumOrchid");
+        namedColors.put(new RGB(0x93, 0x70, 0xDB), "MediumPurple");
+        namedColors.put(new RGB(0x3C, 0xB3, 0x71), "MediumSeaGreen");
+        namedColors.put(new RGB(0x7B, 0x68, 0xEE), "MediumSlateBlue");
+        namedColors.put(new RGB(0x00, 0xFA, 0x9A), "MediumSpringGreen");
+        namedColors.put(new RGB(0x48, 0xD1, 0xCC), "MediumTurquoise");
+        namedColors.put(new RGB(0xC7, 0x15, 0x85), "MediumVioletRed");
+        namedColors.put(new RGB(0x19, 0x19, 0x70), "MidnightBlue");
+        namedColors.put(new RGB(0xF5, 0xFF, 0xFA), "MintCream");
+        namedColors.put(new RGB(0xFF, 0xE4, 0xE1), "MistyRose");
+        namedColors.put(new RGB(0xFF, 0xE4, 0xB5), "Moccasin");
+        namedColors.put(new RGB(0xFF, 0xDE, 0xAD), "NavajoWhite");
+        namedColors.put(new RGB(0x00, 0x00, 0x80), "Navy");
+        namedColors.put(new RGB(0xFD, 0xF5, 0xE6), "OldLace");
+        namedColors.put(new RGB(0x80, 0x80, 0x00), "Olive");
+        namedColors.put(new RGB(0x6B, 0x8E, 0x23), "OliveDrab");
+        namedColors.put(new RGB(0xFF, 0xA5, 0x00), "Orange");
+        namedColors.put(new RGB(0xFF, 0x45, 0x00), "OrangeRed");
+        namedColors.put(new RGB(0xDA, 0x70, 0xD6), "Orchid");
+        namedColors.put(new RGB(0xEE, 0xE8, 0xAA), "PaleGoldenRod");
+        namedColors.put(new RGB(0x98, 0xFB, 0x98), "PaleGreen");
+        namedColors.put(new RGB(0xAF, 0xEE, 0xEE), "PaleTurquoise");
+        namedColors.put(new RGB(0xDB, 0x70, 0x93), "PaleVioletRed");
+        namedColors.put(new RGB(0xFF, 0xEF, 0xD5), "PapayaWhip");
+        namedColors.put(new RGB(0xFF, 0xDA, 0xB9), "PeachPuff");
+        namedColors.put(new RGB(0xCD, 0x85, 0x3F), "Peru");
+        namedColors.put(new RGB(0xFF, 0xC0, 0xCB), "Pink");
+        namedColors.put(new RGB(0xDD, 0xA0, 0xDD), "Plum");
+        namedColors.put(new RGB(0xB0, 0xE0, 0xE6), "PowderBlue");
+        namedColors.put(new RGB(0x80, 0x00, 0x80), "Purple");
+        namedColors.put(new RGB(0xFF, 0x00, 0x00), "Red");
+        namedColors.put(new RGB(0xBC, 0x8F, 0x8F), "RosyBrown");
+        namedColors.put(new RGB(0x41, 0x69, 0xE1), "RoyalBlue");
+        namedColors.put(new RGB(0x8B, 0x45, 0x13), "SaddleBrown");
+        namedColors.put(new RGB(0xFA, 0x80, 0x72), "Salmon");
+        namedColors.put(new RGB(0xF4, 0xA4, 0x60), "SandyBrown");
+        namedColors.put(new RGB(0x2E, 0x8B, 0x57), "SeaGreen");
+        namedColors.put(new RGB(0xFF, 0xF5, 0xEE), "SeaShell");
+        namedColors.put(new RGB(0xA0, 0x52, 0x2D), "Sienna");
+        namedColors.put(new RGB(0xC0, 0xC0, 0xC0), "Silver");
+        namedColors.put(new RGB(0x87, 0xCE, 0xEB), "SkyBlue");
+        namedColors.put(new RGB(0x6A, 0x5A, 0xCD), "SlateBlue");
+        namedColors.put(new RGB(0x70, 0x80, 0x90), "SlateGray");
+        namedColors.put(new RGB(0xFF, 0xFA, 0xFA), "Snow");
+        namedColors.put(new RGB(0x00, 0xFF, 0x7F), "SpringGreen");
+        namedColors.put(new RGB(0x46, 0x82, 0xB4), "SteelBlue");
+        namedColors.put(new RGB(0xD2, 0xB4, 0x8C), "Tan");
+        namedColors.put(new RGB(0x00, 0x80, 0x80), "Teal");
+        namedColors.put(new RGB(0xD8, 0xBF, 0xD8), "Thistle");
+        namedColors.put(new RGB(0xFF, 0x63, 0x47), "Tomato");
+        namedColors.put(new RGB(0x40, 0xE0, 0xD0), "Turquoise");
+        namedColors.put(new RGB(0xEE, 0x82, 0xEE), "Violet");
+        namedColors.put(new RGB(0xF5, 0xDE, 0xB3), "Wheat");
+        namedColors.put(new RGB(0xFF, 0xFF, 0xFF), "White");
+        namedColors.put(new RGB(0xF5, 0xF5, 0xF5), "WhiteSmoke");
+        namedColors.put(new RGB(0xFF, 0xFF, 0x00), "Yellow");
+        namedColors.put(new RGB(0x9A, 0xCD, 0x32), "YellowGreen");
     }
 
     /**
-     * Get the color name that is closest to the given RGB color.
+     * Get the color name that is closest to the given RGB color value.
      *
      * @param r the red component of the color (0 - 255)
      * @param g the green component of the color (0 - 255)
      * @param b the blue component of the color (0 - 255)
-     * @return the name of the color that is the closest to the given RGB color
+     * @return the name of the color that is the closest to the given RGB
+     * color value.
      */
-    private static String getColorNameFromRgb(int r, int g, int b) {
-        NamedColor closestMatch = namedColors.get(0);
+    private static String getClosestNamedColor(int r, int g, int b) {
+        Map.Entry<RGB, String> closestEntry = namedColors.entrySet().iterator().next();
         double minDistanceSeen = Integer.MAX_VALUE;
-        for (NamedColor namedColor : namedColors) {
-            double distance = calculateColorDistSq(Color.color(r / 255.0, g / 255.0, b / 255.0),
-                    namedColor.getColor());
+        for (Map.Entry<RGB, String> namedColor : namedColors.entrySet()) {
+            double distance = calculateColorDistSq(Color.color(
+                    r / 255.0, g / 255.0, b / 255.0), namedColor.getKey().getColor());
             if (distance < minDistanceSeen) {
                 minDistanceSeen = distance;
-                closestMatch = namedColor;
+                closestEntry = namedColor;
             }
         }
 
-        return closestMatch.name;
+        return closestEntry.getValue();
     }
 
     /**
      * Get the color name of the color that is closest to the given hex color
-     * (as an int).
+     * value (as a 6-digit hex String).
      *
-     * @param hexColor the color as an int from 0x000000 - 0xFFFFFF
-     * @return the name of the color that is closest to the given hex color
+     * @param hexString the String containing 6 hex-digits representing a
+     * color value ("000000" to "FFFFFF")
+     * @return the name of the color that is the closest to the given hex
+     * String color value
      */
-    public static String getColorNameFromHex(int hexColor) {
+    public static String getClosestNamedColor(String hexString) {
+        int hexColor = Integer.parseInt(hexString, 16);
         int r = (hexColor & 0xFF0000) >> 16;
         int g = (hexColor & 0xFF00) >> 8;
         int b = (hexColor & 0xFF);
-        return getColorNameFromRgb(r, g, b);
+        return getClosestNamedColor(r, g, b);
+    }
+
+    /**
+     * Get the named color that has exactly the given RGB color value or
+     * {@literal null} if no such named color exists.
+     *
+     * @param r the red component of the color (0 - 255)
+     * @param g the green component of the color (0 - 255)
+     * @param b the blue component of the color (0 - 255)
+     * @return an Optional<String> that either contains the name of the color
+     * with the exact same color value or nothing if no such named color exists
+     */
+    public static Optional<String> getNamedColor(int r, int g, int b) {
+        return Optional.ofNullable(namedColors.get(new RGB(r, g, b)));
+    }
+
+    /**
+     * Get the color name of the color that is exactly equal to the given hex color
+     * value (as a 6-digit hex String).
+     *
+     * @param hexString the String containing 6 hex-digits representing a
+     * color value ("000000" to "FFFFFF")
+     * @return an Optional<String> that either contains the name of the color
+     * with the exact same color value or nothing if no such named color exists
+     */
+    public static Optional<String> getNamedColor(String hexString) {
+        int hexColor = Integer.parseInt(hexString, 16);
+        int r = (hexColor & 0xFF0000) >> 16;
+        int g = (hexColor & 0xFF00) >> 8;
+        int b = (hexColor & 0xFF);
+        return getNamedColor(r, g, b);
     }
 
     /**
@@ -223,40 +261,44 @@ public class ColorUtils
         return (diffRed * diffRed) + (diffGreen * diffGreen) + (diffBlue * diffBlue);
     }
 
-    /**
-     * Get the color name of the color that is closest to the given hex color
-     * (as a 6-digit hex String).
-     *
-     * @param hexString the String containing 6 hex-digits representing a
-     * color ("000000" to "FFFFFF")
-     * @return the name of the color that is the closest to the given hex
-     * String color.
-     */
-    public static String getColorNameFromHex(String hexString) {
-        int hexColor = Integer.parseInt(hexString, 16);
-        int r = (hexColor & 0xFF0000) >> 16;
-        int g = (hexColor & 0xFF00) >> 8;
-        int b = (hexColor & 0xFF);
-        return getColorNameFromRgb(r, g, b);
-    }
-
-    private static class NamedColor
-    {
+    private static class RGB {
         private final int r;
         private final int g;
         private final int b;
-        private final String name;
 
-        private NamedColor(String name, int r, int g, int b) {
+        private RGB(int r, int g, int b) {
             this.r = r;
             this.g = g;
             this.b = b;
-            this.name = name;
         }
 
-        public Color getColor()
-        {
+        public Color getColor() {
             return Color.color(r / 255.0, g / 255.0, b / 255.0);
+        }
+
+        @Override
+        public boolean equals(Object object)
+        {
+            if (object == this)
+            {
+                return true;
+            }
+
+            if (object == null || object.getClass() != getClass())
+            {
+                return false;
+            }
+
+            RGB other = (RGB) object;
+
+            return r == other.r && g == other.g && b == other.b;
+        }
+
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(r, g, b);
         }
     }
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.util;
+
+import java.util.ArrayList;
+
+import javafx.scene.paint.Color;
+
+/**
+ * Provides utilities for working with JavaFX Colors.
+ *
+ * @see <a href="https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#typecolor">Named Colors</a>
+ */
+public class ColorUtils
+{
+    private static ArrayList<NamedColor> namedColors = new ArrayList<>();
+    static {
+        namedColors.add(new NamedColor("AliceBlue", 0xF0, 0xF8, 0xFF));
+        namedColors.add(new NamedColor("AntiqueWhite", 0xFA, 0xEB, 0xD7));
+        namedColors.add(new NamedColor("Aqua", 0x00, 0xFF, 0xFF));
+        namedColors.add(new NamedColor("Aquamarine", 0x7F, 0xFF, 0xD4));
+        namedColors.add(new NamedColor("Azure", 0xF0, 0xFF, 0xFF));
+        namedColors.add(new NamedColor("Beige", 0xF5, 0xF5, 0xDC));
+        namedColors.add(new NamedColor("Bisque", 0xFF, 0xE4, 0xC4));
+        namedColors.add(new NamedColor("Black", 0x00, 0x00, 0x00));
+        namedColors.add(new NamedColor("BlanchedAlmond", 0xFF, 0xEB, 0xCD));
+        namedColors.add(new NamedColor("Blue", 0x00, 0x00, 0xFF));
+        namedColors.add(new NamedColor("BlueViolet", 0x8A, 0x2B, 0xE2));
+        namedColors.add(new NamedColor("Brown", 0xA5, 0x2A, 0x2A));
+        namedColors.add(new NamedColor("BurlyWood", 0xDE, 0xB8, 0x87));
+        namedColors.add(new NamedColor("CadetBlue", 0x5F, 0x9E, 0xA0));
+        namedColors.add(new NamedColor("Chartreuse", 0x7F, 0xFF, 0x00));
+        namedColors.add(new NamedColor("Chocolate", 0xD2, 0x69, 0x1E));
+        namedColors.add(new NamedColor("Coral", 0xFF, 0x7F, 0x50));
+        namedColors.add(new NamedColor("CornflowerBlue", 0x64, 0x95, 0xED));
+        namedColors.add(new NamedColor("Cornsilk", 0xFF, 0xF8, 0xDC));
+        namedColors.add(new NamedColor("Crimson", 0xDC, 0x14, 0x3C));
+        namedColors.add(new NamedColor("Cyan", 0x00, 0xFF, 0xFF));
+        namedColors.add(new NamedColor("DarkBlue", 0x00, 0x00, 0x8B));
+        namedColors.add(new NamedColor("DarkCyan", 0x00, 0x8B, 0x8B));
+        namedColors.add(new NamedColor("DarkGoldenRod", 0xB8, 0x86, 0x0B));
+        namedColors.add(new NamedColor("DarkGray", 0xA9, 0xA9, 0xA9));
+        namedColors.add(new NamedColor("DarkGreen", 0x00, 0x64, 0x00));
+        namedColors.add(new NamedColor("DarkKhaki", 0xBD, 0xB7, 0x6B));
+        namedColors.add(new NamedColor("DarkMagenta", 0x8B, 0x00, 0x8B));
+        namedColors.add(new NamedColor("DarkOliveGreen", 0x55, 0x6B, 0x2F));
+        namedColors.add(new NamedColor("DarkOrange", 0xFF, 0x8C, 0x00));
+        namedColors.add(new NamedColor("DarkOrchid", 0x99, 0x32, 0xCC));
+        namedColors.add(new NamedColor("DarkRed", 0x8B, 0x00, 0x00));
+        namedColors.add(new NamedColor("DarkSalmon", 0xE9, 0x96, 0x7A));
+        namedColors.add(new NamedColor("DarkSeaGreen", 0x8F, 0xBC, 0x8F));
+        namedColors.add(new NamedColor("DarkSlateBlue", 0x48, 0x3D, 0x8B));
+        namedColors.add(new NamedColor("DarkSlateGray", 0x2F, 0x4F, 0x4F));
+        namedColors.add(new NamedColor("DarkTurquoise", 0x00, 0xCE, 0xD1));
+        namedColors.add(new NamedColor("DarkViolet", 0x94, 0x00, 0xD3));
+        namedColors.add(new NamedColor("DeepPink", 0xFF, 0x14, 0x93));
+        namedColors.add(new NamedColor("DeepSkyBlue", 0x00, 0xBF, 0xFF));
+        namedColors.add(new NamedColor("DimGray", 0x69, 0x69, 0x69));
+        namedColors.add(new NamedColor("DodgerBlue", 0x1E, 0x90, 0xFF));
+        namedColors.add(new NamedColor("FireBrick", 0xB2, 0x22, 0x22));
+        namedColors.add(new NamedColor("FloralWhite", 0xFF, 0xFA, 0xF0));
+        namedColors.add(new NamedColor("ForestGreen", 0x22, 0x8B, 0x22));
+        namedColors.add(new NamedColor("Fuchsia", 0xFF, 0x00, 0xFF));
+        namedColors.add(new NamedColor("Gainsboro", 0xDC, 0xDC, 0xDC));
+        namedColors.add(new NamedColor("GhostWhite", 0xF8, 0xF8, 0xFF));
+        namedColors.add(new NamedColor("Gold", 0xFF, 0xD7, 0x00));
+        namedColors.add(new NamedColor("GoldenRod", 0xDA, 0xA5, 0x20));
+        namedColors.add(new NamedColor("Gray", 0x80, 0x80, 0x80));
+        namedColors.add(new NamedColor("Green", 0x00, 0x80, 0x00));
+        namedColors.add(new NamedColor("GreenYellow", 0xAD, 0xFF, 0x2F));
+        namedColors.add(new NamedColor("HoneyDew", 0xF0, 0xFF, 0xF0));
+        namedColors.add(new NamedColor("HotPink", 0xFF, 0x69, 0xB4));
+        namedColors.add(new NamedColor("IndianRed", 0xCD, 0x5C, 0x5C));
+        namedColors.add(new NamedColor("Indigo", 0x4B, 0x00, 0x82));
+        namedColors.add(new NamedColor("Ivory", 0xFF, 0xFF, 0xF0));
+        namedColors.add(new NamedColor("Khaki", 0xF0, 0xE6, 0x8C));
+        namedColors.add(new NamedColor("Lavender", 0xE6, 0xE6, 0xFA));
+        namedColors.add(new NamedColor("LavenderBlush", 0xFF, 0xF0, 0xF5));
+        namedColors.add(new NamedColor("LawnGreen", 0x7C, 0xFC, 0x00));
+        namedColors.add(new NamedColor("LemonChiffon", 0xFF, 0xFA, 0xCD));
+        namedColors.add(new NamedColor("LightBlue", 0xAD, 0xD8, 0xE6));
+        namedColors.add(new NamedColor("LightCoral", 0xF0, 0x80, 0x80));
+        namedColors.add(new NamedColor("LightCyan", 0xE0, 0xFF, 0xFF));
+        namedColors.add(new NamedColor("LightGoldenRodYellow", 0xFA, 0xFA, 0xD2));
+        namedColors.add(new NamedColor("LightGray", 0xD3, 0xD3, 0xD3));
+        namedColors.add(new NamedColor("LightGreen", 0x90, 0xEE, 0x90));
+        namedColors.add(new NamedColor("LightPink", 0xFF, 0xB6, 0xC1));
+        namedColors.add(new NamedColor("LightSalmon", 0xFF, 0xA0, 0x7A));
+        namedColors.add(new NamedColor("LightSeaGreen", 0x20, 0xB2, 0xAA));
+        namedColors.add(new NamedColor("LightSkyBlue", 0x87, 0xCE, 0xFA));
+        namedColors.add(new NamedColor("LightSlateGray", 0x77, 0x88, 0x99));
+        namedColors.add(new NamedColor("LightSteelBlue", 0xB0, 0xC4, 0xDE));
+        namedColors.add(new NamedColor("LightYellow", 0xFF, 0xFF, 0xE0));
+        namedColors.add(new NamedColor("Lime", 0x00, 0xFF, 0x00));
+        namedColors.add(new NamedColor("LimeGreen", 0x32, 0xCD, 0x32));
+        namedColors.add(new NamedColor("Linen", 0xFA, 0xF0, 0xE6));
+        namedColors.add(new NamedColor("Magenta", 0xFF, 0x00, 0xFF));
+        namedColors.add(new NamedColor("Maroon", 0x80, 0x00, 0x00));
+        namedColors.add(new NamedColor("MediumAquaMarine", 0x66, 0xCD, 0xAA));
+        namedColors.add(new NamedColor("MediumBlue", 0x00, 0x00, 0xCD));
+        namedColors.add(new NamedColor("MediumOrchid", 0xBA, 0x55, 0xD3));
+        namedColors.add(new NamedColor("MediumPurple", 0x93, 0x70, 0xDB));
+        namedColors.add(new NamedColor("MediumSeaGreen", 0x3C, 0xB3, 0x71));
+        namedColors.add(new NamedColor("MediumSlateBlue", 0x7B, 0x68, 0xEE));
+        namedColors.add(new NamedColor("MediumSpringGreen", 0x00, 0xFA, 0x9A));
+        namedColors.add(new NamedColor("MediumTurquoise", 0x48, 0xD1, 0xCC));
+        namedColors.add(new NamedColor("MediumVioletRed", 0xC7, 0x15, 0x85));
+        namedColors.add(new NamedColor("MidnightBlue", 0x19, 0x19, 0x70));
+        namedColors.add(new NamedColor("MintCream", 0xF5, 0xFF, 0xFA));
+        namedColors.add(new NamedColor("MistyRose", 0xFF, 0xE4, 0xE1));
+        namedColors.add(new NamedColor("Moccasin", 0xFF, 0xE4, 0xB5));
+        namedColors.add(new NamedColor("NavajoWhite", 0xFF, 0xDE, 0xAD));
+        namedColors.add(new NamedColor("Navy", 0x00, 0x00, 0x80));
+        namedColors.add(new NamedColor("OldLace", 0xFD, 0xF5, 0xE6));
+        namedColors.add(new NamedColor("Olive", 0x80, 0x80, 0x00));
+        namedColors.add(new NamedColor("OliveDrab", 0x6B, 0x8E, 0x23));
+        namedColors.add(new NamedColor("Orange", 0xFF, 0xA5, 0x00));
+        namedColors.add(new NamedColor("OrangeRed", 0xFF, 0x45, 0x00));
+        namedColors.add(new NamedColor("Orchid", 0xDA, 0x70, 0xD6));
+        namedColors.add(new NamedColor("PaleGoldenRod", 0xEE, 0xE8, 0xAA));
+        namedColors.add(new NamedColor("PaleGreen", 0x98, 0xFB, 0x98));
+        namedColors.add(new NamedColor("PaleTurquoise", 0xAF, 0xEE, 0xEE));
+        namedColors.add(new NamedColor("PaleVioletRed", 0xDB, 0x70, 0x93));
+        namedColors.add(new NamedColor("PapayaWhip", 0xFF, 0xEF, 0xD5));
+        namedColors.add(new NamedColor("PeachPuff", 0xFF, 0xDA, 0xB9));
+        namedColors.add(new NamedColor("Peru", 0xCD, 0x85, 0x3F));
+        namedColors.add(new NamedColor("Pink", 0xFF, 0xC0, 0xCB));
+        namedColors.add(new NamedColor("Plum", 0xDD, 0xA0, 0xDD));
+        namedColors.add(new NamedColor("PowderBlue", 0xB0, 0xE0, 0xE6));
+        namedColors.add(new NamedColor("Purple", 0x80, 0x00, 0x80));
+        namedColors.add(new NamedColor("Red", 0xFF, 0x00, 0x00));
+        namedColors.add(new NamedColor("RosyBrown", 0xBC, 0x8F, 0x8F));
+        namedColors.add(new NamedColor("RoyalBlue", 0x41, 0x69, 0xE1));
+        namedColors.add(new NamedColor("SaddleBrown", 0x8B, 0x45, 0x13));
+        namedColors.add(new NamedColor("Salmon", 0xFA, 0x80, 0x72));
+        namedColors.add(new NamedColor("SandyBrown", 0xF4, 0xA4, 0x60));
+        namedColors.add(new NamedColor("SeaGreen", 0x2E, 0x8B, 0x57));
+        namedColors.add(new NamedColor("SeaShell", 0xFF, 0xF5, 0xEE));
+        namedColors.add(new NamedColor("Sienna", 0xA0, 0x52, 0x2D));
+        namedColors.add(new NamedColor("Silver", 0xC0, 0xC0, 0xC0));
+        namedColors.add(new NamedColor("SkyBlue", 0x87, 0xCE, 0xEB));
+        namedColors.add(new NamedColor("SlateBlue", 0x6A, 0x5A, 0xCD));
+        namedColors.add(new NamedColor("SlateGray", 0x70, 0x80, 0x90));
+        namedColors.add(new NamedColor("Snow", 0xFF, 0xFA, 0xFA));
+        namedColors.add(new NamedColor("SpringGreen", 0x00, 0xFF, 0x7F));
+        namedColors.add(new NamedColor("SteelBlue", 0x46, 0x82, 0xB4));
+        namedColors.add(new NamedColor("Tan", 0xD2, 0xB4, 0x8C));
+        namedColors.add(new NamedColor("Teal", 0x00, 0x80, 0x80));
+        namedColors.add(new NamedColor("Thistle", 0xD8, 0xBF, 0xD8));
+        namedColors.add(new NamedColor("Tomato", 0xFF, 0x63, 0x47));
+        namedColors.add(new NamedColor("Turquoise", 0x40, 0xE0, 0xD0));
+        namedColors.add(new NamedColor("Violet", 0xEE, 0x82, 0xEE));
+        namedColors.add(new NamedColor("Wheat", 0xF5, 0xDE, 0xB3));
+        namedColors.add(new NamedColor("White", 0xFF, 0xFF, 0xFF));
+        namedColors.add(new NamedColor("WhiteSmoke", 0xF5, 0xF5, 0xF5));
+        namedColors.add(new NamedColor("Yellow", 0xFF, 0xFF, 0x00));
+        namedColors.add(new NamedColor("YellowGreen", 0x9A, 0xCD, 0x32));
+    }
+
+    /**
+     * Get the color name that is closest to the given RGB color.
+     *
+     * @param r the red component of the color (0 - 255)
+     * @param g the green component of the color (0 - 255)
+     * @param b the blue component of the color (0 - 255)
+     * @return the name of the color that is the closest to the given RGB color
+     */
+    private static String getColorNameFromRgb(int r, int g, int b) {
+        NamedColor closestMatch = namedColors.get(0);
+        double minDistanceSeen = Integer.MAX_VALUE;
+        for (NamedColor namedColor : namedColors) {
+            double distance = calculateColorDistSq(Color.color(r / 255.0, g / 255.0, b / 255.0),
+                    namedColor.getColor());
+            if (distance < minDistanceSeen) {
+                minDistanceSeen = distance;
+                closestMatch = namedColor;
+            }
+        }
+
+        return closestMatch.name;
+    }
+
+    /**
+     * Get the color name of the color that is closest to the given hex color
+     * (as an int).
+     *
+     * @param hexColor the color as an int from 0x000000 - 0xFFFFFF
+     * @return the name of the color that is closest to the given hex color
+     */
+    public static String getColorNameFromHex(int hexColor) {
+        int r = (hexColor & 0xFF0000) >> 16;
+        int g = (hexColor & 0xFF00) >> 8;
+        int b = (hexColor & 0xFF);
+        return getColorNameFromRgb(r, g, b);
+    }
+
+    /**
+     * Calculates the distance between two Colors.
+     *
+     * @param color0 the first color
+     * @param color1 the second color
+     * @return the distance between the two colors
+     */
+    public static double calculateColorDistSq(Color color0,
+                                              Color color1) {
+        double diffRed = color0.getRed() - color1.getRed();
+        double diffGreen = color0.getGreen() - color1.getGreen();
+        double diffBlue = color0.getBlue() - color1.getBlue();
+        return (diffRed * diffRed) + (diffGreen * diffGreen) + (diffBlue * diffBlue);
+    }
+
+    /**
+     * Get the color name of the color that is closest to the given hex color
+     * (as a 6-digit hex String).
+     *
+     * @param hexString the String containing 6 hex-digits representing a
+     * color ("000000" to "FFFFFF")
+     * @return the name of the color that is the closest to the given hex
+     * String color.
+     */
+    public static String getColorNameFromHex(String hexString) {
+        int hexColor = Integer.parseInt(hexString, 16);
+        int r = (hexColor & 0xFF0000) >> 16;
+        int g = (hexColor & 0xFF00) >> 8;
+        int b = (hexColor & 0xFF);
+        return getColorNameFromRgb(r, g, b);
+    }
+
+    private static class NamedColor
+    {
+        private final int r;
+        private final int g;
+        private final int b;
+        private final String name;
+
+        private NamedColor(String name, int r, int g, int b) {
+            this.r = r;
+            this.g = g;
+            this.b = b;
+            this.name = name;
+        }
+
+        public Color getColor()
+        {
+            return Color.color(r / 255.0, g / 255.0, b / 255.0);
+        }
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
@@ -39,9 +39,8 @@ public class TextFlowMatchersTest extends FxRobot
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    public Text foobarText;
-    public Text quuxText;
     public TextFlow textFlow;
+    public TextFlow exactTextFlow;
 
     //---------------------------------------------------------------------------------------------
     // FIXTURE METHODS.
@@ -55,10 +54,15 @@ public class TextFlowMatchersTest extends FxRobot
     @Before
     public void setup() throws Exception {
         FxToolkit.setupFixture(() -> {
-            foobarText = new Text("foobar ");
-            quuxText = new Text("quux");
+            Text foobarText = new Text("foobar ");
+            Text quuxText = new Text("quux");
             quuxText.setFill(Color.RED);
             textFlow = new TextFlow(foobarText, quuxText);
+
+            Text exactText = new Text("exact");
+            // set the fill to the closest color to, but not exactly, LimeGreen (50, 205, 50)
+            exactText.setFill(Color.rgb(51, 205, 50));
+            exactTextFlow = new TextFlow(exactText);
         });
     }
 
@@ -87,11 +91,23 @@ public class TextFlowMatchersTest extends FxRobot
     }
 
     @Test
-    public void hasColorText_fails() {
+    public void hasColoredText_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: TextFlow has colored text \"foobar <BLUE>quux</BLUE>\"\n");
+        exception.expectMessage("Expected: TextFlow has colored text " +
+                "\"foobar <BLUE>quux</BLUE>\"\n");
 
         assertThat(textFlow, TextFlowMatchers.hasColoredText("foobar <BLUE>quux</BLUE>"));
     }
+
+    @Test
+    public void hasExactlyColoredText_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TextFlow has exactly colored " +
+                "text \"<LIMEGREEN>exact</LIMEGREEN>\"\n");
+
+        assertThat(exactTextFlow, TextFlowMatchers.hasExactlyColoredText("<LIMEGREEN>exact</LIMEGREEN>"));
+    }
+
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.matcher.control;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import javafx.scene.paint.Color;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+public class TextFlowMatchersTest extends FxRobot
+{
+    //---------------------------------------------------------------------------------------------
+    // FIELDS.
+    //---------------------------------------------------------------------------------------------
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    public Text foobarText;
+    public Text quuxText;
+    public TextFlow textFlow;
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            foobarText = new Text("foobar ");
+            quuxText = new Text("quux");
+            quuxText.setFill(Color.RED);
+            textFlow = new TextFlow(foobarText, quuxText);
+        });
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Test
+    public void hasText() {
+        // expect:
+        assertThat(textFlow, TextFlowMatchers.hasText("foobar quux"));
+    }
+
+    @Test
+    public void hasText_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TextFlow has text \"foobar baaz\"\n");
+
+        assertThat(textFlow, TextFlowMatchers.hasText("foobar baaz"));
+    }
+
+    @Test
+    public void hasColoredText() {
+        assertThat(textFlow, TextFlowMatchers.hasColoredText("foobar <RED>quux</RED>"));
+    }
+
+    @Test
+    public void hasColorText_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TextFlow has colored text \"foobar <BLUE>quux</BLUE>\"\n");
+
+        assertThat(textFlow, TextFlowMatchers.hasColoredText("foobar <BLUE>quux</BLUE>"));
+    }
+}


### PR DESCRIPTION
Currently there are two ways to match the text contained in a TextFlow.
The first one is based simply off the contained text. The second is
based on the contained text *and* the color of that text. The expected
colors are encoded in the expected String like:

`<COLOR>some text</COLOR>`

where COLOR is one of the named colors in JavaFX. For a list of all such
colors, see:

https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#typecolor

We also extracted out a method for computing the distance between two
colors from PixelMatcherRgb as that functionality was also needed for
finding the color nearest to a named color.

---------------------------------------------------------

I am open to suggestions on a better way to test for colored text in a text flow as I just thought of the simplest thing I could. I could see the TextFlowMatchers being very useful for testing things that mimic
text editor functionality or also in cases where color-coded text helps the user understand the text (for example, using red for negative monetary balances and green for positive monetary balances) and provide better UX.

Let me know what you think!