### PR TITLE
Prevent blocking JVM shutdown by using daemon threads

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -26,8 +26,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -94,7 +96,7 @@ public class WaitForAsyncUtils {
     // STATIC FIELDS.
     // ---------------------------------------------------------------------------------------------
 
-    private static ExecutorService executorService = Executors.newCachedThreadPool();
+    private static ExecutorService executorService = Executors.newCachedThreadPool(new DefaultThreadFactory());
     private static Queue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
 
     /**
@@ -682,4 +684,15 @@ public class WaitForAsyncUtils {
 
     }
 
+    private static class DefaultThreadFactory implements ThreadFactory {
+        private final AtomicInteger threadCount = new AtomicInteger(1);
+
+        @Override
+        public Thread newThread(Runnable r) {
+            final Thread thread = new Thread(r);
+            thread.setDaemon(true);
+            thread.setName(String.format("testfx-async-pool-thread-%d", threadCount.getAndIncrement()));
+            return thread;
+        }
+    }
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
@@ -311,6 +311,13 @@ public class WaitForAsyncUtilsTest {
         WaitForAsyncUtils.waitFor(250, MILLISECONDS, property);
     }
 
+    @Test
+    public void daemonThreads() throws Exception {
+        final Future<Thread> future = WaitForAsyncUtils.async(Thread::currentThread);
+        final Thread thread = future.get();
+        assertThat(thread.isDaemon(), Matchers.is(true));
+    }
+
     protected void waitForException(Future<?> f) throws InterruptedException {
         Thread.sleep(50);
         assertTrue(f.isDone());


### PR DESCRIPTION
Resolves #389. Spawned thread names will also be in the form 'testfx-async-pool-thread-%d'.