### PR TITLE
Allow for matching a table row without specifying index.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
@@ -18,7 +18,9 @@ package org.testfx.matcher.control;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
@@ -65,10 +67,18 @@ public class TableViewMatchers {
 
     @Factory
     @Unstable(reason = "is missing apidocs")
-    public static Matcher<Node> containsRow(int rowIndex, Object...cells) {
+    public static Matcher<Node> containsRowAtIndex(int rowIndex, Object...cells) {
         String descriptionText = "has row: " + Arrays.toString(cells);
         return typeSafeMatcher(TableView.class, descriptionText,
-             node -> containsRow(node, rowIndex, cells));
+             node -> containsRowAtIndex(node, rowIndex, cells));
+    }
+
+    @Factory
+    @Unstable(reason = "is missing apidocs")
+    public static Matcher<Node> containsRow(Object...cells) {
+        String descriptionText = "has row: " + Arrays.toString(cells);
+        return typeSafeMatcher(TableView.class, descriptionText,
+                node -> containsRow(node, cells));
     }
 
     //---------------------------------------------------------------------------------------------
@@ -89,8 +99,8 @@ public class TableViewMatchers {
         return tableView.getItems().size() == amount;
     }
 
-    private static <T> boolean containsRow(TableView<T> tableView, int rowIndex,
-                                       Object...cells) {
+    private static <T> boolean containsRowAtIndex(TableView<T> tableView, int rowIndex,
+                                                  Object...cells) {
         if (rowIndex >= tableView.getItems().size()) {
             return false;
         }
@@ -99,7 +109,8 @@ public class TableViewMatchers {
         List<ObservableValue<?>> rowValues = new ArrayList<>(tableView.getColumns().size());
         for (int i = 0; i < tableView.getColumns().size(); i++) {
             TableColumn<T, ?> column = tableView.getColumns().get(i);
-            TableColumn.CellDataFeatures cellDataFeatures = new TableColumn.CellDataFeatures<>(tableView, column, rowObject);
+            TableColumn.CellDataFeatures cellDataFeatures = new TableColumn.CellDataFeatures<>(
+                    tableView, column, rowObject);
             rowValues.add(i, column.getCellValueFactory().call(cellDataFeatures));
         }
         for (int i = 0; i < cells.length; i++) {
@@ -114,6 +125,50 @@ public class TableViewMatchers {
             }
         }
         return true;
+    }
+
+    private static <T> boolean containsRow(TableView<T> tableView, Object...cells) {
+        if (tableView.getItems().isEmpty()) {
+            return false;
+        }
+
+        Map<Integer, List<ObservableValue<?>>> rowValuesMap = new HashMap<>(tableView.getColumns().size());
+        for (int j = 0; j < tableView.getItems().size(); j++) {
+            T rowObject = tableView.getItems().get(j);
+            List<ObservableValue<?>> rowValues = new ArrayList<>(tableView.getColumns().size());
+
+            for (int i = 0; i < tableView.getColumns().size(); i++) {
+                TableColumn<T, ?> column = tableView.getColumns().get(i);
+                TableColumn.CellDataFeatures cellDataFeatures = new TableColumn.CellDataFeatures<>(
+                        tableView, column, rowObject);
+                rowValues.add(i, column.getCellValueFactory().call(cellDataFeatures));
+            }
+            rowValuesMap.put(j, rowValues);
+        }
+
+        for (List<ObservableValue<?>> rowValues : rowValuesMap.values()) {
+            for (int i = 0; i < cells.length; i++) {
+                if (rowValues.get(i).getValue() == null && cells[i] != null) {
+                    break;
+                } else if (cells[i] == null && rowValues.get(i).getValue() != null) {
+                    break;
+                } else if (rowValues.get(i).getValue() != null && !rowValues.get(i).getValue().equals(cells[i])) {
+                    break;
+                } else {
+                    if (i == cells.length - 1) {
+                        if (rowValues.get(i).getValue() == null && cells[i] != null) {
+                            break;
+                        } else if (cells[i] == null && rowValues.get(i).getValue() != null) {
+                            break;
+                        } else {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     private static boolean hasCellValue(Cell cell,

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -33,6 +33,7 @@ import org.testfx.api.FxToolkit;
 
 import static javafx.collections.FXCollections.observableArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 
 public class TableViewMatchersTest extends FxRobot {
 
@@ -128,6 +129,69 @@ public class TableViewMatchersTest extends FxRobot {
     }
 
     @Test
+    public void containsRowAtIndex() {
+        tableView.setItems(observableArrayList(
+                ImmutableMap.of("name", "alice", "age", 30),
+                ImmutableMap.of("name", "bob", "age", 31),
+                ImmutableMap.of("name", "carol", "age", 42),
+                ImmutableMap.of("name", "dave", "age", 55)
+        ));
+
+        // expect:
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(0, "alice", 30));
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, "bob", 31));
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(2, "carol", 42));
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(3, "dave", 55));
+        assertThat(tableView, not(TableViewMatchers.containsRowAtIndex(0, "ebert", 49)));
+        assertThat(tableView, not(TableViewMatchers.containsRowAtIndex(1, "alice", 30)));
+        assertThat(tableView, not(TableViewMatchers.containsRowAtIndex(4, "ebert", 49)));
+    }
+
+    @Test
+    public void containsRowAtIndex_with_empty_cells() {
+        tableView.setItems(observableArrayList(
+                ImmutableMap.of("name", "alice", "age", 30),
+                ImmutableMap.of("name", "bob", "age", 31),
+                ImmutableMap.of("name", "carol"),
+                ImmutableMap.of("name", "dave")
+        ));
+        // expect:
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(0, "alice", 30));
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, "bob", 31));
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(2, "carol", null));
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(3, "dave", null));
+        assertThat(tableView, not(TableViewMatchers.containsRowAtIndex(0, "ebert", null)));
+        assertThat(tableView, not(TableViewMatchers.containsRowAtIndex(3, "carol", null)));
+    }
+
+    @Test
+    public void containsRowAtIndex_no_such_row_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TableView has row: [jerry, 29]\n");
+
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(0, "jerry", 29));
+    }
+
+    @Test
+    public void containsRowAtIndex_out_of_bounds_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TableView has row: [tom, 54]\n");
+
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(4, "tom", 54));
+    }
+
+    @Test
+    public void containsRowAtIndex_wrong_types_fails() {
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: TableView has row: [63, deedee]\n");
+
+        assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, 63, "deedee"));
+    }
+
+    @Test
     public void containsRow() {
         tableView.setItems(observableArrayList(
                 ImmutableMap.of("name", "alice", "age", 30),
@@ -137,10 +201,11 @@ public class TableViewMatchersTest extends FxRobot {
         ));
 
         // expect:
-        assertThat(tableView, TableViewMatchers.containsRow(0, "alice", 30));
-        assertThat(tableView, TableViewMatchers.containsRow(1, "bob", 31));
-        assertThat(tableView, TableViewMatchers.containsRow(2, "carol", 42));
-        assertThat(tableView, TableViewMatchers.containsRow(3, "dave", 55));
+        assertThat(tableView, TableViewMatchers.containsRow("alice", 30));
+        assertThat(tableView, TableViewMatchers.containsRow("bob", 31));
+        assertThat(tableView, TableViewMatchers.containsRow("carol", 42));
+        assertThat(tableView, TableViewMatchers.containsRow("dave", 55));
+        assertThat(tableView, not(TableViewMatchers.containsRow("ebert", 49)));
     }
 
     @Test
@@ -152,10 +217,11 @@ public class TableViewMatchersTest extends FxRobot {
                 ImmutableMap.of("name", "dave")
         ));
         // expect:
