### PR TITLE
(feature) Introduce the concept of motion.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -44,6 +44,7 @@ import javafx.stage.Window;
 
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
+import org.testfx.robot.Motion;
 import org.testfx.service.locator.PointLocator;
 import org.testfx.service.query.BoundsQuery;
 import org.testfx.service.query.NodeQuery;
@@ -333,7 +334,7 @@ public class FxRobot implements FxRobotInterface {
         PointLocator pointLocator = context.getPointLocator();
         Pos pointPosition = context.getPointPosition();
         targetWindow(node.getScene().getWindow());
-        return pointLocator.point(node).atPosition(pointPosition);
+        return pointLocator.point(node).onNode(node).atPosition(pointPosition);
     }
 
     @Override
@@ -499,7 +500,7 @@ public class FxRobot implements FxRobotInterface {
         waitForFxEvents();
         return this;
     }
-    
+
     @Override
     public FxRobot interactNoWait(Runnable runnable) {
         waitFor(asyncFx(runnable));
@@ -510,7 +511,7 @@ public class FxRobot implements FxRobotInterface {
         waitFor(asyncFx(callable));
         return this;
     }
-    
+
     @Override
     public FxRobot interrupt() {
         waitForFxEvents();
@@ -679,8 +680,9 @@ public class FxRobot implements FxRobotInterface {
 
     @Override
     public FxRobot clickOn(PointQuery pointQuery,
+                           Motion motion,
                            MouseButton... buttons) {
-        context.getClickRobot().clickOn(pointQuery, buttons);
+        context.getClickRobot().clickOn(pointQuery, motion, buttons);
         return this;
     }
 
@@ -692,65 +694,75 @@ public class FxRobot implements FxRobotInterface {
 
     @Override
     public FxRobot doubleClickOn(PointQuery pointQuery,
+                                 Motion motion,
                                  MouseButton... buttons) {
-        context.getClickRobot().doubleClickOn(pointQuery, buttons);
+        context.getClickRobot().doubleClickOn(pointQuery, motion, buttons);
         return this;
     }
 
     @Override
     public FxRobot clickOn(double x,
                            double y,
+                           Motion motion,
                            MouseButton... buttons) {
-        return clickOn(point(x, y), buttons);
+        return clickOn(point(x, y), motion, buttons);
     }
 
     @Override
     public FxRobot clickOn(Point2D point,
+                           Motion motion,
                            MouseButton... buttons) {
-        return clickOn(point(point), buttons);
+        return clickOn(point(point), motion, buttons);
     }
 
     @Override
     public FxRobot clickOn(Bounds bounds,
+                           Motion motion,
                            MouseButton... buttons) {
-        return clickOn(point(bounds), buttons);
+        return clickOn(point(bounds), motion, buttons);
     }
 
     @Override
     public FxRobot clickOn(Node node,
+                           Motion motion,
                            MouseButton... buttons) {
-        return clickOn(point(node), buttons);
+        return clickOn(point(node), motion, buttons);
     }
 
     @Override
     public FxRobot clickOn(Scene scene,
+                           Motion motion,
                            MouseButton... buttons) {
-        return clickOn(point(scene), buttons);
+        return clickOn(point(scene), motion, buttons);
     }
 
     @Override
     public FxRobot clickOn(Window window,
+                           Motion motion,
                            MouseButton... buttons) {
-        return clickOn(point(window), buttons);
+        return clickOn(point(window), motion, buttons);
     }
 
     @Override
     public FxRobot clickOn(String query,
+                           Motion motion,
                            MouseButton... buttons) {
-        return clickOn(pointOfVisibleNode(query), buttons);
+        return clickOn(pointOfVisibleNode(query), motion, buttons);
     }
 
     @Override
     @Unstable(reason = "might change to accept all objects")
     public <T extends Node> FxRobot clickOn(Matcher<T> matcher,
+                                            Motion motion,
                                             MouseButton... buttons) {
-        return clickOn(pointOfVisibleNode(matcher), buttons);
+        return clickOn(pointOfVisibleNode(matcher), motion, buttons);
     }
 
     @Override
     public <T extends Node> FxRobot clickOn(Predicate<T> predicate,
+                                            Motion motion,
                                             MouseButton... buttons) {
-        return clickOn(pointOfVisibleNode(predicate), buttons);
+        return clickOn(pointOfVisibleNode(predicate), motion, buttons);
     }
 
     @Override
@@ -759,110 +771,99 @@ public class FxRobot implements FxRobotInterface {
     }
 
     @Override
-    public FxRobot rightClickOn(PointQuery pointQuery) {
-        return clickOn(pointQuery, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(PointQuery pointQuery, Motion motion) {
+        return clickOn(pointQuery, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot rightClickOn(double x,
-                                double y) {
-        return clickOn(x, y, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(double x, double y, Motion motion) {
+        return clickOn(x, y, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot rightClickOn(Point2D point) {
-        return clickOn(point, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(Point2D point, Motion motion) {
+        return clickOn(point, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot rightClickOn(Bounds bounds) {
-        return clickOn(bounds, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(Bounds bounds, Motion motion) {
+        return clickOn(bounds, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot rightClickOn(Node node) {
-        return clickOn(node, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(Node node, Motion motion) {
+        return clickOn(node, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot rightClickOn(Scene scene) {
-        return clickOn(scene, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(Scene scene, Motion motion) {
+        return clickOn(scene, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot rightClickOn(Window window) {
-        return clickOn(window, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(Window window, Motion motion) {
+        return clickOn(window, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot rightClickOn(String query) {
-        return clickOn(query, MouseButton.SECONDARY);
+    public FxRobot rightClickOn(String query, Motion motion) {
+        return clickOn(query, motion, MouseButton.SECONDARY);
     }
 
     @Override
     @Unstable(reason = "might change to accept all objects")
-    public <T extends Node> FxRobot rightClickOn(Matcher<T> matcher) {
-        return clickOn(matcher, MouseButton.SECONDARY);
+    public <T extends Node> FxRobot rightClickOn(Matcher<T> matcher, Motion motion) {
+        return clickOn(matcher, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public <T extends Node> FxRobot rightClickOn(Predicate<T> predicate) {
-        return clickOn(predicate, MouseButton.SECONDARY);
+    public <T extends Node> FxRobot rightClickOn(Predicate<T> predicate, Motion motion) {
+        return clickOn(predicate, motion, MouseButton.SECONDARY);
     }
 
     @Override
-    public FxRobot doubleClickOn(double x,
-                                 double y,
-                                 MouseButton... buttons) {
-        return doubleClickOn(point(x, y), buttons);
+    public FxRobot doubleClickOn(double x, double y, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(point(x, y), motion, buttons);
     }
 
     @Override
-    public FxRobot doubleClickOn(Point2D point,
-                                 MouseButton... buttons) {
-        return doubleClickOn(point(point), buttons);
+    public FxRobot doubleClickOn(Point2D point, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(point(point), motion, buttons);
     }
 
     @Override
-    public FxRobot doubleClickOn(Bounds bounds,
-                                 MouseButton... buttons) {
-        return doubleClickOn(point(bounds), buttons);
+    public FxRobot doubleClickOn(Bounds bounds, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(point(bounds), motion, buttons);
     }
 
     @Override
-    public FxRobot doubleClickOn(Node node,
-                                 MouseButton... buttons) {
-        return doubleClickOn(point(node), buttons);
+    public FxRobot doubleClickOn(Node node, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(point(node), motion, buttons);
     }
 
     @Override
-    public FxRobot doubleClickOn(Scene scene,
-                                 MouseButton... buttons) {
-        return doubleClickOn(point(scene), buttons);
+    public FxRobot doubleClickOn(Scene scene, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(point(scene), motion, buttons);
     }
 
     @Override
-    public FxRobot doubleClickOn(Window window,
-                                 MouseButton... buttons) {
-        return doubleClickOn(point(window), buttons);
+    public FxRobot doubleClickOn(Window window, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(point(window), motion, buttons);
     }
 
     @Override
-    public FxRobot doubleClickOn(String query,
-                                 MouseButton... buttons) {
-        return doubleClickOn(pointOfVisibleNode(query), buttons);
+    public FxRobot doubleClickOn(String query, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(pointOfVisibleNode(query), motion, buttons);
     }
 
     @Override
-    public <T extends Node> FxRobot doubleClickOn(Matcher<T> matcher,
-                                                  MouseButton... buttons) {
-        return doubleClickOn(pointOfVisibleNode(matcher), buttons);
+    public <T extends Node> FxRobot doubleClickOn(Matcher<T> matcher, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(pointOfVisibleNode(matcher), motion, buttons);
     }
 
     @Override
-    public <T extends Node> FxRobot doubleClickOn(Predicate<T> predicate,
-                                                  MouseButton... buttons) {
-        return doubleClickOn(pointOfVisibleNode(predicate), buttons);
+    public <T extends Node> FxRobot doubleClickOn(Predicate<T> predicate, Motion motion, MouseButton... buttons) {
+        return doubleClickOn(pointOfVisibleNode(predicate), motion, buttons);
     }
 
     //---------------------------------------------------------------------------------------------
@@ -1009,63 +1010,61 @@ public class FxRobot implements FxRobotInterface {
     //---------------------------------------------------------------------------------------------
 
     @Override
-    public FxRobot moveTo(PointQuery pointQuery) {
-        context.getMoveRobot().moveTo(pointQuery);
+    public FxRobot moveTo(PointQuery pointQuery, Motion motion) {
+        context.getMoveRobot().moveTo(pointQuery, motion);
         return this;
     }
 
     @Override
-    public FxRobot moveBy(double x,
-                          double y) {
-        context.getMoveRobot().moveBy(x, y);
+    public FxRobot moveBy(double x, double y, Motion motion) {
+        context.getMoveRobot().moveBy(x, y, motion);
         return this;
     }
 
     @Override
-    public FxRobot moveTo(double x,
-                          double y) {
-        return moveTo(point(new Point2D(x, y)));
+    public FxRobot moveTo(double x, double y, Motion motion) {
+        return moveTo(point(new Point2D(x, y)), motion);
     }
 
     @Override
-    public FxRobot moveTo(Point2D point) {
-        return moveTo(point(point));
+    public FxRobot moveTo(Point2D point, Motion motion) {
+        return moveTo(point(point), motion);
     }
 
     @Override
-    public FxRobot moveTo(Bounds bounds) {
-        return moveTo(point(bounds));
+    public FxRobot moveTo(Bounds bounds, Motion motion) {
+        return moveTo(point(bounds), motion);
     }
 
     @Override
-    public FxRobot moveTo(Node node) {
-        return moveTo(point(node));
+    public FxRobot moveTo(Node node, Motion motion) {
+        return moveTo(point(node), motion);
     }
 
     @Override
-    public FxRobot moveTo(Scene scene) {
-        return moveTo(point(scene));
+    public FxRobot moveTo(Scene scene, Motion motion) {
+        return moveTo(point(scene), motion);
     }
 
     @Override
-    public FxRobot moveTo(Window window) {
-        return moveTo(point(window));
+    public FxRobot moveTo(Window window, Motion motion) {
+        return moveTo(point(window), motion);
     }
 
     @Override
-    public FxRobot moveTo(String query) {
-        return moveTo(pointOfVisibleNode(query));
+    public FxRobot moveTo(String query, Motion motion) {
+        return moveTo(pointOfVisibleNode(query), motion);
     }
 
     @Override
     @Unstable(reason = "might change to accept all objects")
-    public <T extends Node> FxRobot moveTo(Matcher<T> matcher) {
-        return moveTo(pointOfVisibleNode(matcher));
+    public <T extends Node> FxRobot moveTo(Matcher<T> matcher, Motion motion) {
+        return moveTo(pointOfVisibleNode(matcher), motion);
     }
 
     @Override
-    public <T extends Node> FxRobot moveTo(Predicate<T> predicate) {
-        return moveTo(pointOfVisibleNode(predicate));
+    public <T extends Node> FxRobot moveTo(Predicate<T> predicate, Motion motion) {
+        return moveTo(pointOfVisibleNode(predicate), motion);
     }
 
     //---------------------------------------------------------------------------------------------

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -40,6 +40,7 @@ import javafx.stage.Window;
 
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
+import org.testfx.robot.Motion;
 import org.testfx.service.finder.NodeFinder;
 import org.testfx.service.finder.WindowFinder;
 import org.testfx.service.query.BoundsQuery;
@@ -434,7 +435,7 @@ public interface FxRobotInterface {
      * Calls a runnable on the FX application thread and waits for it and
      * consecutive events to execute. So changes to the gui triggered by the
      * runnable will be performed when returned from this method.
-     * 
+     *
      * @param runnable
      *            the runnable
      * @return this robot
@@ -445,19 +446,19 @@ public interface FxRobotInterface {
      * Calls a callable on the FX application thread and waits for it and
      * consecutive events to execute. So changes to the gui triggered by the
      * callable will be performed when returned from this method.
-     * 
+     *
      * @param callable
      *            the callable
      * @return this robot
      */
     public <T> FxRobotInterface interact(Callable<T> callable);
-    
+
     /**
      * Calls a runnable on the FX application thread and waits for it to
      * execute. It does not wait for other events on the fx application thread.
      * So changes to the gui triggered by the runnable may not be performed when
      * returned from this method.
-     * 
+     *
      * @param runnable
      *            the runnable
      * @return this robot
@@ -469,7 +470,7 @@ public interface FxRobotInterface {
      * execute. It does not wait for other events on the fx application thread.
      * So changes to the gui triggered by the callable may not be performed when
      * returned from this method.
-     * 
+     *
      * @param callable
      *            the callable
      * @return this robot
@@ -508,222 +509,445 @@ public interface FxRobotInterface {
     /**
      * Calls {@link org.testfx.robot.ClickRobot#clickOn(MouseButton...)} and returns itself for more method chaining.
      */
-    public FxRobotInterface clickOn(MouseButton... buttons);
+    FxRobotInterface clickOn(MouseButton... buttons);
+
+    /**
+     * Calls {@link org.testfx.robot.ClickRobot#clickOn(PointQuery, Motion, MouseButton...)} and returns itself for
+     * more method chaining.
+     */
+    default FxRobotInterface clickOn(PointQuery pointQuery, MouseButton... buttons) {
+        return clickOn(pointQuery, Motion.DEFAULT, buttons);
+    }
 
     /**
      * Calls {@link org.testfx.robot.ClickRobot#clickOn(PointQuery, MouseButton...)} and returns itself for more method
      * chaining.
      */
-    public FxRobotInterface clickOn(PointQuery pointQuery,
-                                    MouseButton... buttons);
+    FxRobotInterface clickOn(PointQuery pointQuery, Motion motion, MouseButton... buttons);
 
     /**
      * Calls {@link org.testfx.robot.ClickRobot#doubleClickOn(MouseButton...)} and returns itself for more method
      * chaining.
      */
-    public FxRobotInterface doubleClickOn(MouseButton... buttons);
+    FxRobotInterface doubleClickOn(MouseButton... buttons);
 
     /**
-     * Calls {@link org.testfx.robot.ClickRobot#doubleClickOn(PointQuery, MouseButton...)} and returns itself
+     * Calls {@link org.testfx.robot.ClickRobot#doubleClickOn(PointQuery, Motion, MouseButton...)} and returns itself
      * for method chaining.
      */
-    public FxRobotInterface doubleClickOn(PointQuery pointQuery,
-                                          MouseButton... buttons);
+    default FxRobotInterface doubleClickOn(PointQuery pointQuery, MouseButton... buttons) {
+        return doubleClickOn(pointQuery, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Calls {@link org.testfx.robot.ClickRobot#doubleClickOn(PointQuery, Motion, MouseButton...)} and returns itself
+     * for method chaining.
+     */
+    FxRobotInterface doubleClickOn(PointQuery pointQuery, Motion motion, MouseButton... buttons);
 
     // Convenience methods:
     /**
-     * Convenience method: Moves mouse to the given coordinates, clicks the given buttons, and returns itself for
-     * method chaining
+     * Convenience method: Moves mouse directly to the given coordinates, clicks the given buttons, and returns itself
+     * for method chaining.
      */
-    public FxRobotInterface clickOn(double x,
-                                    double y,
-                                    MouseButton... buttons);
+    default FxRobotInterface clickOn(double x, double y, MouseButton... buttons) {
+        return clickOn(x, y, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the given point, clicks the given buttons, and returns itself for method
-     * chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the given coordinates,
+     * clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface clickOn(Point2D point,
-                                    MouseButton... buttons);
+    FxRobotInterface clickOn(double x, double y, Motion motion, MouseButton... buttons);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Bounds)}, clicks the given buttons,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse directly to the given point, clicks the given buttons, and returns itself for
+     * method chaining.
      */
-    public FxRobotInterface clickOn(Bounds bounds,
-                                    MouseButton... buttons);
+    default FxRobotInterface clickOn(Point2D point, MouseButton... buttons) {
+        return clickOn(point, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Node)}, clicks the given buttons,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the given point, clicks
+     * the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface clickOn(Node node,
-                                    MouseButton... buttons);
+    FxRobotInterface clickOn(Point2D point, Motion motion, MouseButton... buttons);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Scene)}, clicks the given buttons,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Bounds)}, clicks the given
+     * buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface clickOn(Scene scene,
-                                   MouseButton... buttons);
+    default FxRobotInterface clickOn(Bounds bounds, MouseButton... buttons) {
+        return clickOn(bounds, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Window)}, clicks the given buttons,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned
+     * from {@link #point(Bounds)}, clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface clickOn(Window window,
-                                    MouseButton... buttons);
+    FxRobotInterface clickOn(Bounds bounds, Motion motion, MouseButton... buttons);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(String)}, clicks the given buttons,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Node)}, clicks the given
+     * buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface clickOn(String query,
-                                    MouseButton... buttons);
+    default FxRobotInterface clickOn(Node node, MouseButton... buttons) {
+        return clickOn(node, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Matcher)}, clicks the given buttons,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Node)}, clicks the given buttons, and returns itself for method chaining.
      */
-    public <T extends Node> FxRobotInterface clickOn(Matcher<T> matcher,
-                                                     MouseButton... buttons);
+    FxRobotInterface clickOn(Node node, Motion motion, MouseButton... buttons);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Predicate)}, clicks the given buttons,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Scene)}, clicks the given
+     * buttons, and returns itself for method chaining.
      */
-    public <T extends Node> FxRobotInterface clickOn(Predicate<T> predicate,
-                                                     MouseButton... buttons);
+    default FxRobotInterface clickOn(Scene scene, MouseButton... buttons) {
+        return clickOn(scene, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Scene)}, clicks the given buttons, and returns itself for method chaining.
+     */
+    FxRobotInterface clickOn(Scene scene, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Window)}, clicks the given
+     * buttons, and returns itself for method chaining.
+     */
+    default FxRobotInterface clickOn(Window window, MouseButton... buttons) {
+        return clickOn(window, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Window)}, clicks the given buttons, and returns itself for method chaining.
+     */
+    FxRobotInterface clickOn(Window window, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(String)}, clicks the given
+     * buttons, and returns itself for method chaining.
+     */
+    default FxRobotInterface clickOn(String query, MouseButton... buttons) {
+        return clickOn(query, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(String)}, clicks the given buttons, and returns itself for method chaining.
+     */
+    FxRobotInterface clickOn(String query, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Matcher)}, clicks the given
+     * buttons, and returns itself for method chaining.
+     */
+    default <T extends Node> FxRobotInterface clickOn(Matcher<T> matcher, MouseButton... buttons) {
+        return clickOn(matcher, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Matcher)}, clicks the given buttons, and returns itself for method chaining.
+     */
+    <T extends Node> FxRobotInterface clickOn(Matcher<T> matcher, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Predicate)}, clicks the given
+     * buttons, and returns itself for method chaining.
+     */
+    default <T extends Node> FxRobotInterface clickOn(Predicate<T> predicate, MouseButton... buttons) {
+        return clickOn(predicate, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Predicate)}, clicks the given buttons, and returns itself for method chaining.
+     */
+    <T extends Node> FxRobotInterface clickOn(Predicate<T> predicate, Motion motion, MouseButton... buttons);
 
     /**
      * Convenience method: Clicks the {@link MouseButton#SECONDARY} button and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn();
+    FxRobotInterface rightClickOn();
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link PointQuery#query()}, clicks
+     * Convenience method: Moves mouse directly to the point returned from {@link PointQuery#query()}, clicks
      * the {@link MouseButton#SECONDARY} button and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn(PointQuery pointQuery);
+    default FxRobotInterface rightClickOn(PointQuery pointQuery) {
+        return rightClickOn(pointQuery, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the given coordinates, clicks the {@link MouseButton#SECONDARY} button,
-     * and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link PointQuery#query()}, clicks the {@link MouseButton#SECONDARY} button and returns itself for method
+     * chaining.
      */
-    public FxRobotInterface rightClickOn(double x,
-                                         double y);
+    FxRobotInterface rightClickOn(PointQuery pointQuery, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the given coordinates, clicks the {@link MouseButton#SECONDARY}
+     * button, and returns itself for method chaining.
+     */
+    default FxRobotInterface rightClickOn(double x, double y) {
+        return rightClickOn(x, y, Motion.DEFAULT);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the given coordinates,
+     * clicks the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
+     */
+    FxRobotInterface rightClickOn(double x, double y, Motion motion);
 
     /**
      * Convenience method: Moves mouse to the point returned from {@link #point(Point2D)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn(Point2D point);
+    default FxRobotInterface rightClickOn(Point2D point) {
+        return rightClickOn(point, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Bounds)}, clicks
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Point2D)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method
+     * chaining.
+     */
+    FxRobotInterface rightClickOn(Point2D point, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Bounds)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn(Bounds bounds);
+    default FxRobotInterface rightClickOn(Bounds bounds) {
+        return rightClickOn(bounds, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Node)}, clicks
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Bounds)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
+     */
+    FxRobotInterface rightClickOn(Bounds bounds, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Node)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn(Node node);
+    default FxRobotInterface rightClickOn(Node node) {
+        return rightClickOn(node, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Scene)}, clicks
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Node)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
+     */
+    FxRobotInterface rightClickOn(Node node, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Scene)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn(Scene scene);
+    default FxRobotInterface rightClickOn(Scene scene) {
+        return rightClickOn(scene, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Window)}, clicks
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Scene)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
+     */
+    FxRobotInterface rightClickOn(Scene scene, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Window)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn(Window window);
+    default FxRobotInterface rightClickOn(Window window) {
+        return rightClickOn(window, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(String)}, clicks
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Window)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
+     */
+    FxRobotInterface rightClickOn(Window window, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(String)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public FxRobotInterface rightClickOn(String query);
+    default FxRobotInterface rightClickOn(String query) {
+        return rightClickOn(query, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Matcher)}, clicks
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(String)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
+     */
+    FxRobotInterface rightClickOn(String query, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Matcher)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public <T extends Node> FxRobotInterface rightClickOn(Matcher<T> matcher);
+    default <T extends Node> FxRobotInterface rightClickOn(Matcher<T> matcher) {
+        return rightClickOn(matcher, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Predicate)}, clicks
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Matcher)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method
+     * chaining.
+     */
+    <T extends Node> FxRobotInterface rightClickOn(Matcher<T> matcher, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Predicate)}, clicks
      * the {@link MouseButton#SECONDARY} button, and returns itself for method chaining.
      */
-    public <T extends Node> FxRobotInterface rightClickOn(Predicate<T> predicate);
+    default <T extends Node> FxRobotInterface rightClickOn(Predicate<T> predicate) {
+        return rightClickOn(predicate, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(double, double)}, double
-     * clicks the given buttons, and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Predicate)}, clicks the {@link MouseButton#SECONDARY} button, and returns itself for method
+     * chaining.
      */
-    public FxRobotInterface doubleClickOn(double x,
-                                          double y,
-                                          MouseButton... buttons);
+    <T extends Node> FxRobotInterface rightClickOn(Predicate<T> predicate, Motion motion);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Point2D)}, double
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(double, double)}, double
      * clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface doubleClickOn(Point2D point,
-                                          MouseButton... buttons);
+    default FxRobotInterface doubleClickOn(double x, double y, MouseButton... buttons) {
+        return doubleClickOn(x, y, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Bounds)}, double
-     * clicks the given buttons, and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(double, double)}, double clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface doubleClickOn(Bounds bounds,
-                                          MouseButton... buttons);
+    FxRobotInterface doubleClickOn(double x, double y, Motion motion, MouseButton... buttons);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Node)}, double
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Point2D)}, double
      * clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface doubleClickOn(Node node,
-                                          MouseButton... buttons);
+    default FxRobotInterface doubleClickOn(Point2D point, MouseButton... buttons) {
+        return doubleClickOn(point, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Scene)}, double
-     * clicks the given buttons, and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Point2D)}, double clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface doubleClickOn(Scene scene,
-                                          MouseButton... buttons);
+    FxRobotInterface doubleClickOn(Point2D point, Motion motion, MouseButton... buttons);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Window)}, double
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Bounds)}, double
      * clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface doubleClickOn(Window window,
-                                          MouseButton... buttons);
+    default FxRobotInterface doubleClickOn(Bounds bounds, MouseButton... buttons) {
+        return doubleClickOn(bounds, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(String)}, double
-     * clicks the given buttons, and returns itself for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Bounds)}, double clicks the given buttons, and returns itself for method chaining.
      */
-    public FxRobotInterface doubleClickOn(String query,
-                                          MouseButton... buttons);
+    FxRobotInterface doubleClickOn(Bounds bounds, Motion motion, MouseButton... buttons);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Matcher)}, double
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Node)}, double
      * clicks the given buttons, and returns itself for method chaining.
      */
-    public <T extends Node> FxRobotInterface doubleClickOn(Matcher<T> matcher,
-                                                           MouseButton... buttons);
+    default FxRobotInterface doubleClickOn(Node node, MouseButton... buttons) {
+        return doubleClickOn(node, Motion.DEFAULT, buttons);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Predicate)}, double
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Node)}, double clicks the given buttons, and returns itself for method chaining.
+     */
+    FxRobotInterface doubleClickOn(Node node, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Scene)}, double
      * clicks the given buttons, and returns itself for method chaining.
      */
-    public <T extends Node> FxRobotInterface doubleClickOn(Predicate<T> predicate,
-                                                           MouseButton... buttons);
+    default FxRobotInterface doubleClickOn(Scene scene, MouseButton... buttons) {
+        return doubleClickOn(scene, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Scene)}, double clicks the given buttons, and returns itself for method chaining.
+     */
+    FxRobotInterface doubleClickOn(Scene scene, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Window)}, double
+     * clicks the given buttons, and returns itself for method chaining.
+     */
+    default FxRobotInterface doubleClickOn(Window window, MouseButton... buttons) {
+        return doubleClickOn(window, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Window)}, double clicks the given buttons, and returns itself for method chaining.
+     */
+    FxRobotInterface doubleClickOn(Window window, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(String)}, double
+     * clicks the given buttons, and returns itself for method chaining.
+     */
+    default FxRobotInterface doubleClickOn(String query, MouseButton... buttons) {
+        return doubleClickOn(query, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(String)}, double clicks the given buttons, and returns itself for method chaining.
+     */
+    FxRobotInterface doubleClickOn(String query, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Matcher)}, double
+     * clicks the given buttons, and returns itself for method chaining.
+     */
+    default <T extends Node> FxRobotInterface doubleClickOn(Matcher<T> matcher, MouseButton... buttons) {
+        return doubleClickOn(matcher, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Matcher)}, double clicks the given buttons, and returns itself for method chaining.
+     */
+    <T extends Node> FxRobotInterface doubleClickOn(Matcher<T> matcher, Motion motion, MouseButton... buttons);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Predicate)}, double
+     * clicks the given buttons, and returns itself for method chaining.
+     */
+    default <T extends Node> FxRobotInterface doubleClickOn(Predicate<T> predicate, MouseButton... buttons) {
+        return doubleClickOn(predicate, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Predicate)}, double clicks the given buttons, and returns itself for method chaining.
+     */
+    <T extends Node> FxRobotInterface doubleClickOn(Predicate<T> predicate,
+                                                    Motion motion,
+                                                    MouseButton... buttons);
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR DRAGGING.
@@ -924,70 +1148,155 @@ public interface FxRobotInterface {
     /**
      * Calls {@link org.testfx.robot.MoveRobot#moveTo(PointQuery)} and returns itself for more method chaining.
      */
-    public FxRobotInterface moveTo(PointQuery pointQuery);
+    default FxRobotInterface moveTo(PointQuery pointQuery) {
+        return moveTo(pointQuery, Motion.DEFAULT);
+    }
+
+    /**
+     * Calls {@link org.testfx.robot.MoveRobot#moveTo(PointQuery, Motion)} and returns itself for more method chaining.
+     */
+    FxRobotInterface moveTo(PointQuery pointQuery, Motion motion);
 
     /**
      * Calls {@link org.testfx.robot.MoveRobot#moveBy(double, double)} and returns itself for more method chaining.
      */
-    public FxRobotInterface moveBy(double x,
-                                   double y);
+    default FxRobotInterface moveBy(double x, double y) {
+        return moveBy(x, y, Motion.DEFAULT);
+    }
+
+    /**
+     * Calls {@link org.testfx.robot.MoveRobot#moveBy(double, double, Motion)} and returns itself for more method
+     * chaining.
+     */
+    FxRobotInterface moveBy(double x, double y, Motion motion);
 
     // Convenience methods:
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(double, double)} and returns itself
-     * for method chaining.
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(double, double)} and returns
+     * itself for method chaining.
      */
-    public FxRobotInterface moveTo(double x,
-                                   double y);
+    default FxRobotInterface moveTo(double x, double y) {
+        return moveTo(x, y, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Point2D)} and returns itself
-     * for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(double, double)} and returns itself for method chaining.
      */
-    public FxRobotInterface moveTo(Point2D point);
+    FxRobotInterface moveTo(double x, double y, Motion motion);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Bounds)} and returns itself
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Point2D)} and returns itself
      * for method chaining.
      */
-    public FxRobotInterface moveTo(Bounds bounds);
+    default FxRobotInterface moveTo(Point2D point) {
+        return moveTo(point, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Node)} and returns itself
-     * for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Point2D)} and returns itself for method chaining.
      */
-    public FxRobotInterface moveTo(Node node);
+    FxRobotInterface moveTo(Point2D point, Motion motion);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Scene)} and returns itself
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Bounds)} and returns itself
      * for method chaining.
      */
-    public FxRobotInterface moveTo(Scene scene);
+    default FxRobotInterface moveTo(Bounds bounds) {
+        return moveTo(bounds, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Window)} and returns itself
-     * for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Bounds)} and returns itself for method chaining.
      */
-    public FxRobotInterface moveTo(Window window);
+    FxRobotInterface moveTo(Bounds bounds, Motion motion);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(String)} and returns itself
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Node)} and returns itself
      * for method chaining.
      */
-    public FxRobotInterface moveTo(String query);
+    default FxRobotInterface moveTo(Node node) {
+        return moveTo(node, Motion.DEFAULT);
+    }
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Matcher)} and returns itself
-     * for method chaining.
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Node)} and returns itself for method chaining.
      */
-    public <T extends Node> FxRobotInterface moveTo(Matcher<T> matcher);
+    FxRobotInterface moveTo(Node node, Motion motion);
 
     /**
-     * Convenience method: Moves mouse to the point returned from {@link #point(Predicate)} and returns itself
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Scene)} and returns itself
      * for method chaining.
      */
-    public <T extends Node> FxRobotInterface moveTo(Predicate<T> predicate);
+    default FxRobotInterface moveTo(Scene scene) {
+        return moveTo(scene, Motion.DEFAULT);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Scene)} and returns itself for method chaining.
+     */
+    FxRobotInterface moveTo(Scene scene, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Window)} and returns itself
+     * for method chaining.
+     */
+    default FxRobotInterface moveTo(Window window) {
+        return moveTo(window, Motion.DEFAULT);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Window)} and returns itself for method chaining.
+     */
+    FxRobotInterface moveTo(Window window, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(String)} and returns itself
+     * for method chaining.
+     */
+    default FxRobotInterface moveTo(String query) {
+        return moveTo(query, Motion.DEFAULT);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(String)} and returns itself for method chaining.
+     */
+    FxRobotInterface moveTo(String query, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Matcher)} and returns itself
+     * for method chaining.
+     */
+    default <T extends Node> FxRobotInterface moveTo(Matcher<T> matcher) {
+        return moveTo(matcher, Motion.DEFAULT);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Matcher)} and returns itself for method chaining.
+     */
+    <T extends Node> FxRobotInterface moveTo(Matcher<T> matcher, Motion motion);
+
+    /**
+     * Convenience method: Moves mouse directly to the point returned from {@link #point(Predicate)} and returns itself
+     * for method chaining.
+     */
+    default <T extends Node> FxRobotInterface moveTo(Predicate<T> predicate) {
+        return moveTo(predicate, Motion.DEFAULT);
+    }
+
+    /**
+     * Convenience method: Moves mouse using the given {@code motion} (see: {@link Motion} to the point returned from
+     * {@link #point(Predicate)} and returns itself for method chaining.
+     */
+    <T extends Node> FxRobotInterface moveTo(Predicate<T> predicate, Motion motion);
 
     //---------------------------------------------------------------------------------------------
     // METHODS FOR SCROLLING.

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/ClickRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/ClickRobot.java
@@ -27,31 +27,54 @@ public interface ClickRobot {
      *
      * @param buttons the mouse buttons to click
      */
-    public void clickOn(MouseButton... buttons);
+    void clickOn(MouseButton... buttons);
 
     /**
-     * Moves mouse to {@link PointQuery#query()} and clicks whatever is under it.
+     * Moves mouse directly to {@link PointQuery#query()} and clicks whatever is under it.
      *
      * @param pointQuery the pointQuery
      * @param buttons the mouse buttons to click
      */
-    public void clickOn(PointQuery pointQuery,
-                        MouseButton... buttons);
+    default void clickOn(PointQuery pointQuery, MouseButton... buttons) {
+        clickOn(pointQuery, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Moves mouse to {@link PointQuery#query()} using the specified {@code motion}
+     * (see: {@link Motion}) and clicks whatever is under it.
+     *
+     * @param pointQuery the pointQuery
+     * @param motion the type of motion to use for movement
+     * @param buttons the mouse buttons to click
+     */
+    void clickOn(PointQuery pointQuery, Motion motion, MouseButton... buttons);
 
     /**
      * Double-clicks whatever is under the mouse.
      *
      * @param buttons the mouse buttons to click
      */
-    public void doubleClickOn(MouseButton... buttons);
+    void doubleClickOn(MouseButton... buttons);
 
     /**
-     * Moves mouse to {@link PointQuery#query()} and double-clicks whatever is under it.
+     * Moves mouse directly to {@link PointQuery#query()} and double-clicks whatever
+     * is under it.
      *
      * @param pointQuery the pointQuery
      * @param buttons the mouse buttons to click
      */
-    public void doubleClickOn(PointQuery pointQuery,
-                              MouseButton... buttons);
+    default void doubleClickOn(PointQuery pointQuery, MouseButton... buttons) {
+        doubleClickOn(pointQuery, Motion.DEFAULT, buttons);
+    }
+
+    /**
+     * Moves mouse to {@link PointQuery#query()} using the specified {@code motion}
+     * (see: {@link Motion} and double-clicks whatever is under it.
+     *
+     * @param pointQuery the pointQuery
+     * @param motion the type of motion to use for movement
+     * @param buttons the mouse buttons to click
+     */
+    void doubleClickOn(PointQuery pointQuery, Motion motion, MouseButton... buttons);
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/Motion.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/Motion.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+
+package org.testfx.robot;
+
+/**
+ * Enumeration holding the three simplest types of motion between two 2D points
+ * a = (x₁, y₁) and b = (x₂, y₂). Given any two points in the plane we can construct
+ * a right-angled triangle where the hypotenuse is the straight-line between a and b.
+ * <p>
+ * <pre><code>
+ * +------------------------> +x
+ * |    d        b
+ * |    |        *
+ * |    |      * *
+ * |    |    *   *
+ * |    |  *     *
+ * |    |*       *
+ * |    **********
+ * |    a        c
+ * |
+ * v
+ * +y
+ * </code></pre>
+ * <p>
+ * Traveling in a straight-line between a and b (that is, tracing the hypotenuse) is
+ * {@code DIRECT}. Traveling first from a to c and then from c to b is {@code HORIZONTAL_FIRST}.
+ * Traveling first from a to d and then from d to b is {@code VERTICAL_FIRST}. {@code DIRECT}
+ * means that no specific type of motion was explicitly requested.
+ */
+public enum Motion {
+    DEFAULT,
+    DIRECT,
+    HORIZONTAL_FIRST,
+    VERTICAL_FIRST,
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/MoveRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/MoveRobot.java
@@ -21,20 +21,43 @@ import org.testfx.service.query.PointQuery;
 public interface MoveRobot {
 
     /**
-     * Moves mouse to {@link PointQuery#query()}.
+     * Moves mouse directly to {@link PointQuery#query()}.
      *
      * @param pointQuery the pointQuery
      */
-    public void moveTo(PointQuery pointQuery);
+    default void moveTo(PointQuery pointQuery) {
+        moveTo(pointQuery, Motion.DEFAULT);
+    }
 
     /**
-     * Moves mouse from current location to new location by {@code x} on the horizontal axis and by {@code y} on
-     * the vertical axis.
+     * Moves mouse to {@link PointQuery#query()} using the specified {@code motion}
+     * (see: {@link Motion}) and clicks whatever is under it.
+     *
+     * @param pointQuery the pointQuery
+     * @param motion the type of motion to use for movement
+     */
+    void moveTo(PointQuery pointQuery, Motion motion);
+
+    /**
+     * Moves mouse directly from current location to new location by {@code x} on the
+     * horizontal axis and by {@code y} on the vertical axis.
      *
      * @param x the amount by which to move the mouse horizontally
      * @param y the amount by which to move the mouse vertically
      */
-    public void moveBy(double x,
-                       double y);
+    default void moveBy(double x, double y) {
+        moveBy(x, y, Motion.DEFAULT);
+    }
+
+    /**
+     * Moves mouse from current location to new location by {@code x} using the given
+     * {@code motion} (see: {@link Motion} on the horizontal axis and by {@code y} on
+     * the vertical axis.
+     *
+     * @param x the amount by which to move the mouse horizontally
+     * @param y the amount by which to move the mouse vertically
+     * @param motion the type of motion to use for movement
+     */
+    void moveBy(double x, double y, Motion motion);
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
@@ -20,6 +20,7 @@ import javafx.scene.input.MouseButton;
 
 import org.testfx.api.annotation.Unstable;
 import org.testfx.robot.ClickRobot;
+import org.testfx.robot.Motion;
 import org.testfx.robot.MouseRobot;
 import org.testfx.robot.MoveRobot;
 import org.testfx.robot.SleepRobot;
@@ -46,9 +47,7 @@ public class ClickRobotImpl implements ClickRobot {
     // CONSTRUCTORS.
     //---------------------------------------------------------------------------------------------
 
-    public ClickRobotImpl(MouseRobot mouseRobot,
-                          MoveRobot moveRobot,
-                          SleepRobot sleepRobot) {
+    public ClickRobotImpl(MouseRobot mouseRobot, MoveRobot moveRobot, SleepRobot sleepRobot) {
         this.mouseRobot = mouseRobot;
         this.moveRobot = moveRobot;
         this.sleepRobot = sleepRobot;
@@ -65,9 +64,8 @@ public class ClickRobotImpl implements ClickRobot {
     }
 
     @Override
-    public void clickOn(PointQuery pointQuery,
-                        MouseButton... buttons) {
-        moveRobot.moveTo(pointQuery);
+    public void clickOn(PointQuery pointQuery, Motion motion, MouseButton... buttons) {
+        moveRobot.moveTo(pointQuery, motion);
         clickOn(buttons);
     }
 
@@ -79,9 +77,9 @@ public class ClickRobotImpl implements ClickRobot {
     }
 
     @Override
-    public void doubleClickOn(PointQuery pointQuery,
-                              MouseButton... buttons) {
-        clickOn(pointQuery, buttons);
+    public void doubleClickOn(PointQuery pointQuery, Motion motion, MouseButton... buttons) {
+        moveRobot.moveTo(pointQuery, motion);
+        clickOn(buttons);
         clickOn(buttons);
         sleepRobot.sleep(SLEEP_AFTER_DOUBLE_CLICK_IN_MILLIS);
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
@@ -66,7 +66,7 @@ public class PointLocatorImpl implements PointLocator {
     @Override
     public PointQuery point(Node node) {
         Callable<Bounds> callable = callableBoundsFor(node);
-        return new CallableBoundsPointQuery(callable);
+        return new CallableBoundsPointQuery(callable, node);
     }
 
     @Override

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
@@ -16,8 +16,12 @@
  */
 package org.testfx.service.query;
 
+import java.util.Optional;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
+
+import org.testfx.robot.Motion;
 
 /**
  * Used to calculate a position within a given {@link javafx.geometry.Bounds}.
@@ -83,8 +87,12 @@ public interface PointQuery {
 
     /**
      *
-     * @return a position that offsets the relative position within the initial {@code Bounds} object that is calculated
+     * @return a position that offsets the relative position within the initial {@code Bounds}object that is calculated
      * via {@link #getPosition()} by {@link #getOffset()} amount.
      */
     public Point2D query();
+
+    PointQuery onNode(Node node);
+
+    Optional<Motion> queryMotion();
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/CallableBoundsPointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/CallableBoundsPointQuery.java
@@ -19,6 +19,7 @@ package org.testfx.service.query.impl;
 import java.util.concurrent.Callable;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
+import javafx.scene.Node;
 
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.query.PointQuery;
@@ -37,7 +38,12 @@ public class CallableBoundsPointQuery extends PointQueryBase {
     //---------------------------------------------------------------------------------------------
 
     public CallableBoundsPointQuery(Callable<Bounds> callableBounds) {
+        this(callableBounds, null);
+    }
+
+    public CallableBoundsPointQuery(Callable<Bounds> callableBounds, Node node) {
         this.callableBounds = callableBounds;
+        this.node = node;
     }
 
     //---------------------------------------------------------------------------------------------

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
@@ -16,10 +16,13 @@
  */
 package org.testfx.service.query.impl;
 
+import java.util.Optional;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 
 import org.testfx.api.annotation.Unstable;
+import org.testfx.robot.Motion;
 import org.testfx.service.query.PointQuery;
 import org.testfx.util.PointQueryUtils;
 
@@ -33,6 +36,8 @@ public abstract class PointQueryBase implements PointQuery {
     private Point2D position = new Point2D(0, 0);
 
     private Point2D offset = new Point2D(0, 0);
+
+    protected Node node;
 
     //---------------------------------------------------------------------------------------------
     // METHODS.
@@ -80,4 +85,22 @@ public abstract class PointQueryBase implements PointQuery {
         return atOffset(new Point2D(offsetX, offsetY));
     }
 
+    @Override
+    public PointQuery onNode(Node node) {
+        this.node = node;
+        return this;
+    }
+
+    @Override
+    public Optional<Motion> queryMotion() {
+        if (node == null) {
+            return Optional.empty();
+        }
+        switch (node.getClass().getSimpleName()) {
+            case "MenuItemContainer":
+                return Optional.of(Motion.VERTICAL_FIRST);
+            default:
+                return Optional.of(Motion.DEFAULT);
+        }
+    }
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.cases.integration;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.robot.Motion;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class MenuBarTest {
+
+    FxRobot fxRobot = new FxRobot();
+    Menu editMenu;
+    CountDownLatch newMenuShownLatch = new CountDownLatch(1);
+    CountDownLatch editMenuShownLatch = new CountDownLatch(1);
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupStage(stage -> {
+            Menu fileMenu = new Menu("File");
+            fileMenu.setId("fileMenu");
+
+            MenuItem newItem = new MenuItem("New");
+            newItem.setId("newItem");
+            newItem.setOnAction((actionEvent) -> newMenuShownLatch.countDown());
+            fileMenu.getItems().add(newItem);
+
+            MenuItem saveAsItem = new MenuItem("Save As..............................");
+            saveAsItem.setId("saveAsItem");
+            saveAsItem.setAccelerator(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN,
+                    KeyCombination.CONTROL_DOWN));
+            fileMenu.getItems().add(saveAsItem);
+
+            editMenu = new Menu("Edit");
+            editMenu.setId("editMenu");
+
+            MenuItem cutItem = new MenuItem("cut");
+            cutItem.setId("cutItem");
+            editMenu.getItems().add(cutItem);
+
+            MenuBar menuBar = new MenuBar(fileMenu, editMenu);
+            StackPane pane = new StackPane(new VBox(menuBar));
+            pane.setAlignment(Pos.CENTER);
+            Scene scene = new Scene(pane, 300, 400);
+            stage.setScene(scene);
+            stage.show();
+        });
+    }
+
+    @Test
+    public void should_move_vertically_first() throws Exception {
+        // When moving directly from "#fileMenu" to "#newItem" (i.e. diagonally) the {@code editMenu}
+        // is activated because of the width of {@code fileMenu}. However we detect this scenario and
+        // instead move vertically (along the y-axis) first, and then horizontally (along the x-axis).
+        // see: https://github.com/TestFX/TestFX/issues/309
+
+        // First we show that it is indeed the case that {@code editMenu} is triggered when moving directly:
+        editMenu.setOnShown(event -> editMenuShownLatch.countDown());
+        fxRobot.clickOn("#fileMenu").clickOn("#newItem", Motion.DIRECT);
+        assertThat(editMenuShownLatch.await(3, TimeUnit.SECONDS), is(true));
+        assertThat(newMenuShownLatch.getCount(), is(1L));
+
+        // Next we show that calling the "clickOn" method without specifying the type of motion automatically
+        // uses Motion.VERTICAL_FIRST because "#newItem" is a MenuItem.
+        fxRobot.clickOn("#fileMenu").clickOn("#newItem");
+        assertThat(newMenuShownLatch.await(3, TimeUnit.SECONDS), is(true));
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
@@ -21,6 +21,7 @@ import javafx.scene.input.MouseButton;
 import org.junit.Before;
 import org.junit.Test;
 import org.testfx.robot.ClickRobot;
+import org.testfx.robot.Motion;
 import org.testfx.robot.MouseRobot;
 import org.testfx.robot.MoveRobot;
 import org.testfx.robot.SleepRobot;
@@ -99,7 +100,7 @@ public final class ClickRobotImplTest {
         clickRobot.clickOn(pointQuery, MouseButton.PRIMARY);
 
         // then:
-        verify(moveRobot, times(1)).moveTo(eq(pointQuery));
+        verify(moveRobot, times(1)).moveTo(eq(pointQuery), eq(Motion.DEFAULT));
         verify(mouseRobot, times(1)).pressNoWait(eq(MouseButton.PRIMARY));
         verify(mouseRobot, times(1)).release(eq(MouseButton.PRIMARY));
         verifyNoMoreInteractions(moveRobot, mouseRobot);
@@ -145,7 +146,7 @@ public final class ClickRobotImplTest {
         clickRobot.doubleClickOn(pointQuery, MouseButton.PRIMARY);
 
         // then:
-        verify(moveRobot, times(1)).moveTo(eq(pointQuery));
+        verify(moveRobot, times(1)).moveTo(eq(pointQuery), eq(Motion.DEFAULT));
         verify(mouseRobot, times(2)).pressNoWait(eq(MouseButton.PRIMARY));
         verify(mouseRobot, times(2)).release(eq(MouseButton.PRIMARY));
         verify(sleepRobot, times(1)).sleep(anyLong());


### PR DESCRIPTION
Allow the user to explicitly request a certain type of motion
using the API. Automatically detect when certain types of motion
should be used and if the user has not explicitly requested a type
of motion use the most appropriate one.

For example when moving to a MenuItem the mouse should move vertically
(along the y-axis) first and the horizontally so that adjacent menus
are not activated.

Fixes #305.