### PR TITLE
(feat) Add `ComboBoxMatchers` functionality and tests.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.matcher.control;
+
+import java.util.Arrays;
+import java.util.Objects;
+import javafx.scene.Node;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.TableView;
+
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.testfx.api.annotation.Unstable;
+
+import static org.testfx.matcher.base.GeneralMatchers.typeSafeMatcher;
+
+@Unstable(reason = "needs more tests")
+public class ComboBoxMatchers {
+
+    //---------------------------------------------------------------------------------------------
+    // STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Node> hasItems(int amount) {
+        String descriptionText = "has " + amount + " items";
+        return typeSafeMatcher(ComboBox.class, descriptionText, node -> hasItems(node, amount));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static <T> Matcher<Node> hasSelection(T selection) {
+        String descriptionText = "has selection " + selection;
+        return typeSafeMatcher(ComboBox.class, descriptionText, node -> hasSelection(node, selection));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static <T> Matcher<Node> containsItems(T... items) {
+        String descriptionText = "contains items " + Arrays.toString(items);
+        return typeSafeMatcher(ComboBox.class, descriptionText, node -> containsItems(node, items));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static <T> Matcher<Node> containsExactlyItems(T... items) {
+        String descriptionText = "contains exactly items " + Arrays.toString(items);
+        return typeSafeMatcher(ComboBox.class, descriptionText, node -> containsExactlyItems(node, items));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static <T> Matcher<Node> containsItemsInOrder(T... items) {
+        String descriptionText = "contains items in order " + Arrays.toString(items);
+        return typeSafeMatcher(ComboBox.class, descriptionText, node -> containsItemsInOrder(node, items));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static <T> Matcher<Node> containsExactlyItemsInOrder(T... items) {
+        String descriptionText = "contains exactly items in order " + Arrays.toString(items);
+        return typeSafeMatcher(ComboBox.class, descriptionText, node -> containsExactlyItemsInOrder(node, items));
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // PRIVATE STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    private static boolean hasItems(ComboBox<?> comboBox,
+                                    int amount) {
+        return comboBox.getItems().size() == amount;
+    }
+
+    private static <T> boolean hasSelection(ComboBox<?> comboBox,
+                                            T selection) {
+        return selection.equals(comboBox.getSelectionModel().getSelectedItem());
+    }
+
+    private static boolean containsItems(ComboBox<?> comboBox,
+                                         Object... items) {
+        return comboBox.getItems().containsAll(Arrays.asList(items));
+    }
+
+    private static boolean containsExactlyItems(ComboBox<?> comboBox,
+                                         Object... items) {
+        return comboBox.getItems().size() == items.length &&
+                comboBox.getItems().containsAll(Arrays.asList(items));
+    }
+
+    private static boolean containsItemsInOrder(ComboBox<?> comboBox,
+                                                Object... items) {
+        int index = 0;
+
+        // find start of matching sub-sequence
+        while (!comboBox.getItems().get(index).equals(items[0]))
+        {
+            index++;
+        }
+
+        // make sure sub-sequence matches
+        for (Object item : items) {
+            if (!comboBox.getItems().get(index).equals(item)) {
+                return false;
+            }
+            index++;
+        }
+        return true;
+    }
+
+    private static boolean containsExactlyItemsInOrder(ComboBox<?> comboBox,
+                                                       Object... items) {
+        int index = 0;
+        for (Object item : items) {
+            if (!comboBox.getItems().get(index).equals(item)) {
+                return false;
+            }
+            index++;
+        }
+        return true;
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.matcher.control;
+
+import javafx.scene.control.ComboBox;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.StackPane;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static javafx.collections.FXCollections.observableArrayList;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ComboBoxMatchersTest extends FxRobot {
+
+    //---------------------------------------------------------------------------------------------
+    // FIELDS.
+    //---------------------------------------------------------------------------------------------
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    public ComboBox<String> comboBox;
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupSceneRoot(() -> {
+            comboBox = new ComboBox<>();
+            comboBox.setItems(observableArrayList("alice", "bob", "carol", "dave"));
+            comboBox.getSelectionModel().selectFirst();
+            return new StackPane(comboBox);
+        });
+        FxToolkit.showStage();
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Test
+    public void hasItems() {
+        // expect:
+        assertThat(comboBox, ComboBoxMatchers.hasItems(4));
+    }
+
+    @Test
+    public void hasItems_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: ComboBox has 3 items\n");
+
+        assertThat(comboBox, ComboBoxMatchers.hasItems(3));
+    }
+
+    @Test
+    public void hasSelection() {
+        assertThat(comboBox, ComboBoxMatchers.hasSelection("alice"));
+
+        clickOn(".combo-box-base");
+
+        press(KeyCode.DOWN);
+        release(KeyCode.DOWN);
+
+        press(KeyCode.ENTER);
+        release(KeyCode.ENTER);
+
+        assertThat(comboBox, ComboBoxMatchers.hasSelection("bob"));
+    }
+
+    @Test
+    public void hasSelection_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: ComboBox has selection bob\n");
+
+        assertThat(comboBox, ComboBoxMatchers.hasSelection("bob"));
+    }
+
+    @Test
+    public void containsItems() {
+        // expect:
+        // in order
+        assertThat(comboBox, ComboBoxMatchers.containsItems("alice", "bob", "carol", "dave"));
+        // not in order
+        assertThat(comboBox, ComboBoxMatchers.containsItems("bob", "alice", "dave", "carol"));
+        // partial
+        assertThat(comboBox, ComboBoxMatchers.containsItems("bob", "alice", "dave"));
+    }
+
+    @Test
+    public void containsItems_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: ComboBox contains items [alice, bob, eric]\n");
+
+        assertThat(comboBox, ComboBoxMatchers.containsItems("alice", "bob", "eric"));
+    }
+
+    @Test
+    public void containsExactlyItems() {
+        // expect:
+        // in order
+        assertThat(comboBox, ComboBoxMatchers.containsExactlyItems("alice", "bob", "carol", "dave"));
+        // not in order
+        assertThat(comboBox, ComboBoxMatchers.containsExactlyItems("bob", "alice", "dave", "carol"));
+    }
+
+    @Test
+    public void containsExactlyItems_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: ComboBox contains exactly items [alice, bob, carol]\n");
+
+        // missing "dave", so should fail
+        assertThat(comboBox, ComboBoxMatchers.containsExactlyItems("alice", "bob", "carol"));
+    }
+
+    @Test
+    public void containsItemsInOrder() {
+        // expect:
+        // in order
+        assertThat(comboBox, ComboBoxMatchers.containsItemsInOrder("alice", "bob", "carol", "dave"));
+        // partial (but in-order)
+        assertThat(comboBox, ComboBoxMatchers.containsItemsInOrder("bob", "carol", "dave"));
+    }
+
+    @Test
+    public void containsItemsInOrder_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: ComboBox contains items in order [alice, carol, bob]\n");
+
+        assertThat(comboBox, ComboBoxMatchers.containsItemsInOrder("alice", "carol", "bob"));
+    }
+
+    @Test
+    public void containsExactlyItemsInOrder() {
+        // expect:
+        // in order
+        assertThat(comboBox, ComboBoxMatchers.containsExactlyItemsInOrder("alice", "bob", "carol", "dave"));
+    }
+
+    @Test
+    public void containsExactlyItemsInOrder_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: ComboBox contains exactly items in order [bob, alice, dave, carol]\n");
+
+        // not in correct order, should fail
+        assertThat(comboBox, ComboBoxMatchers.containsExactlyItemsInOrder("bob", "alice", "dave", "carol"));
+    }
+
+}


### PR DESCRIPTION
As the topic says and as discussed in gitter, this PR adds ComboBoxMatchers functionality for testing the number of items, sub-sequences of items (both in and out of order) and full matching sequences of items.