### PR TITLE
Disable TestFX for CI

### DIFF
--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
@@ -24,6 +24,7 @@ import javafx.stage.Stage;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 import org.testfx.api.annotation.Unstable;
@@ -31,6 +32,11 @@ import org.testfx.api.annotation.Unstable;
 @Unstable(reason = "might be renamed to ApplicationTestBase")
 public abstract class ApplicationTest extends FxRobot implements ApplicationFixture {
 
+	/**
+	 * This flag enables/disables the UI test. All tests will be skipped if set to false. 
+	 */
+	public static boolean doUITest=true;
+	
     //---------------------------------------------------------------------------------------------
     // STATIC METHODS.
     //---------------------------------------------------------------------------------------------
@@ -42,6 +48,18 @@ public abstract class ApplicationTest extends FxRobot implements ApplicationFixt
         FxToolkit.setupApplication(appClass, appArgs);
     }
 
+    /**
+     * Evaluates the environment variable {@code UI_TEST} and sets {@code doUITest} to false, 
+     * if the variable exists and is set to anything else than true.
+     */
+	@BeforeClass public final static void internalBeforeClass(){
+		String doUI=System.getenv("UI_TEST");
+		if(doUI!=null){
+			doUITest=doUI.equals("true");
+			if(!doUITest)
+				System.out.println("Executing UI-Tests="+doUITest);
+		}
+	}
     //---------------------------------------------------------------------------------------------
     // METHODS.
     //---------------------------------------------------------------------------------------------
@@ -50,15 +68,21 @@ public abstract class ApplicationTest extends FxRobot implements ApplicationFixt
     @Unstable(reason = "is missing apidocs")
     public final void internalBefore()
                               throws Exception {
-        FxToolkit.registerPrimaryStage();
-        FxToolkit.setupApplication(() -> new ApplicationAdapter(this));
+		//skipping tests if not doing ui tests
+		org.junit.Assume.assumeTrue(doUITest);
+		if(doUITest){
+			FxToolkit.registerPrimaryStage();
+			FxToolkit.setupApplication(() -> new ApplicationAdapter(this));
+		}
     }
 
     @After
     @Unstable(reason = "is missing apidocs")
     public final void internalAfter()
                              throws Exception {
-        FxToolkit.cleanupApplication(new ApplicationAdapter(this));
+		if(doUITest){
+			FxToolkit.cleanupApplication(new ApplicationAdapter(this));
+		}
     }
 
     @Override

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationTestTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationTestTest.java
@@ -1,0 +1,60 @@
+package org.testfx.framework.junit;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+
+public class ApplicationTestTest {
+
+	@Test public void shouldRunTest(){
+		DutClass dut=new DutClass();
+		assertTrue(!dut.started);
+		ApplicationTest.doUITest=true;
+		try{
+			dut.internalBefore();
+			assertTrue(dut.started);
+			dut.internalAfter();
+		}catch(Exception e){
+			assertTrue(false);
+		}
+	}
+
+	@Test public void shouldNotRunTest(){
+		DutClass dut=new DutClass();
+		assertTrue(!dut.started);
+		ApplicationTest.doUITest=false;
+		try{
+			dut.internalBefore();
+			assertTrue(!dut.started);
+			dut.internalAfter();
+		}catch(Exception e){
+			if(!(e instanceof AssumptionViolatedException)){
+				assertTrue(false);
+			}
+		}
+	}
+	
+	
+	protected class DutClass extends ApplicationTest{
+
+		public boolean started=false;
+		
+		
+		@Override
+		public void start(Stage stage) throws Exception {
+			started=true;
+			Pane p=new Pane();
+			p.setId("dutPane");
+	        // setup scene and stage.
+	        Scene scene = new Scene(p, 200, 200);
+	        stage.setScene(scene);
+	        stage.show();
+		}
+		
+	}
+}

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationTestTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationTestTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+
 package org.testfx.framework.junit;
 
 import static org.junit.Assert.assertTrue;
@@ -9,8 +26,15 @@ import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 
+/**
+ * Class for testing features of {@link ApplicationTest}.
+ * 
+ */
 public class ApplicationTestTest {
 
+	/**
+	 * Tests that the application runs with doUITest set to true.
+	 */
 	@Test public void shouldRunTest(){
 		DutClass dut=new DutClass();
 		assertTrue(!dut.started);
@@ -24,6 +48,9 @@ public class ApplicationTestTest {
 		}
 	}
 
+	/**
+	 * Tests that the application does not run with doUITest set to false.
+	 */
 	@Test public void shouldNotRunTest(){
 		DutClass dut=new DutClass();
 		assertTrue(!dut.started);


### PR DESCRIPTION
See #271 

Added static field, so all tests can be disabled by that field. The field is evaluated in the `internalBefore()` and `internalAfter()` methods.

Additionally all tests can be skipped by setting the environment variable `UI_TEST` to anything else than true (if not set all tests will be executed).