### PR TITLE
Added interactFast(...) Method to FxRobot(Interface)

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -542,6 +542,20 @@ public class FxRobot implements FxRobotInterface {
         waitForFxEvents();
         return this;
     }
+    
+    @Override
+    @Unstable(reason = "is missing tests")
+    public FxRobot interactNoWait(Runnable runnable) {
+        waitFor(asyncFx(runnable));
+        return this;
+    }
+    @Override
+    @Unstable(reason = "is missing tests")
+    public <T> FxRobot interactNoWait(Callable<T> callable) {
+        waitFor(asyncFx(callable));
+        return this;
+    }
+    
 
     @Override
     @Unstable(reason = "is missing apidocs")

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -187,8 +187,51 @@ public interface FxRobotInterface {
     // METHODS FOR INTERACTION AND INTERRUPTION.
     //---------------------------------------------------------------------------------------------
 
+    /**
+     * Calls a runnable on the FX application thread and waits for it and
+     * consecutive events to execute. So changes to the gui triggered by the
+     * runnable will be performed when returned from this method.
+     * 
+     * @param runnable
+     *            the runnable
+     * @return this robot
+     */
     public FxRobotInterface interact(Runnable runnable);
+
+    /**
+     * Calls a callable on the FX application thread and waits for it and
+     * consecutive events to execute. So changes to the gui triggered by the
+     * callable will be performed when returned from this method.
+     * 
+     * @param callable
+     *            the callable
+     * @return this robot
+     */
     public <T> FxRobotInterface interact(Callable<T> callable);
+    
+    /**
+     * Calls a runnable on the FX application thread and waits for it to
+     * execute. It does not wait for other events on the fx application thread.
+     * So changes to the gui triggered by the runnable may not be performed when
+     * returned from this method.
+     * 
+     * @param runnable
+     *            the runnable
+     * @return this robot
+     */
+    public FxRobotInterface interactNoWait(Runnable runnable);
+
+    /**
+     * Calls a callable on the FX application thread and waits for it to
+     * execute. It does not wait for other events on the fx application thread.
+     * So changes to the gui triggered by the callable may not be performed when
+     * returned from this method.
+     * 
+     * @param callable
+     *            the callable
+     * @return this robot
+     */
+    public <T> FxRobotInterface interactNoWait(Callable<T> callable);
 
     public FxRobotInterface interrupt();
     public FxRobotInterface interrupt(int attemptsCount);


### PR DESCRIPTION
The interactFast method doesn't wait for the gui pulse which makes it
much faster. It is especially useful for timing relevant tests e.g.
animations and for reading parameters of the gui thread.
