### PR TITLE
(cleanup) Use `getWidth()` and `getHeight()` rather than calculate it

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
@@ -46,8 +46,8 @@ public final class PointQueryUtils {
 
     public static Point2D atPositionFactors(Bounds bounds,
                                             Point2D positionFactors) {
-        double pointX = lerp(bounds.getMinX(), bounds.getMaxX(), positionFactors.getX());
-        double pointY = lerp(bounds.getMinY(), bounds.getMaxY(), positionFactors.getY());
+        double pointX = lerp(bounds.getMinX(), bounds.getWidth(), positionFactors.getX());
+        double pointY = lerp(bounds.getMinY(), bounds.getHeight(), positionFactors.getY());
         return new Point2D(pointX, pointY);
     }
 
@@ -62,9 +62,9 @@ public final class PointQueryUtils {
     //---------------------------------------------------------------------------------------------
 
     private static double lerp(double start,
-                               double end,
+                               double distance,
                                double factor) {
-        return start + ((end - start) * factor);
+        return start + (distance * factor);
     }
 
     private static double computePositionX(HPos hPos) {


### PR DESCRIPTION
Address a point I made in #328 