### PR TITLE
Junit5 adapter

### DIFF
--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationAdapter.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5;
+
+import javafx.application.Application;
+import javafx.stage.Stage;
+
+import org.testfx.api.annotation.Unstable;
+
+@Unstable(reason = "needs more tests")
+public final class ApplicationAdapter extends Application {
+
+    //---------------------------------------------------------------------------------------------
+    // PRIVATE FIELDS.
+    //---------------------------------------------------------------------------------------------
+
+    private ApplicationFixture applicationFixture;
+
+    //---------------------------------------------------------------------------------------------
+    // CONSTRUCTORS.
+    //---------------------------------------------------------------------------------------------
+
+    public ApplicationAdapter(ApplicationFixture applicationFixture) {
+        this.applicationFixture = applicationFixture;
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    public void init()
+              throws Exception {
+        applicationFixture.init();
+    }
+
+    @Override
+    public void start(Stage primaryStage)
+               throws Exception {
+        applicationFixture.start(primaryStage);
+    }
+
+    @Override
+    public void stop()
+              throws Exception {
+        applicationFixture.stop();
+    }
+
+}

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
@@ -39,26 +39,22 @@ public class ApplicationExtension extends FxRobot implements BeforeEachCallback,
 
     @Override
     public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
-        if (testInstance instanceof ApplicationFixture) {
-            applicationFixture = (ApplicationFixture) testInstance;
-        } else {
-            List<Method> init = new ArrayList<>();
-            List<Method> start = new ArrayList<>();
-            List<Method> stop = new ArrayList<>();
-            Method[] methods = testInstance.getClass().getDeclaredMethods();
-            for (Method method : methods) {
-                if (method.isAnnotationPresent(Init.class)) {
-                    init.add(method);
-                }
-                if (method.isAnnotationPresent(Start.class)) {
-                    start.add(method);
-                }
-                if (method.isAnnotationPresent(Stop.class)) {
-                    stop.add(method);
-                }
+        List<Method> init = new ArrayList<>();
+        List<Method> start = new ArrayList<>();
+        List<Method> stop = new ArrayList<>();
+        Method[] methods = testInstance.getClass().getDeclaredMethods();
+        for (Method method : methods) {
+            if (method.isAnnotationPresent(Init.class)) {
+                init.add(method);
             }
-            applicationFixture = new AnnotationBasedApplicationFixture(testInstance, init, start, stop);
+            if (method.isAnnotationPresent(Start.class)) {
+                start.add(method);
+            }
+            if (method.isAnnotationPresent(Stop.class)) {
+                stop.add(method);
+            }
         }
+        applicationFixture = new AnnotationBasedApplicationFixture(testInstance, init, start, stop);
     }
 
     @Override

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+public class ApplicationExtension extends FxRobot implements BeforeEachCallback, AfterEachCallback,
+        TestInstancePostProcessor, ParameterResolver {
+
+    private ApplicationFixture applicationFixture;
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
+        if (testInstance instanceof ApplicationFixture) {
+            applicationFixture = (ApplicationFixture) testInstance;
+        } else {
+            List<Method> init = new ArrayList<>();
+            List<Method> start = new ArrayList<>();
+            List<Method> stop = new ArrayList<>();
+            Method[] methods = testInstance.getClass().getDeclaredMethods();
+            for (Method method : methods) {
+                if (method.isAnnotationPresent(Init.class)) {
+                    init.add(method);
+                }
+                if (method.isAnnotationPresent(Start.class)) {
+                    start.add(method);
+                }
+                if (method.isAnnotationPresent(Stop.class)) {
+                    stop.add(method);
+                }
+            }
+            applicationFixture = new AnnotationBasedApplicationFixture(testInstance, init, start, stop);
+        }
+    }
+
+    @Override
+    public boolean supports(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType().isAssignableFrom(FxRobot.class);
+    }
+
+    @Override
+    public Object resolve(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return this;
+    }
+
+    @Override
+    public void beforeEach(TestExtensionContext context) throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.setupApplication(() -> new ApplicationAdapter(applicationFixture));
+    }
+
+    @Override
+    public void afterEach(TestExtensionContext context) throws Exception {
+        FxToolkit.cleanupApplication(new ApplicationAdapter(applicationFixture));
+    }
+
+    private static class AnnotationBasedApplicationFixture implements ApplicationFixture {
+
+        private final Object testInstance;
+        private final List<Method> init;
+        private final List<Method> start;
+        private final List<Method> stop;
+
+        private AnnotationBasedApplicationFixture(Object testInstance, List<Method> init,
+                                                  List<Method> start, List<Method> stop) {
+            this.testInstance = testInstance;
+            this.init = init;
+            this.start = start;
+            this.stop = stop;
+        }
+
+        @Override
+        public void init() throws InvocationTargetException, IllegalAccessException {
+            for (Method method : init) {
+                method.invoke(testInstance);
+            }
+        }
+
+        @Override
+        public void start(Stage stage) throws InvocationTargetException, IllegalAccessException {
+            for (Method method : start) {
+                method.invoke(testInstance, stage);
+            }
+        }
+
+        @Override
+        public void stop() throws InvocationTargetException, IllegalAccessException {
+            for (Method method : stop) {
+                method.invoke(testInstance);
+            }
+        }
+
+    }
+
+}

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationFixture.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationFixture.java
@@ -14,22 +14,16 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+package org.testfx.framework.junit5;
 
