### PR TITLE
(refactor) Make ApplicationTest#start() not abstract

### DIFF
--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
@@ -74,8 +74,8 @@ public abstract class ApplicationTest extends FxRobot implements ApplicationFixt
 
     @Override
     @Unstable(reason = "is missing apidocs")
-    public abstract void start(Stage stage)
-                        throws Exception;
+    public void start(Stage stage)
+                        throws Exception {}
 
     @Override
     @Unstable(reason = "is missing apidocs")

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
@@ -74,8 +74,8 @@ public abstract class ApplicationTest extends FxRobot implements ApplicationFixt
 
     @Override
     @Unstable(reason = "is missing apidocs")
-    public abstract void start(Stage stage)
-                        throws Exception;
+    public void start(Stage stage)
+                        throws Exception {}
 
     @Override
     @Unstable(reason = "is missing apidocs")


### PR DESCRIPTION
There are times where I override start and it is just a no-op because I only need the JavaFX Application thread to exist.  This makes it so I do not _need_ to override the start method.