### PR TITLE
(fix) Pass along application parameters.

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -5,7 +5,11 @@ echo "which java: $(which java)"
 echo "java_home: $(command -v "/usr/libexec/java_home")"
 ./gradlew --version
 ulimit -c unlimited -S
-./gradlew build --info
+if [ "$TRAVIS_JDK_VERSION" == "oraclejdk9" ]; then
+  ./gradlew build --debug --stacktrace
+else
+  ./gradlew build --info
+fi
 RESULT=$?
 if [[ ${RESULT} -ne 0 ]]; then
   JVMCRASH="$(find . -name "hs_err_pid*.log" -type f -print | head -n 1)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 sudo: false
 
-# install the newest java.
 addons:
   apt:
     packages:
@@ -13,6 +12,7 @@ addons:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - $HOME/.gradle/caches/
@@ -36,7 +36,7 @@ matrix:
       jdk: oraclejdk9
       env:
         - USE_FRAMEBUFFER=true
-        - _JAVA_OPTIONS="--add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED"
+        - _JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-exports-private java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED --permit-illegal-access"
     - os: osx
       osx_image: xcode8.2
       env:
@@ -46,15 +46,13 @@ matrix:
       osx_image: xcode8.2
       env: _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
   allow_failures:
+    - jdk: oraclejdk9
     - env:
       - USE_FRAMEBUFFER=false
       - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
     - env:
       - OSX_HEADLESS=false
       - _JAVA_OPTIONS="-Dprism.order=sw"
-    - env:
-      - USE_FRAMEBUFFER=true
-      - _JAVA_OPTIONS="--add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED"
 
 
 before_script:

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.testfx.api.FxToolkit;
 import org.testfx.cases.TestCaseBase;
+import org.testfx.util.WaitForAsyncUtils;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -125,6 +126,7 @@ public class DragAndDropTest extends TestCaseBase {
         // when:
         drag("R3");
         dropTo("L2");
+        WaitForAsyncUtils.waitForFxEvents();
 
         // then:
         verifyThat(leftListView.getItems(), hasSize(4));
@@ -138,6 +140,7 @@ public class DragAndDropTest extends TestCaseBase {
         // when:
         drag("L3");
         dropTo("L2");
+        WaitForAsyncUtils.waitForFxEvents();
 
         // then:
         verifyThat(leftListView.getItems(), hasSize(3));

--- a/subprojects/testfx-core/src/test/java/org/testfx/toolkit/impl/ToolkitServiceImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/toolkit/impl/ToolkitServiceImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.testfx.toolkit.impl;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -35,6 +36,7 @@ import org.testfx.toolkit.PrimaryStageFuture;
 import org.testfx.toolkit.ToolkitService;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testfx.util.WaitForAsyncUtils.sleep;
 import static org.testfx.util.WaitForAsyncUtils.waitFor;
@@ -58,11 +60,11 @@ public class ToolkitServiceImplTest {
         PrimaryStageFuture primaryStageFuture = PrimaryStageApplication.PRIMARY_STAGE_FUTURE;
         Class<? extends Application> toolkitApplication = PrimaryStageApplication.class;
         toolkitService = new ToolkitServiceImpl(
-            new ApplicationLauncherImpl(), new ApplicationServiceImpl()
+                new ApplicationLauncherImpl(), new ApplicationServiceImpl()
         );
 
         primaryStage = waitFor(10, TimeUnit.SECONDS,
-            toolkitService.setupPrimaryStage(primaryStageFuture, toolkitApplication)
+                toolkitService.setupPrimaryStage(primaryStageFuture, toolkitApplication)
         );
     }
 
@@ -91,18 +93,19 @@ public class ToolkitServiceImplTest {
     public void should_construct_application() throws Exception {
         printCurrentThreadName("should_construct_application()");
         Application application = waitFor(5, TimeUnit.SECONDS,
-            toolkitService.setupApplication(() -> primaryStage, FixtureApplication.class)
+                toolkitService.setupApplication(() -> primaryStage, FixtureApplication.class)
         );
 
         sleep(2, TimeUnit.SECONDS);
         assertThat(application, instanceOf(FixtureApplication.class));
+        assertThat(application.getParameters().getNamed(), notNullValue());
     }
 
     @Test
     public void should_construct_scene() throws Exception {
         printCurrentThreadName("should_construct_scene");
         Scene scene = waitFor(5, TimeUnit.SECONDS,
-            toolkitService.setupScene(primaryStage, () -> new FixtureScene())
+                toolkitService.setupScene(primaryStage, () -> new FixtureScene())
         );
 
         sleep(2, TimeUnit.SECONDS);
@@ -131,6 +134,11 @@ public class ToolkitServiceImplTest {
         @Override
         public void stop() throws Exception {
             printCurrentThreadName("Application#stop()");
+        }
+
+        private String getApplicationParameter(String parameterName) {
+            Map<String, String> applicationParameters = getParameters().getNamed();
+            return applicationParameters.get(parameterName);
         }
     }
 


### PR DESCRIPTION
However do it in a way that avoids compile-time dependencies on the
JavaFX private API for Java 9 compatibility. This is accomplished
via the Reflection API.

Support for registering parameters was removed in e910aeed0089df - this
brings it back.

Fixes #380