### PR TITLE
Document query-related interfaces

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
@@ -21,6 +21,7 @@ import javafx.geometry.Bounds;
 /**
  * Essentially, a {@link java.util.function.Supplier} that returns a {@link Bounds} object via {@link #query()}.
  */
+@FunctionalInterface
 public interface BoundsQuery {
 
     public Bounds query();

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
@@ -18,6 +18,9 @@ package org.testfx.service.query;
 
 import javafx.geometry.Bounds;
 
+/**
+ * Essentially, a {@link java.util.function.Supplier} that returns a {@link Bounds} object via {@link #query()}.
+ */
 public interface BoundsQuery {
 
     public Bounds query();

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
@@ -31,20 +31,102 @@ public interface NodeQuery {
     // METHODS.
     //---------------------------------------------------------------------------------------------
 
+    /**
+     * Stores all given {@code parentNodes} within this NodeQuery
+     *
+     * @param parentNodes the parentNodes to store
+     * @return itself
+     */
     NodeQuery from(Node... parentNodes);
+
+    /**
+     * Stores all given {@code parentNodes} within this NodeQuery
+     *
+     * @param parentNodes the parentNodes to store
+     * @return itself
+     */
     NodeQuery from(Collection<Node> parentNodes);
 
+    /**
+     * Sifts through stored nodes by their id ("#id"), their class (".class"), or the text it has ("text"),
+     * depending on the query used, and keeps only those {@code Node}s that meet the query.
+     *
+     * @param query the query to use
+     * @return itself
+     */
     NodeQuery lookup(String query);
+
+    /**
+     * Sifts through stored nodes and keeps only those {@code Node}s that match the given matcher.
+     *
+     * @param matcher the matcher used to determine which {@code Node}s to keep and which to remove
+     * @param <T> matcher type
+     * @return itself
+     */
     <T> NodeQuery lookup(Matcher<T> matcher);
+
+    /**
+     * Sifts through stored nodes and keeps only those {@code Node}s that pass the given {@code predicate}.
+     *
+     * @param predicate the predicate used to determine which {@code Node}s to keep and which to remove.
+     * @param <T> type that extends {@code Node}
+     * @return itself
+     */
     <T extends Node> NodeQuery lookup(Predicate<T> predicate);
+
+    /**
+     * Sifts through stored nodes and uses {@code function} to determine which nodes to keep and which to remove.
+     *
+     * @param function that returns the {@code Node}s to keep
+     * @return itself
+     */
     NodeQuery lookup(Function<Node, Set<Node>> function);
 
+    /**
+     * Sifts through stored nodes and removes all {@code Node}s that match the given matcher.
+     *
+     * @param matcher that determines which {@code Node}s to remove
+     * @param <T> matcher type
+     * @return itself
+     */
     <T> NodeQuery match(Matcher<T> matcher);
+
+    /**
+     * Sifts through stored nodes and removes all {@code Node}s that pass the given predicate.
+     *
+     * @param predicate that indicates which {@code Node}s to remove
+     * @param <T> predicate type
+     * @return itself
+     */
     <T extends Node> NodeQuery match(Predicate<T> predicate);
+
+    /**
+     * Keeps the nth {@code Node} in stored nodes and removes all others.
+     *
+     * @param index within the collection of {@code Node}s
+     * @return itself
+     */
     NodeQuery nth(int index);
 
+    /**
+     *
+     * @param <T> type that extends {@code Node}
+     * @return the first node found or null.
+     */
     <T extends Node> T query();
+
+    /**
+     *
+     * @param <T> type that extends {@code Node}
+     * @return the first node found or null
+     */
     <T extends Node> Optional<T> tryQuery();
+
+    /**
+     *
+     * @param <T> type that extends {@code Node}
+     * @return all nodes found
+     */
     <T extends Node> Set<T> queryAll();
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
@@ -19,20 +19,72 @@ package org.testfx.service.query;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
 
+/**
+ * Used to calculate a position within a given {@link javafx.geometry.Bounds}.
+ */
 public interface PointQuery {
+
+    /**
+     *
+     * @return the position that stores the {@code x} and {@code y} percentages (0.0 = 0% to 1.0 = 100%)
+     * to use when calculating a relative position within a {@code Bounds} object.
+     */
     public Point2D getPosition();
 
+    /**
+     *
+     * @return the amount by which to offset the point calculated via {@link #getPosition()}.
+     */
     public Point2D getOffset();
 
+    /**
+     * Updates {@link #getPosition()} to the new {@code position}
+     *
+     * @param position the new position
+     * @return itself
+     */
     public PointQuery atPosition(Point2D position);
 
+    /**
+     * Updates {@link #getPosition()} to the new {@code position}
+     *
+     * @param positionX the percentage to use: 0.0 (0%) to 1.0 (100%).
+     * @param positionY the percentage to use: 0.0 (0%) to 1.0 (100%).
+     * @return itself
+     */
     public PointQuery atPosition(double positionX, double positionY);
 
+    /**
+     * Updates {@link #getPosition()} to a new one based on the given {@code position}.
+     *
+     * @param position left/up = 0.0 (0%); center = 0.5 (50%); right/down = 1.0 (100%)
+     * @return itself
+     */
     public PointQuery atPosition(Pos position);
 
+    /**
+     * Updates {@link #getOffset()} to be
+     * {@code new Point2D(this.offset.getX() + offset.getX(), this.offset.getY() + offset.getY())}.
+     *
+     * @param offset the amount by which to increase/decrease the offset's x & y values
+     * @return itself
+     */
     public PointQuery atOffset(Point2D offset);
 
+    /**
+     * Updates {@link #getOffset()} by the combination of the current {@code offset}'s {@code x} value and
+     * {@code offsetX} and its {@code y} value and {@code offsetY}.
+     *
+     * @param offsetX the amount by which to increase/decrease the offset's x value
+     * @param offsetY the amount by which to increase/decrease the offset's y value
+     * @return itself
+     */
     public PointQuery atOffset(double offsetX, double offsetY);
 
+    /**
+     *
+     * @return a position that offsets the relative position within the initial {@code Bounds} object that is calculated
+     * via {@link #getPosition()} by {@link #getOffset()} amount.
+     */
     public Point2D query();
 }


### PR DESCRIPTION
I believe `PointQuery` should extend `BoundsQuery` (since that provides the initial `query` method) and should better clarifies what its query method method does. There is no `PointQueryImpl` because `BoundsQueryImpl` is the actual implementation used for the `PointQuery` interface. 

Why then does the `BoundsQuery` interface exist? I have no idea. Perhaps to prevent any changes to the implementation's position or offset values.