### PR TITLE
(feature) Add Spock variant of TestFX

### DIFF
--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationAdapter.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationAdapter.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.spock;
+
+import javafx.application.Application;
+import javafx.stage.Stage;
+
+public final class ApplicationAdapter extends Application implements ApplicationFixture {
+
+    //---------------------------------------------------------------------------------------------
+    // PRIVATE FIELDS.
+    //---------------------------------------------------------------------------------------------
+
+    private ApplicationFixture applicationFixture;
+
+    //---------------------------------------------------------------------------------------------
+    // CONSTRUCTORS.
+    //---------------------------------------------------------------------------------------------
+
+    ApplicationAdapter(ApplicationFixture applicationFixture) {
+        this.applicationFixture = applicationFixture;
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    public void init()
+            throws Exception {
+        applicationFixture.init();
+    }
+
+    @Override
+    public void start(Stage primaryStage)
+            throws Exception {
+        applicationFixture.start(primaryStage);
+    }
+
+    @Override
+    public void stop()
+            throws Exception {
+        applicationFixture.stop();
+    }
+}

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationFixture.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationFixture.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.spock;
+
+import javafx.stage.Stage;
+
+public interface ApplicationFixture {
+
+    void init() throws Exception;
+
+    void start(Stage stage) throws Exception;
+
+    void stop() throws Exception;
+
+}

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationSpec.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationSpec.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.spock
+
+import javafx.application.Application
+import javafx.application.HostServices
+import javafx.application.Preloader
+import javafx.scene.input.KeyCode
+import javafx.scene.input.MouseButton
+import javafx.stage.Stage
+import org.testfx.api.FxRobot
+import org.testfx.api.FxToolkit
+import org.testfx.api.annotation.Unstable
+import spock.lang.Specification
+
+abstract class ApplicationSpec extends Specification implements ApplicationFixture {
+
+    @Delegate
+    private final FxRobot robot = new FxRobot()
+
+    //---------------------------------------------------------------------------------------------
+    // STATIC METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Unstable(reason = "is missing apidocs")
+    public static void launch(Class<? extends Application> appClass,
+                              String... appArgs) throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.setupApplication(appClass, appArgs);
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    def setup() {
+        internalBefore()
+    }
+
+    def cleanup() {
+        internalAfter()
+    }
+
+    @Unstable(reason = "is missing apidocs")
+    public final void internalBefore()
+            throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.setupApplication( { new ApplicationAdapter(this) });
+    }
+
+    @Unstable(reason = "is missing apidocs")
+    public final void internalAfter()
+            throws Exception {
+        // release all keys
+        release(new KeyCode[0]);
+        // release all mouse buttons
+        release(new MouseButton[0]);
+        FxToolkit.cleanupApplication(new ApplicationAdapter(this));
+    }
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public void init()
+            throws Exception {}
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public abstract void start(Stage stage)
+            throws Exception;
+
+    @Override
+    @Unstable(reason = "is missing apidocs")
+    public void stop()
+            throws Exception {}
+
+    @Deprecated
+    public final HostServices getHostServices() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    public final Application.Parameters getParameters() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    public final void notifyPreloader(Preloader.PreloaderNotification notification) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.cases.acceptance
+
+import javafx.application.Application
+import javafx.scene.Scene
+import javafx.scene.control.Button
+import javafx.scene.layout.StackPane
+import javafx.stage.Stage
+import org.testfx.api.FxRobot
+import org.testfx.api.FxToolkit
+import org.testfx.framework.spock.ApplicationSpec
+import spock.lang.Specification
+
+import static org.testfx.api.FxAssert.verifyThat
+import static org.testfx.matcher.base.NodeMatchers.hasText
+
+public class ApplicationLaunchSpec extends Specification {
+
+    @Delegate
+    private final FxRobot robot = new FxRobot()
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURES.
+    //---------------------------------------------------------------------------------------------
+
+    public static class DemoApplication extends Application {
+        @Override
+        public void start(Stage stage) {
+            Button button = new Button("click me!")
+            button.setOnAction { button.setText("clicked!") }
+            stage.setScene(new Scene(new StackPane(button), 100, 100))
+            stage.show()
+        }
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    def setup() throws Exception {
+        ApplicationSpec.launch(DemoApplication.class);
+    }
+
+    def cleanup() throws Exception {
+        FxToolkit.cleanupStages();
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    def "should contain button"() {
+        expect:
+        verifyThat(".button", hasText("click me!"));
+    }
+
+    def "should click on button"() {
+        when:
+        clickOn(".button");
+
+        then:
+        verifyThat(".button", hasText("clicked!"));
+    }
+
+}

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.cases.acceptance
+
+import javafx.scene.Scene
+import javafx.scene.control.Button
+import javafx.scene.layout.StackPane
+import javafx.stage.Stage
+import org.testfx.api.FxToolkit
+import org.testfx.framework.spock.ApplicationSpec
+
+import static org.testfx.api.FxAssert.verifyThat
+import static org.testfx.matcher.base.NodeMatchers.hasText
+
+class ApplicationStartSpec extends ApplicationSpec {
+
+    //---------------------------------------------------------------------------------------------
+    // FIXTURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    @Override
+    public void init() throws Exception {
+        FxToolkit.registerStage { new Stage() }
+    }
+
+    @Override
+    public void start(Stage stage) {
+        Button button = new Button("click me!")
+        button.setOnAction { button.setText("clicked!") }
+        stage.setScene(new Scene(new StackPane(button), 100, 100))
+        stage.show()
+    }
+
+    @Override
+    public void stop() throws Exception {
+        FxToolkit.hideStage()
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // FEATURE METHODS.
+    //---------------------------------------------------------------------------------------------
+
+    def "should contain button"() {
+        expect:
+        verifyThat(".button", hasText("click me!"))
+    }
+
+    def "should click on button"() {
+        when:
+        clickOn(".button")
+
+        then:
+        verifyThat(".button", hasText("clicked!"))
+    }
+
+}

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.spock
+
+import javafx.scene.input.KeyCode
+import javafx.scene.input.MouseButton
+import javafx.stage.Stage
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+
+class KeyAndButtonReleaseSpec extends ApplicationSpec {
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        stage.show();
+    }
+
+    def "Keys are released whether test remembers to unrelease them or not"() {
+        given: "a test where keys are pressed at some point and not released"
+        press(KeyCode.CONTROL, KeyCode.SHIFT, KeyCode.ALT);
+
+        when: "the test ends"
+        internalAfter()
+
+        then: "all pressed keys have been released"
+        assertThat(robotContext().getKeyboardRobot().getPressedKeys().isEmpty(), is(true))
+    }
+
+    def "Buttons are released whether test remembers to unrelease them or not"() {
+        given: "a test where keys are pressed at some point and not released"
+        press(MouseButton.PRIMARY, MouseButton.SECONDARY, MouseButton.MIDDLE);
+
+        when: "the test ends"
+        internalAfter()
+
+        then: "all pressed mouse buttons have been released"
+        assertThat(robotContext().getMouseRobot().getPressedButtons().isEmpty(), is(true))
+    }
+}

--- a/subprojects/testfx-spock/testfx-spock.gradle
+++ b/subprojects/testfx-spock/testfx-spock.gradle
@@ -14,23 +14,18 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+ext.pomDescription = "TestFX Spock"
 
-// name of root project.
-rootProject.name = "TestFX"
+apply plugin: 'groovy'
 
-// list of projects.
-include "subprojects/testfx-core"
-include "subprojects/testfx-junit"
-include "subprojects/testfx-junit5"
-include "subprojects/testfx-legacy"
-include "subprojects/testfx-spock"
+dependencies {
+    compile project(":testfx-core")
 
-// location of the build files.
-rootProject.children.each { project ->
-    def projectDir = new File(project.name)
-    project.name = projectDir.name
-    project.projectDir = projectDir
-    project.buildFileName = "${projectDir.name}.gradle"
-    assert project.projectDir.isDirectory()
-    assert project.buildFile.isFile()
+    compile "org.spockframework:spock-core:1.1-groovy-2.4"
+    testRuntime ('com.athaydes:spock-reports:1.2.7') {
+        transitive = false
+    }
+
+    testCompile "org.hamcrest:hamcrest-library:1.3"
+    testCompile "org.testfx:openjfx-monocle:8u76-b04"
 }


### PR DESCRIPTION
Using `providedCompile` for the groovy dependency fails the build with a `java.lang.ExceptionInInitializerError`. So, I'm using `compile`. Any idea how to get around this?

Other than that, every variant of TestFX (spock, junit, junit5, legacy) are failing their `Application[Start/Launch][Test/Spec]`'s `should_click_on_button` test due to an NPE from the node query ".button".

Also, I realized there's a way to write the `KeyAndButtonReleaseTest` without needing to use `@FixedMethodOrder`. We can fix the JUnit 5 test to use the new approach since it doesn't have JUnit 4's annotation yet.