-        assertThat(tableView, TableViewMatchers.containsRow(0, "alice", 30));
-        assertThat(tableView, TableViewMatchers.containsRow(1, "bob", 31));
-        assertThat(tableView, TableViewMatchers.containsRow(2, "carol", null));
-        assertThat(tableView, TableViewMatchers.containsRow(3, "dave", null));
+        assertThat(tableView, TableViewMatchers.containsRow("alice", 30));
+        assertThat(tableView, TableViewMatchers.containsRow("bob", 31));
+        assertThat(tableView, TableViewMatchers.containsRow("carol", null));
+        assertThat(tableView, TableViewMatchers.containsRow("dave", null));
+        assertThat(tableView, not(TableViewMatchers.containsRow("ebert", null)));
     }
 
     @Test
@@ -164,16 +230,7 @@ public class TableViewMatchersTest extends FxRobot {
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: TableView has row: [jerry, 29]\n");
 
-        assertThat(tableView, TableViewMatchers.containsRow(0, "jerry", 29));
-    }
-
-    @Test
-    public void containsRow_out_of_bounds_fails() {
-        // expect:
-        exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: TableView has row: [tom, 54]\n");
-
-        assertThat(tableView, TableViewMatchers.containsRow(4, "tom", 54));
+        assertThat(tableView, TableViewMatchers.containsRow("jerry", 29));
     }
 
     @Test
@@ -182,6 +239,6 @@ public class TableViewMatchersTest extends FxRobot {
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: TableView has row: [63, deedee]\n");
 
-        assertThat(tableView, TableViewMatchers.containsRow(1, 63, "deedee"));
+        assertThat(tableView, TableViewMatchers.containsRow(63, "deedee"));
     }
 }


### PR DESCRIPTION
Rename the old containsRow method to containsRowAtIndex and add a new
method, containsRow, that matches if the given TableView has the row
at any index.
