### PR TITLE
(doc) Add documentation to TextInputControls

### DIFF
--- a/subprojects/testfx-legacy/src/main/java/org/loadui/testfx/controls/TextInputControls.java
+++ b/subprojects/testfx-legacy/src/main/java/org/loadui/testfx/controls/TextInputControls.java
@@ -28,12 +28,27 @@ import static javafx.scene.input.KeyCode.BACK_SPACE;
 import static javafx.scene.input.KeyCode.SHORTCUT;
 import static org.loadui.testfx.GuiTest.find;
 
+/**
+ * Provides methods for interacting with TextInputControls.
+ */
 public class TextInputControls {
 
+    /**
+     * Clears all text in the given TextInputControl.
+     *
+     * @param textInputControl the textInputControl to clear
+     */
     public static void clearTextIn(TextInputControl textInputControl) {
         textInputControl.clear();
     }
 
+    /**
+     * Clears all text in the TextInputControl defined by the given query. The
+     * query is resolved by {@link org.loadui.testfx.GuiTest#find(String)}. If
+     * the control is already empty, nothing will be done.
+     *
+     * @param textInputQuery the query to lookup the TextInputControl.
+     */
     public static void clearTextIn(String textInputQuery) {
         Node node = find(textInputQuery);
         if (!(node instanceof TextInputControl)) {


### PR DESCRIPTION
Sorry, I didn't see the javadoc in #277. This adds it so that PR can be closed.