### PR TITLE
Replace all uber jar deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,10 @@ rootProject.with { project ->
 //-------------------------------------------------------------------------------------------------
 
 allprojects { project ->
+    configurations {
+        providedCompile
+    }
+
     // task to create main and test source directories.
     task("initSourceDirs", group: "build setup").doLast {
         // ignore source directories for projects without source sets.
@@ -108,6 +112,10 @@ subprojects { subproject ->
     apply(from: rootProject.file("gradle/publish-jar.gradle"))
     apply(from: rootProject.file("gradle/publish-maven.gradle"))
     apply(from: rootProject.file("gradle/publish-bintray.gradle"))
+
+    sourceSets.main.compileClasspath += configurations.providedCompile
+    sourceSets.test.compileClasspath += configurations.providedCompile
+    sourceSets.test.runtimeClasspath += configurations.providedCompile
 
     task("sourceJar", type: Jar) {
         group "Build"
@@ -194,6 +202,7 @@ subprojects { subproject ->
     // configure javadoc task.
     javadoc {
         excludes = ["**/*.html", "META-INF/**"]
+        classpath = configurations.compile + configurations.providedCompile
         options.use         = true
         options.splitIndex  = true
         options.encoding    = "UTF-8"

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -19,13 +19,12 @@ ext.pomDescription = "TestFX Core"
 
 dependencies {
     compile "com.google.guava:guava:20.0"
-    compile "org.hamcrest:hamcrest-all:1.3"
+    compile "org.hamcrest:hamcrest-core:1.3"
     compile 'com.google.code.findbugs:annotations:3.0.1u2'
 
-    testCompile("junit:junit:4.12") {
-        exclude group: "org.hamcrest", module: "hamcrest-core"
-    }
-    testCompile "org.mockito:mockito-core:2.2.27"
+    testCompile "junit:junit:4.12"
+    testCompile "org.mockito:mockito-core:2.3.5"
+    testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile "org.controlsfx:controlsfx:8.40.12"
     testCompile "org.testfx:openjfx-monocle:1.8.0_20"
 }

--- a/subprojects/testfx-junit/testfx-junit.gradle
+++ b/subprojects/testfx-junit/testfx-junit.gradle
@@ -19,11 +19,9 @@ ext.pomDescription = "TestFX JUnit"
 
 dependencies {
     compile project(":testfx-core")
-    compile "junit:junit:4.12", {
-        exclude group: "org.hamcrest", module: "hamcrest-core"
-    }
 
-    testCompile "org.hamcrest:hamcrest-all:1.3"
-    testCompile "org.mockito:mockito-all:1.10.19"
+    providedCompile "junit:junit:4.12"
+
+    testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile "org.testfx:openjfx-monocle:1.8.0_20"
 }

--- a/subprojects/testfx-legacy/testfx-legacy.gradle
+++ b/subprojects/testfx-legacy/testfx-legacy.gradle
@@ -19,13 +19,10 @@ ext.pomDescription = "TestFX Legacy"
 
 dependencies {
     compile project(":testfx-core")
-
     compile "com.google.guava:guava:20.0"
-    compile("junit:junit:4.12") {
-        exclude group: "org.hamcrest", module: "hamcrest-core"
-    }
 
-    compile "org.hamcrest:hamcrest-all:1.3"
-    testCompile "org.mockito:mockito-all:1.10.19"
+    providedCompile "junit:junit:4.12"
+
+    testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile "org.testfx:openjfx-monocle:1.8.0_20"
 }


### PR DESCRIPTION
TestFx uses compile dependencies like mockito-all, hamcrest-all, etc. which doesn't play well with other project dependencies since they basically are one big dependency which can't be versioned partially. 
I've replaced all these dependencies onto a more preferable ones.

Additionally I scoped junit dependency as provided, so user would have to provide their own preferable junit version to work with TestFX.