### PR TITLE
Refactor spock

### DIFF
--- a/subprojects/testfx-spock/testfx-spock.gradle
+++ b/subprojects/testfx-spock/testfx-spock.gradle
@@ -22,9 +22,6 @@ dependencies {
     compile project(":testfx-core")
 
     compile "org.spockframework:spock-core:1.1-groovy-2.4"
-    testRuntime ('com.athaydes:spock-reports:1.2.7') {
-        transitive = false
-    }
 
     testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile "org.testfx:openjfx-monocle:8u76-b04"


### PR DESCRIPTION
Continuing what was started in #404, tests whether removing the Spock reports runtime dependency affects the success of a previously-failing test on the allow-fail JDK 8 build