### PR TITLE
(docs) fix pom formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ Maven `pom.xml` with `testfx-core` from Maven Central repository (at https://rep
         <version>4.0.1-alpha</version>
         <scope>test</scope>
     </dependency>
-        <dependency>
-            <groupId>org.testfx</groupId>
-            <artifactId>testfx-junit</artifactId>
-            <version>4.0.1-alpha</version>
-            <scope>test</scope>
-        </dependency>
+    <dependency>
+        <groupId>org.testfx</groupId>
+        <artifactId>testfx-junit</artifactId>
+        <version>4.0.1-alpha</version>
+        <scope>test</scope>
+    </dependency>
 </dependencies>
 ~~~
 


### PR DESCRIPTION
Slight formatting fix. The extra indent made me initially mis-read it; so I thought I'd fix it.
