### PR TITLE
Bump the macOS travis image version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ matrix:
         - USE_FRAMEBUFFER=false
         - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.2
       env:
         - OSX_HEADLESS=false
         - _JAVA_OPTIONS="-Dprism.order=sw"
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.2
       env: _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
   allow_failures:
     - env:


### PR DESCRIPTION
We want to be on the latest JDK possible so that if crashes occur,
the Java bug reports that we open will get better attention and we
will eliminate the "can you try on the latest JDK?" obligatory question.