### PR TITLE
Added moveTo(Node,offset)

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -1113,47 +1113,6 @@ public class FxRobot implements FxRobotInterface {
         return this;
     }
 
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public FxRobot moveTo(double x,
-                          double y) {
-        return moveTo(point(new Point2D(x, y)));
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public FxRobot moveTo(Point2D point) {
-        return moveTo(point(point));
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public FxRobot moveTo(Bounds bounds) {
-        return moveTo(point(bounds));
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public FxRobot moveTo(Node node) {
-        return moveTo(point(node));
-    }
-    @Override
-    @Unstable(reason = "not tested yet")
-    public FxRobot moveTo(Node node, Point2D offset) {
-        return moveTo(point(node,Pos.TOP_LEFT).atOffset(offset));
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public FxRobot moveTo(Scene scene) {
-        return moveTo(point(scene));
-    }
-
-    @Override
-    @Unstable(reason = "is missing apidocs")
-    public FxRobot moveTo(Window window) {
-        return moveTo(point(window));
-    }
 
     @Override
     @Unstable(reason = "is missing apidocs")

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -354,10 +354,15 @@ public class FxRobot implements FxRobotInterface {
     @Override
     @Unstable(reason = "is missing apidocs")
     public PointQuery point(Node node) {
+        return point(node,context.getPointPosition());
+    }
+
+    @Override
+    @Unstable(reason = "is missing tests")
+    public PointQuery point(Node node, Pos pos) {
         PointLocator pointLocator = context.getPointLocator();
-        Pos pointPosition = context.getPointPosition();
         targetWindow(node.getScene().getWindow());
-        return pointLocator.point(node).atPosition(pointPosition);
+        return pointLocator.point(node).atPosition(pos);
     }
 
     @Override
@@ -1135,7 +1140,7 @@ public class FxRobot implements FxRobotInterface {
     @Override
     @Unstable(reason = "not tested yet")
     public FxRobot moveTo(Node node, Point2D offset) {
-        return moveTo(point(node).atOffset(offset));
+        return moveTo(point(node,Pos.TOP_LEFT).atOffset(offset));
     }
 
     @Override

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -1132,6 +1132,11 @@ public class FxRobot implements FxRobotInterface {
     public FxRobot moveTo(Node node) {
         return moveTo(point(node));
     }
+    @Override
+    @Unstable(reason = "not tested yet")
+    public FxRobot moveTo(Node node, Point2D offset) {
+        return moveTo(point(node).atOffset(offset));
+    }
 
     @Override
     @Unstable(reason = "is missing apidocs")

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -129,7 +129,19 @@ public interface FxRobotInterface {
                             double y);
     public PointQuery point(Point2D point);
     public PointQuery point(Bounds bounds);
+    /**
+     * Returns the center of the node in screen coordinates.
+     * @param node the node
+     * @return the point
+     */
     public PointQuery point(Node node);
+    /**
+     * Returns a point (screen coordinates) within the node, the exact 
+     * Position within the node is defined by the given Position.
+     * @param node the node
+     * @param pos the position within the node
+     * @return the point
+     */
     public PointQuery point(Node node, Pos pos);
     public PointQuery point(Scene scene);
     public PointQuery point(Window window);

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -346,6 +346,13 @@ public interface FxRobotInterface {
     public FxRobotInterface moveTo(Point2D point);
     public FxRobotInterface moveTo(Bounds bounds);
     public FxRobotInterface moveTo(Node node);
+    /**
+     * Moves the cursor to a node with the given offset within the node.
+     * @param node the node
+     * @param offset the offset to the upper left corner of the node
+     * @return the FXRobotInterface
+     */
+    public FxRobotInterface moveTo(Node node, Point2D offset);
     public FxRobotInterface moveTo(Scene scene);
     public FxRobotInterface moveTo(Window window);
     public FxRobotInterface moveTo(String query);

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -353,26 +353,44 @@ public interface FxRobotInterface {
     public FxRobotInterface moveBy(double x,
                                    double y);
 
-    // Convenience methods:
-    public FxRobotInterface moveTo(double x,
-                                   double y);
-    public FxRobotInterface moveTo(Point2D point);
-    public FxRobotInterface moveTo(Bounds bounds);
+    // Convenience methods (default implementation as only interface methods are used):
+    @Unstable(reason = "is missing apidocs")
+    public default FxRobotInterface moveTo(double x, double y){
+        return moveTo(point(new Point2D(x, y)));
+    }
+    @Unstable(reason = "is missing apidocs")
+    public default FxRobotInterface moveTo(Point2D point){
+        return moveTo(point(point));
+    }
+    @Unstable(reason = "is missing apidocs")
+    public default FxRobotInterface moveTo(Bounds bounds){
+        return moveTo(point(bounds));
+    }
     /**
      * Moves the cursor to the center of the given node.
      * @param node the node
      * @return this robot
      */
-    public FxRobotInterface moveTo(Node node);
+    public default FxRobotInterface moveTo(Node node){
+        return moveTo(point(node));
+    }
     /**
      * Moves the cursor to a node with the given offset within the node.
      * @param node the node
      * @param offset the offset to the upper left corner of the node
      * @return the FXRobotInterface
      */
-    public FxRobotInterface moveTo(Node node, Point2D offset);
-    public FxRobotInterface moveTo(Scene scene);
-    public FxRobotInterface moveTo(Window window);
+    public default FxRobotInterface moveTo(Node node, Point2D offset){
+        return moveTo(point(node,Pos.TOP_LEFT).atOffset(offset));
+    }
+    @Unstable(reason = "is missing apidocs")
+    public default FxRobotInterface moveTo(Scene scene){
+        return moveTo(point(scene));
+    }
+    @Unstable(reason = "is missing apidocs")
+    public default FxRobotInterface moveTo(Window window){
+        return moveTo(point(window));
+    }
     public FxRobotInterface moveTo(String query);
     public <T extends Node> FxRobotInterface moveTo(Matcher<T> matcher);
     public <T extends Node> FxRobotInterface moveTo(Predicate<T> predicate);

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -349,20 +349,44 @@ public interface FxRobotInterface {
     // METHODS FOR MOVING.
     //---------------------------------------------------------------------------------------------
 
+    /**
+     * Moves the cursor to the given point query.
+     * @param pointQuery the point query
+     * @return this robot
+     */
     public FxRobotInterface moveTo(PointQuery pointQuery);
+    /**
+     * Moves the cursor from its current position by the given amount of pixels.
+     * @param x the pixels in x direction to add
+     * @param y the pixels in y direction to add
+     * @return this robot
+     */
     public FxRobotInterface moveBy(double x,
                                    double y);
 
     // Convenience methods (default implementation as only interface methods are used):
-    @Unstable(reason = "is missing apidocs")
+    /**
+     * Moves the cursor to a point in screen coordinates.
+     * @param x the x value of the point
+     * @param y the y value of the point
+     * @return this robot
+     */
     public default FxRobotInterface moveTo(double x, double y){
         return moveTo(point(new Point2D(x, y)));
     }
-    @Unstable(reason = "is missing apidocs")
+    /**
+     * Moves the cursor to a point in screen coordinates.
+     * @param point the point
+     * @return this robot
+     */
     public default FxRobotInterface moveTo(Point2D point){
         return moveTo(point(point));
     }
-    @Unstable(reason = "is missing apidocs")
+    /**
+     * Moves the cursor to the center of the given bounds.
+     * @param bounds the bounds
+     * @return this robot
+     */
     public default FxRobotInterface moveTo(Bounds bounds){
         return moveTo(point(bounds));
     }
@@ -383,11 +407,19 @@ public interface FxRobotInterface {
     public default FxRobotInterface moveTo(Node node, Point2D offset){
         return moveTo(point(node,Pos.TOP_LEFT).atOffset(offset));
     }
-    @Unstable(reason = "is missing apidocs")
+    /**
+     * Moves the cursor to the center of the given scene.
+     * @param scene the scene
+     * @return this robot
+     */
     public default FxRobotInterface moveTo(Scene scene){
         return moveTo(point(scene));
     }
-    @Unstable(reason = "is missing apidocs")
+    /**
+     * Moves the cursor to the center of the given window.
+     * @param window the window
+     * @return this robot
+     */
     public default FxRobotInterface moveTo(Window window){
         return moveTo(point(window));
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -130,6 +130,7 @@ public interface FxRobotInterface {
     public PointQuery point(Point2D point);
     public PointQuery point(Bounds bounds);
     public PointQuery point(Node node);
+    public PointQuery point(Node node, Pos pos);
     public PointQuery point(Scene scene);
     public PointQuery point(Window window);
 
@@ -345,6 +346,11 @@ public interface FxRobotInterface {
                                    double y);
     public FxRobotInterface moveTo(Point2D point);
     public FxRobotInterface moveTo(Bounds bounds);
+    /**
+     * Moves the cursor to the center of the given node.
+     * @param node the node
+     * @return this robot
+     */
     public FxRobotInterface moveTo(Node node);
     /**
      * Moves the cursor to a node with the given offset within the node.

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
@@ -58,8 +58,8 @@ public interface PointQuery {
      */
     public PointQuery atPosition(double positionX, double positionY);
     /**
-     * Sets the position to the given value. The value refers to a certain 
-     * position within the bounds of a object.
+     * Sets the position to the given Position within a area. 
+     * The value refers to a certain position within the bounds of a object (Top left, top right...).
      * @see BoundsPointQuery
      * @param position the position
      * @return the query with the position set

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
@@ -16,23 +16,75 @@
  */
 package org.testfx.service.query;
 
+import org.testfx.service.query.impl.BoundsPointQuery;
+
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
 
+/**
+ * Defines the interface queries to points on the screen must implement.
+ * It has a position and a offset to the position. Offsets to the Position can be
+ * added by the {@code atOffset} methods.<br>
+ * Point queries usually refer to screen coordinates.
+ * 
+ * @see BoundsPointQuery
+ * 
+ * @author Jan Ortner
+ *
+ */
 public interface PointQuery {
+	/**
+	 * Get the position of the point query
+	 * @return the position
+	 */
     public Point2D getPosition();
-
+    /**
+     * Gets the offset of this point query.
+     * The resulting point is calculated by adding the offset to the position.
+     * @return the offset
+     */
     public Point2D getOffset();
-
+    /**
+     * Sets the position to the given value.
+     * @param position the position
+     * @return the query with the position set
+     */
     public PointQuery atPosition(Point2D position);
-
+    /**
+     * Sets the position to the given value.
+     * @param positionX the x value of the position
+     * @param positionY the y value of the position
+     * @return the query with the position set
+     */
     public PointQuery atPosition(double positionX, double positionY);
-
+    /**
+     * Sets the position to the given value. The value refers to a certain 
+     * position within the bounds of a object.
+     * @see BoundsPointQuery
+     * @param position the position
+     * @return the query with the position set
+     */
     public PointQuery atPosition(Pos position);
 
+    /**
+     * Adds an offset to this query. The offset is added to the existing offset
+     * of this query.
+     * @param offset the offset to add
+     * @return this query with the offset set
+     */
     public PointQuery atOffset(Point2D offset);
 
+    /**
+     * Adds an offset to this query. The offset is added to the existing offset
+     * of this query.
+     * @param offsetX the x offset
+     * @param offsetY the y offset
+     * @return this query with the offset set
+     */
     public PointQuery atOffset(double offsetX, double offsetY);
-
+    /**
+     * Gets the resulting Point. The offset is added to the position.
+     * @return the point
+     */
     public Point2D query();
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
@@ -18,10 +18,18 @@ package org.testfx.service.query.impl;
 
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
+import javafx.geometry.Pos;
 
 import org.testfx.api.annotation.Unstable;
 import org.testfx.util.PointQueryUtils;
 
+/**
+ * This point query implements a PointQuery within the bounds of an object.
+ * The Position ({@link Pos}) can be set to a value within the bounds.
+ * 
+ * @author Jan Ortner
+ *
+ */
 @Unstable
 public class BoundsPointQuery extends PointQueryBase {
 
@@ -34,7 +42,10 @@ public class BoundsPointQuery extends PointQueryBase {
     //---------------------------------------------------------------------------------------------
     // CONSTRUCTORS.
     //---------------------------------------------------------------------------------------------
-
+    /**
+     * Constructor defining the bounds to position the point in.
+     * @param bounds the bounds
+     */
     public BoundsPointQuery(Bounds bounds) {
         this.bounds = bounds;
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
@@ -43,7 +43,14 @@ public final class PointQueryUtils {
                                      Pos position) {
         return atPositionFactors(bounds, computePositionFactors(position));
     }
-
+    /**
+     * Returns a point within the given bounds.
+     * The horizontal/vertical position is calculated by:<br>
+     * {@code x/y = bounds.x/y + positionFactors.x/y * bounds.width/height} 
+     * @param bounds the bounds
+     * @param positionFactors the factors
+     * @return the point within the bounds
+     */
     public static Point2D atPositionFactors(Bounds bounds,
                                             Point2D positionFactors) {
         double pointX = lerp(bounds.getMinX(), bounds.getMaxX(), positionFactors.getX());
@@ -51,6 +58,13 @@ public final class PointQueryUtils {
         return new Point2D(pointX, pointY);
     }
 
+    /**
+     * Computes the width/height factors for the point defined by the pos object.<br>
+     * The width factor is returned in the x component, the height factor in the y component of the point.
+     * E.g. {@link Pos#TOP_LEFT} has the width and height factor 0.0, {@link Pos#BOTTOM_RIGHT} 1.0.
+     * @param position the position
+     * @return the factors
+     */
     public static Point2D computePositionFactors(Pos position) {
         double positionX = computePositionX(position.getHpos());
         double positionY = computePositionY(position.getVpos());


### PR DESCRIPTION
Added a method to move to a point within a node with a given offset to the upper left corner of the node.

It's just a convenience method to prevent calls of moveTo(Node) and moveBy(Offset).

Other modifications:
- Added some Documentation (don't know whether it conforms to your JavaDoc guidelines, just dump it if not)
- Moved some methods as default implementation to the FXRobotInterface

By the way, why are the pointOfVisibleNode(...) methods private in FXRobot and not public API. I think they might be useful for users too.
