### PR TITLE
(feat) `ColorMatchers`: Add `hasColor()`.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
@@ -21,8 +21,9 @@ import javafx.scene.paint.Color;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
+import org.testfx.service.support.ColorMatcher;
+
 import static org.testfx.matcher.base.GeneralMatchers.typeSafeMatcher;
-import org.testfx.service.support.PixelMatcher;
 
 public class ColorMatchers {
 
@@ -32,34 +33,34 @@ public class ColorMatchers {
 
     @Factory
     @Unstable(reason = "is missing apidocs")
-    public static Matcher<Color> hasColor(Color color) {
+    public static Matcher<Color> isColor(Color color) {
         String descriptionText = "has color (" + color.toString() + ")";
         return typeSafeMatcher(Color.class, descriptionText,
-                actualColor -> hasColor(actualColor, color));
+                actualColor -> isColor(actualColor, color));
     }
 
     @Factory
     @Unstable(reason = "is missing apidocs")
-    public static Matcher<Color> hasColor(Color color,
-                                          PixelMatcher pixelMatcher) {
+    public static Matcher<Color> isColor(Color color,
+                                         ColorMatcher colorMatcher) {
         String descriptionText = "has color (" + color.toString() + ")";
         return typeSafeMatcher(Color.class, descriptionText,
-                actualColor -> hasColor(actualColor, color, pixelMatcher));
+                actualColor -> isColor(actualColor, color, colorMatcher));
     }
 
     //---------------------------------------------------------------------------------------------
     // PRIVATE STATIC METHODS.
     //---------------------------------------------------------------------------------------------
 
-    private static boolean hasColor(Color actualColor,
-                                    Color color) {
+    private static boolean isColor(Color actualColor,
+                                   Color color) {
         return actualColor.equals(color);
     }
 
-    private static boolean hasColor(Color actualColor,
-                                    Color color,
-                                    PixelMatcher pixelMatcher) {
-        return pixelMatcher.matchColors(actualColor, color);
+    private static boolean isColor(Color actualColor,
+                                   Color color,
+                                   ColorMatcher colorMatcher) {
+        return colorMatcher.matchColors(actualColor, color);
     }
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
@@ -22,6 +22,7 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
 import static org.testfx.matcher.base.GeneralMatchers.typeSafeMatcher;
+import org.testfx.service.support.PixelMatcher;
 
 public class ColorMatchers {
 
@@ -37,6 +38,15 @@ public class ColorMatchers {
                 actualColor -> hasColor(actualColor, color));
     }
 
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Color> hasColor(Color color,
+                                          PixelMatcher pixelMatcher) {
+        String descriptionText = "has color (" + color.toString() + ")";
+        return typeSafeMatcher(Color.class, descriptionText,
+                actualColor -> hasColor(actualColor, color, pixelMatcher));
+    }
+
     //---------------------------------------------------------------------------------------------
     // PRIVATE STATIC METHODS.
     //---------------------------------------------------------------------------------------------
@@ -44,6 +54,12 @@ public class ColorMatchers {
     private static boolean hasColor(Color actualColor,
                                     Color color) {
         return actualColor.equals(color);
+    }
+
+    private static boolean hasColor(Color actualColor,
+                                    Color color,
+                                    PixelMatcher pixelMatcher) {
+        return pixelMatcher.matchColors(actualColor, color);
     }
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.matcher.base;
+
+import javafx.scene.paint.Color;
+
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.testfx.api.annotation.Unstable;
+import static org.testfx.matcher.base.GeneralMatchers.typeSafeMatcher;
+
+public class ColorMatchers {
+
+    //---------------------------------------------------------------------------------------------
+    // STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Color> hasColor(Color color) {
+        String descriptionText = "has color (" + color.toString() + ")";
+        return typeSafeMatcher(Color.class, descriptionText,
+                actualColor -> hasColor(actualColor, color));
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // PRIVATE STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    private static boolean hasColor(Color actualColor,
+                                    Color color) {
+        return actualColor.equals(color);
+    }
+
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/ColorMatcher.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/ColorMatcher.java
@@ -16,22 +16,11 @@
  */
 package org.testfx.service.support;
 
-import javafx.scene.image.Image;
-import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
 
-public interface PixelMatcher extends ColorMatcher {
+public interface ColorMatcher {
 
-    PixelMatcherResult match(Image image0,
-                             Image image1);
-
-    WritableImage createEmptyMatchImage(Image image0,
-                                        Image image1);
-
-    Color createMatchColor(Color color0,
-                           Color color1);
-
-    Color createNonMatchColor(Color color0,
-                              Color color1);
+    boolean matchColors(Color color0,
+                        Color color1);
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
@@ -55,7 +55,8 @@ public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
     //---------------------------------------------------------------------------------------------
 
     @Override
-    public boolean matchColors(Color color0, Color color1) {
+    public boolean matchColors(Color color0,
+                               Color color1) {
         if (minColorDistSq == Double.MIN_VALUE) {
             double maxColorDistSq = ColorUtils.calculateColorDistSq(Color.BLACK, Color.WHITE);
             minColorDistSq = maxColorDistSq * (minColorDistFactor * minColorDistFactor);
@@ -72,7 +73,8 @@ public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
     }
 
     @Override
-    public Color createMatchColor(Color color0, Color color1) {
+    public Color createMatchColor(Color color0,
+                                  Color color1) {
         double gray = color0.grayscale().getRed();
         double opacity = color0.getOpacity();
         return Color.gray(blendToWhite(gray, colorBlendFactor), opacity);
@@ -80,7 +82,8 @@ public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
     }
 
     @Override
-    public Color createNonMatchColor(Color color0, Color color1) {
+    public Color createNonMatchColor(Color color0,
+                                     Color color1) {
         return Color.RED;
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
@@ -39,32 +39,32 @@ public class ColorMatchersTest extends FxRobot {
     //---------------------------------------------------------------------------------------------
 
     @Test
-    public void hasColor() {
+    public void isColor() {
         // expect:
-        assertThat(Color.color(1, 0, 0), ColorMatchers.hasColor(Color.RED));
+        assertThat(Color.color(1, 0, 0), ColorMatchers.isColor(Color.RED));
     }
 
     @Test
-    public void hasColor_fails() {
+    public void isColor_fails() {
         // expect:
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: Color has color (0x000000ff)\n");
 
-        assertThat(Color.color(1, 0, 0), ColorMatchers.hasColor(Color.BLACK));
+        assertThat(Color.color(1, 0, 0), ColorMatchers.isColor(Color.BLACK));
     }
 
     @Test
-    public void hasColor_pixelMatcher() {
+    public void isColor_colorMatcher() {
         // expect:
         assertThat(Color.color(0.9, 0, 0),
-                ColorMatchers.hasColor(Color.RED, new PixelMatcherRgb()));
+                ColorMatchers.isColor(Color.RED, new PixelMatcherRgb()));
     }
 
     @Test
-    public void hasColor_pixelMatcher_fails() {
+    public void isColor_colorMatcher_fails() {
         // expect:
         assertThat(Color.color(0.5, 0, 0),
-                ColorMatchers.hasColor(Color.RED, new PixelMatcherRgb(0.5, 0)));
+                ColorMatchers.isColor(Color.RED, new PixelMatcherRgb(0.5, 0)));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
@@ -21,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.testfx.api.FxRobot;
+import org.testfx.service.support.impl.PixelMatcherRgb;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -50,6 +51,20 @@ public class ColorMatchersTest extends FxRobot {
         exception.expectMessage("Expected: Color has color (0x000000ff)\n");
 
         assertThat(Color.color(1, 0, 0), ColorMatchers.hasColor(Color.BLACK));
+    }
+
+    @Test
+    public void hasColor_pixelMatcher() {
+        // expect:
+        assertThat(Color.color(0.9, 0, 0),
+                ColorMatchers.hasColor(Color.RED, new PixelMatcherRgb()));
+    }
+
+    @Test
+    public void hasColor_pixelMatcher_fails() {
+        // expect:
+        assertThat(Color.color(0.5, 0, 0),
+                ColorMatchers.hasColor(Color.RED, new PixelMatcherRgb(0.5, 0)));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.matcher.base;
+
+import javafx.scene.paint.Color;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.testfx.api.FxRobot;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ColorMatchersTest extends FxRobot {
+
+    //---------------------------------------------------------------------------------------------
+    // FIELDS.
+    //---------------------------------------------------------------------------------------------
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Test
+    public void hasColor() {
+        // expect:
+        assertThat(Color.color(1, 0, 0), ColorMatchers.hasColor(Color.RED));
+    }
+
+    @Test
+    public void hasColor_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: Color has color (0x000000ff)\n");
+
+        assertThat(Color.color(1, 0, 0), ColorMatchers.hasColor(Color.BLACK));
+    }
+
+}


### PR DESCRIPTION
## Problem

We need basic `Matcher`s for `Color`s as a foundation for the matchers for colors in `TextFlow` controls introduced in #259.
## Solution

Implement `ColorMatchers`:
- `Matcher<Color> hasColor(Color color)`
- `Matcher<Color> hasColor(Color color, PixelMatcher pixelMatcher)`
## Testing

Check matchers for successful states, assertion errors and type errors (`TypeSafeMatcher`).