-// name of root project.
-rootProject.name = "TestFX"
+import javafx.stage.Stage;
 
-// list of projects.
-include "subprojects/testfx-core"
-include "subprojects/testfx-junit"
-include "subprojects/testfx-junit5"
-include "subprojects/testfx-legacy"
+public interface ApplicationFixture {
 
-// location of the build files.
-rootProject.children.each { project ->
-    def projectDir = new File(project.name)
-    project.name = projectDir.name
-    project.projectDir = projectDir
-    project.buildFileName = "${projectDir.name}.gradle"
-    assert project.projectDir.isDirectory()
-    assert project.buildFile.isFile()
+    void init() throws Exception;
+
+    void start(Stage stage) throws Exception;
+
+    void stop() throws Exception;
+
 }

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5;
+
+import javafx.application.Application;
+import javafx.application.Application.Parameters;
+import javafx.application.HostServices;
+import javafx.application.Preloader.PreloaderNotification;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.api.annotation.Unstable;
+
+@Unstable(reason = "might be renamed to ApplicationTestBase")
+public abstract class ApplicationTest extends FxRobot implements ApplicationFixture {
+
+    //---------------------------------------------------------------------------------------------
+    // STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Unstable(reason = "is missing apidocs")
+    public static void launch(Class<? extends Application> appClass,
+                              String... appArgs) throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.setupApplication(appClass, appArgs);
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @BeforeEach
+    @Unstable(reason = "is missing apidocs")
+    public final void internalBefore()
+                              throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.setupApplication(() -> new ApplicationAdapter(this));
+    }
+
+    @AfterEach
+    @Unstable(reason = "is missing apidocs")
+    public final void internalAfter()
+                             throws Exception {
+        // release all keys
+        release(new KeyCode[0]);
+        // release all mouse buttons
+        release(new MouseButton[0]);
+        FxToolkit.cleanupApplication(new ApplicationAdapter(this));
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public void init()
+            throws Exception {}
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public abstract void start(Stage stage)
+                        throws Exception;
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public void stop()
+              throws Exception {}
+
+    @Deprecated
+    public final HostServices getHostServices() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    public final Parameters getParameters() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    public final void notifyPreloader(PreloaderNotification notification) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Init.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Init.java
@@ -14,22 +14,16 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+package org.testfx.framework.junit5;
 
-// name of root project.
-rootProject.name = "TestFX"
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-// list of projects.
-include "subprojects/testfx-core"
-include "subprojects/testfx-junit"
-include "subprojects/testfx-junit5"
-include "subprojects/testfx-legacy"
+import static java.lang.annotation.ElementType.METHOD;
 
-// location of the build files.
-rootProject.children.each { project ->
-    def projectDir = new File(project.name)
-    project.name = projectDir.name
-    project.projectDir = projectDir
-    project.buildFileName = "${projectDir.name}.gradle"
-    assert project.projectDir.isDirectory()
-    assert project.buildFile.isFile()
-}
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(METHOD)
+public @interface Init { }

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Start.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Start.java
@@ -14,22 +14,16 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+package org.testfx.framework.junit5;
 
-// name of root project.
-rootProject.name = "TestFX"
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-// list of projects.
-include "subprojects/testfx-core"
-include "subprojects/testfx-junit"
-include "subprojects/testfx-junit5"
-include "subprojects/testfx-legacy"
+import static java.lang.annotation.ElementType.METHOD;
 
-// location of the build files.
-rootProject.children.each { project ->
-    def projectDir = new File(project.name)
-    project.name = projectDir.name
-    project.projectDir = projectDir
-    project.buildFileName = "${projectDir.name}.gradle"
-    assert project.projectDir.isDirectory()
-    assert project.buildFile.isFile()
-}
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(METHOD)
+public @interface Start { }

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Stop.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Stop.java
@@ -14,22 +14,16 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+package org.testfx.framework.junit5;
 
-// name of root project.
-rootProject.name = "TestFX"
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-// list of projects.
-include "subprojects/testfx-core"
-include "subprojects/testfx-junit"
-include "subprojects/testfx-junit5"
-include "subprojects/testfx-legacy"
+import static java.lang.annotation.ElementType.METHOD;
 
-// location of the build files.
-rootProject.children.each { project ->
-    def projectDir = new File(project.name)
-    project.name = projectDir.name
-    project.projectDir = projectDir
-    project.buildFileName = "${projectDir.name}.gradle"
-    assert project.projectDir.isDirectory()
-    assert project.buildFile.isFile()
-}
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(METHOD)
+public @interface Stop { }

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.cases.acceptance;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import static org.testfx.api.FxAssert.verifyThat;
+import static org.testfx.matcher.base.NodeMatchers.hasText;
+
+class ApplicationLaunchTest extends FxRobot {
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURES.
+    //---------------------------------------------------------------------------------------------
+
+    static class DemoApplication extends Application {
+        @Override
+        public void start(Stage stage) {
+            Button button = new Button("click me!");
+            button.setOnAction((actionEvent) -> button.setText("clicked!"));
+            stage.setScene(new Scene(new StackPane(button), 100, 100));
+            stage.show();
+        }
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @BeforeEach
+    void setup() throws Exception {
+        ApplicationTest.launch(DemoApplication.class);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        FxToolkit.cleanupStages();
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Test
+    void should_contain_button() {
+        // expect:
+        verifyThat(".button", hasText("click me!"));
+    }
+
+    @Test
+    void should_click_on_button() {
+        // when:
+        clickOn(".button");
+
+        // then:
+        verifyThat(".button", hasText("clicked!"));
+    }
+
+}

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.cases.acceptance;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import static org.testfx.api.FxAssert.verifyThat;
+import static org.testfx.matcher.base.NodeMatchers.hasText;
+
+class ApplicationStartTest extends ApplicationTest {
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    public void init() throws Exception {
+        FxToolkit.registerStage(() -> new Stage());
+    }
+
+    @Override
+    public void start(Stage stage) {
+        Button button = new Button("click me!");
+        button.setOnAction((actionEvent) -> button.setText("clicked!"));
+        stage.setScene(new Scene(new StackPane(button), 100, 100));
+        stage.show();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        FxToolkit.hideStage();
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Test
+    void should_contain_button() {
+        // expect:
+        verifyThat(".button", hasText("click me!"));
+    }
+
+    @Test
+    void should_click_on_button() {
+        // when:
+        clickOn(".button");
+
+        // then:
+        verifyThat(".button", hasText("clicked!"));
+    }
+
+}

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import static org.testfx.api.FxAssert.verifyThat;
+import static org.testfx.matcher.base.NodeMatchers.hasText;
+
+@ExtendWith(ApplicationExtension.class)
+class ApplicationRuleTest {
+
+    @Start
+    void onStart(Stage stage) {
+        Button button = new Button("click me!");
+        button.setOnAction(actionEvent -> button.setText("clicked!"));
+        stage.setScene(new Scene(new StackPane(button), 100, 100));
+        stage.show();
+    }
+
+    @Test
+    void should_contain_button() {
+        // expect:
+        verifyThat(".button", hasText("click me!"));
+    }
+
+    @Test
+    void should_click_on_button(FxRobot robot) {
+        // when:
+        robot.clickOn(".button");
+
+        // then:
+        verifyThat(".button", hasText("clicked!"));
+    }
+
+}

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit;
+
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests to see if pressed keys/buttons are released after a test is run.
+ *
+ * For keys, this prevents hanging issues (if Shortcut key is pressed) or deletion issues (if backspace/delete key
+ * is pressed) or insertion issues (if anything else is pressed). The same for mouse buttons
+ */
+
+class KeyAndButtonReleaseTest extends ApplicationTest {
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        stage.show();
+    }
+
+    @Test
+    void b_When_a_test_forgets_to_release_keys() {
+        press(KeyCode.CONTROL, KeyCode.SHIFT, KeyCode.ALT);
+    }
+
+    @Test
+    void c_Then_keys_are_not_pressed() {
+        assertThat(robotContext().getKeyboardRobot().getPressedKeys().isEmpty(), is(true));
+    }
+
+    @Test
+    void e_When_a_test_forgets_to_release_buttons() {
+        press(MouseButton.PRIMARY, MouseButton.SECONDARY, MouseButton.MIDDLE);
+    }
+
+    @Test
+    void f_Then_buttons_are_not_pressed() {
+        assertThat(robotContext().getMouseRobot().getPressedButtons().isEmpty(), is(true));
+    }
+}

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit/ShortcutKeyTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit/ShortcutKeyTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit;
+
+import java.util.Locale;
+
+import javafx.scene.Scene;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import static javafx.scene.input.KeyCode.COMMAND;
+import static javafx.scene.input.KeyCode.CONTROL;
+import static javafx.scene.input.KeyCode.SHORTCUT;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests whether pressing {@code KeyCode.SHORTCUT} will convert into the OS-specific KeyCode (i.e.
+ * {@code KeyCode.COMMAND} for Macs and {@code KeyCode.CONTROL} for everything else).
+ */
+class ShortcutKeyTest extends ApplicationTest {
+
+    private final KeyCode osSpecificShortcutKey;
+    {
+        String osName = System.getProperty("os.name").toLowerCase(Locale.US);
+        osSpecificShortcutKey = osName.startsWith("mac") ? COMMAND : CONTROL;
+    }
+
+    private TextField field;
+    private final String pressedText = "pressed";
+    private final String releasedText = "released";
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        field = new TextField();
+        field.setOnKeyPressed(e -> {
+            if (e.getCode().equals(osSpecificShortcutKey)) {
+                field.setText(pressedText);
+            }
+            e.consume();
+        });
+        field.setOnKeyReleased(e -> {
+            if (e.getCode().equals(osSpecificShortcutKey)) {
+                field.setText(releasedText);
+            }
+            e.consume();
+        });
+        stage.setScene(new Scene(field, 400, 400));
+        stage.show();
+        field.requestFocus();
+    }
+
+    @Test
+    void shortcut_keyCode_converts_to_OS_specific_keyCode_when_pressed() {
+        // when:
+        press(SHORTCUT);
+
+        // then:
+        assertThat(field.getText(), equalTo(pressedText));
+    }
+
+    @Test
+    void shortcut_keyCode_converts_to_OS_specific_keyCode_when_released() {
+        // given:
+        press(osSpecificShortcutKey);
+
+        // and:
+        assertThat(field.getText(), equalTo(pressedText));
+
+        // when:
+        release(SHORTCUT);
+
+        // then:
+        assertThat(field.getText(), equalTo(releasedText));
+    }
+
+}

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -19,10 +19,10 @@ ext.pomDescription = "TestFX JUnit5"
 
 dependencies {
     compile project(":testfx-core")
-    compile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M3'
-    compile 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M3'
 
-    testCompile "org.hamcrest:hamcrest-all:1.3"
-    testCompile "org.mockito:mockito-all:1.10.19"
+    providedCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M3'
+
+    testCompile 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M3'
+    testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile "org.testfx:openjfx-monocle:1.8.0_20"
 }

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -15,21 +15,14 @@
  * specific language governing permissions and limitations under the Licence.
  */
 
-// name of root project.
-rootProject.name = "TestFX"
+ext.pomDescription = "TestFX JUnit5"
 
-// list of projects.
-include "subprojects/testfx-core"
-include "subprojects/testfx-junit"
-include "subprojects/testfx-junit5"
-include "subprojects/testfx-legacy"
+dependencies {
+    compile project(":testfx-core")
+    compile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M3'
+    compile 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M3'
 
-// location of the build files.
-rootProject.children.each { project ->
-    def projectDir = new File(project.name)
-    project.name = projectDir.name
-    project.projectDir = projectDir
-    project.buildFileName = "${projectDir.name}.gradle"
-    assert project.projectDir.isDirectory()
-    assert project.buildFile.isFile()
+    testCompile "org.hamcrest:hamcrest-all:1.3"
+    testCompile "org.mockito:mockito-all:1.10.19"
+    testCompile "org.testfx:openjfx-monocle:1.8.0_20"
 }


### PR DESCRIPTION
This is a very simple TestFX idiomatic junit5 adapter. It can be used in two ways. Either extending the ApplicationAdapter ( similar to testfx-junit adapter ) or by declaring extension on your test class i.e.:
```
@ExtendsWith(ApplicationExtension.class)
class MyJunit5Test {
    /* after that you can declare methods annotated with @Init */
    @Init
    void sceneInitMethod() { }
    /* or @Start */
    @Start
    void start(Scene scene) { }
    /* or @Stop */
    @Stop
    void stop() {}
    /* to get the access to FxRobot instance during the test, just declare the test parameter of type FxRobot */
    @Test
    void shouldTestFx(FxRobot robot) {
         robot.click("whatever");
    }
}
```