### PR TITLE
[RFC] Increase debugability

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
@@ -21,6 +21,8 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.image.Image;
@@ -59,7 +61,14 @@ public final class FxAssert {
     @Unstable(reason = "is missing apidocs; might be removed due to complications with generics")
     public static <T> void verifyThat(T value,
                                       Matcher<? super T> matcher) {
-        verifyThatImpl(emptyReason(), value, matcher);
+        verifyThatImpl(emptyReason(), value, matcher, defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs; might be removed due to complications with generics")
+    public static <T> void verifyThat(T value,
+                                      Matcher<? super T> matcher,
+                                      UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), value, matcher, errorHandler);
     }
 
     // ASSERTIONS: {NODE, NODES} + MATCHER.
@@ -67,13 +76,27 @@ public final class FxAssert {
     @Unstable(reason = "is missing apidocs")
     public static <T extends Node> void verifyThat(T node,
                                                    Matcher<T> nodeMatcher) {
-        verifyThatImpl(emptyReason(), node, nodeMatcher);
+        verifyThatImpl(emptyReason(), node, nodeMatcher, defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs")
+    public static <T extends Node> void verifyThat(T node,
+                                                   Matcher<T> nodeMatcher,
+                                                   UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), node, nodeMatcher, errorHandler);
     }
 
     @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
     public static <T extends Node> void verifyThatIter(Iterable<T> nodes,
                                                        Matcher<Iterable<T>> nodesMatcher) {
-        verifyThatImpl(emptyReason(), nodes, nodesMatcher);
+        verifyThatImpl(emptyReason(), nodes, nodesMatcher, defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
+    public static <T extends Node> void verifyThatIter(Iterable<T> nodes,
+                                                       Matcher<Iterable<T>> nodesMatcher,
+                                                       UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), nodes, nodesMatcher, errorHandler);
     }
 
     // ASSERTIONS: STRING QUERY + MATCHER.
@@ -81,13 +104,27 @@ public final class FxAssert {
     @Unstable(reason = "is missing apidocs")
     public static <T extends Node> void verifyThat(String nodeQuery,
                                                    Matcher<T> nodeMatcher) {
-        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher);
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs")
+    public static <T extends Node> void verifyThat(String nodeQuery,
+                                                   Matcher<T> nodeMatcher,
+                                                   UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, errorHandler);
     }
 
     @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
     public static <T extends Node> void verifyThatIter(String nodeQuery,
                                                        Matcher<Iterable<T>> nodesMatcher) {
-        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher);
+        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
+    public static <T extends Node> void verifyThatIter(String nodeQuery,
+                                                       Matcher<Iterable<T>> nodesMatcher,
+                                                       UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, errorHandler);
     }
 
     // ASSERTIONS: NODE QUERY + MATCHER.
@@ -95,13 +132,27 @@ public final class FxAssert {
     @Unstable(reason = "is missing apidocs")
     public static <T extends Node> void verifyThat(NodeQuery nodeQuery,
                                                    Matcher<T> nodeMatcher) {
-        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher);
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs")
+    public static <T extends Node> void verifyThat(NodeQuery nodeQuery,
+                                                   Matcher<T> nodeMatcher,
+                                                   UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, errorHandler);
     }
 
     @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
     public static <T extends Node> void verifyThatIter(NodeQuery nodeQuery,
                                                        Matcher<Iterable<T>> nodesMatcher) {
-        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher);
+        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
+    public static <T extends Node> void verifyThatIter(NodeQuery nodeQuery,
+                                                       Matcher<Iterable<T>> nodesMatcher,
+                                                       UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, errorHandler);
     }
 
     // ASSERTIONS: {NODE, STRING QUERY, NODE QUERY} + PREDICATE.
@@ -109,19 +160,40 @@ public final class FxAssert {
     @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
     public static <T extends Node> void verifyThat(T node,
                                                    Predicate<T> nodePredicate) {
-        verifyThatImpl(emptyReason(), node, toNodeMatcher(nodePredicate));
+        verifyThatImpl(emptyReason(), node, toNodeMatcher(nodePredicate), defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
+    public static <T extends Node> void verifyThat(T node,
+                                                   Predicate<T> nodePredicate,
+                                                   UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), node, toNodeMatcher(nodePredicate), errorHandler);
     }
 
     @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
     public static <T extends Node> void verifyThat(String nodeQuery,
                                                    Predicate<T> nodePredicate) {
-        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate));
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
+    public static <T extends Node> void verifyThat(String nodeQuery,
+                                                   Predicate<T> nodePredicate,
+                                                   UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), errorHandler);
     }
 
     @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
     public static <T extends Node> void verifyThat(NodeQuery nodeQuery,
                                                    Predicate<T> nodePredicate) {
-        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate));
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), defaultErrorHandler());
+    }
+
+    @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
+    public static <T extends Node> void verifyThat(NodeQuery nodeQuery,
+                                                   Predicate<T> nodePredicate,
+                                                   UnaryOperator<AssertionError> errorHandler) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), errorHandler);
     }
 
     // INTERNAL CONTEXT.
@@ -138,17 +210,23 @@ public final class FxAssert {
     // PRIVATE STATIC METHODS.
     //---------------------------------------------------------------------------------------------
 
-    private static <T> void verifyThatImpl(String reason,
-                                           T value,
-                                           Matcher<? super T> matcher) {
+    /**
+     * Allow developer to debug a failed test (e.g. the state of the stage or node, which keys were pressed, etc.)
+     */
+    private static <T> void verifyThatImpl(String reason, T value, Matcher<? super T> matcher,
+                                           UnaryOperator<AssertionError> mapper) {
         try {
             MatcherAssert.assertThat(reason, value, matcher);
         }
         catch (AssertionError error) {
             // TODO: make error capture and assertion throw more reliable.
             // captureErrorScreenshot();
-            throw new AssertionError(error.getMessage());
+            throw mapper.apply(error);
         }
+    }
+
+    private static UnaryOperator<AssertionError> defaultErrorHandler() {
+        return error -> new AssertionError(error.getMessage());
     }
 
     private static String emptyReason() {

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
+import javafx.event.Event;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.image.Image;
@@ -278,9 +279,15 @@ public final class FxAssert {
             Set<KeyCode> keysPressed = robot.robotContext().getKeyboardRobot().getPressedKeys();
             Set<MouseButton> buttonsPressed = robot.robotContext().getMouseRobot().getPressedButtons();
             StringBuilder sb = new StringBuilder(error.getMessage());
+            String spacedTab = "   ";
             sb.append("\n\n").append("Context:")
-                    .append("\n   Keys pressed: ").append(keysPressed)
-                    .append("\n   Mouse Buttons pressed: ").append(buttonsPressed);
+                    .append("\n").append(spacedTab).append("Keys pressed: ").append(keysPressed)
+                    .append("\n").append(spacedTab).append("Mouse Buttons pressed: ").append(buttonsPressed)
+                    .append("\n").append(spacedTab).append("Fired events since test began:");
+
+            FxToolkit.toolkitContext().getFiredEvents().stream()
+                    .map(Event::toString)
+                    .forEach(e -> sb.append("\n").append(spacedTab).append(spacedTab).append(e));
 
             return new AssertionError(sb.toString());
         };

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
@@ -279,15 +279,17 @@ public final class FxAssert {
             Set<KeyCode> keysPressed = robot.robotContext().getKeyboardRobot().getPressedKeys();
             Set<MouseButton> buttonsPressed = robot.robotContext().getMouseRobot().getPressedButtons();
             StringBuilder sb = new StringBuilder(error.getMessage());
-            String spacedTab = "   ";
+            // simulate tab character with 3 spaces
             sb.append("\n\n").append("Context:")
-                    .append("\n").append(spacedTab).append("Keys pressed: ").append(keysPressed)
-                    .append("\n").append(spacedTab).append("Mouse Buttons pressed: ").append(buttonsPressed)
-                    .append("\n").append(spacedTab).append("Fired events since test began:");
+                    .append("\n   ").append("Keys pressed at test failure: ")
+                    .append("\n      ").append(keysPressed)
+                    .append("\n   ").append("Mouse Buttons pressed at test failure: ")
+                    .append("\n      ").append(buttonsPressed)
+                    .append("\n   ").append("Fired events since test began:");
 
             FxToolkit.toolkitContext().getFiredEvents().stream()
                     .map(Event::toString)
-                    .forEach(e -> sb.append("\n").append(spacedTab).append(spacedTab).append(e));
+                    .forEach(e -> sb.append("\n      ").append(e));
 
             return new AssertionError(sb.toString());
         };

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
@@ -26,6 +26,8 @@ import java.util.function.UnaryOperator;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.image.Image;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
 import javafx.stage.Screen;
 
 import org.hamcrest.Matcher;
@@ -71,6 +73,13 @@ public final class FxAssert {
         verifyThatImpl(emptyReason(), value, matcher, errorHandler);
     }
 
+    @Unstable(reason = "is missing apidocs; might be removed due to complications with generics")
+    public static <T> void verifyThat(T value,
+                                      Matcher<? super T> matcher,
+                                      FxRobot robot) {
+        verifyThatImpl(emptyReason(), value, matcher, robot);
+    }
+
     // ASSERTIONS: {NODE, NODES} + MATCHER.
 
     @Unstable(reason = "is missing apidocs")
@@ -86,6 +95,13 @@ public final class FxAssert {
         verifyThatImpl(emptyReason(), node, nodeMatcher, errorHandler);
     }
 
+    @Unstable(reason = "is missing apidocs")
+    public static <T extends Node> void verifyThat(T node,
+                                                   Matcher<T> nodeMatcher,
+                                                   FxRobot robot) {
+        verifyThatImpl(emptyReason(), node, nodeMatcher, robot);
+    }
+
     @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
     public static <T extends Node> void verifyThatIter(Iterable<T> nodes,
                                                        Matcher<Iterable<T>> nodesMatcher) {
@@ -97,6 +113,13 @@ public final class FxAssert {
                                                        Matcher<Iterable<T>> nodesMatcher,
                                                        UnaryOperator<AssertionError> errorHandler) {
         verifyThatImpl(emptyReason(), nodes, nodesMatcher, errorHandler);
+    }
+
+    @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
+    public static <T extends Node> void verifyThatIter(Iterable<T> nodes,
+                                                       Matcher<Iterable<T>> nodesMatcher,
+                                                       FxRobot robot) {
+        verifyThatImpl(emptyReason(), nodes, nodesMatcher, robot);
     }
 
     // ASSERTIONS: STRING QUERY + MATCHER.
@@ -114,6 +137,13 @@ public final class FxAssert {
         verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, errorHandler);
     }
 
+    @Unstable(reason = "is missing apidocs")
+    public static <T extends Node> void verifyThat(String nodeQuery,
+                                                   Matcher<T> nodeMatcher,
+                                                   FxRobot robot) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, robot);
+    }
+
     @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
     public static <T extends Node> void verifyThatIter(String nodeQuery,
                                                        Matcher<Iterable<T>> nodesMatcher) {
@@ -125,6 +155,13 @@ public final class FxAssert {
                                                        Matcher<Iterable<T>> nodesMatcher,
                                                        UnaryOperator<AssertionError> errorHandler) {
         verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, errorHandler);
+    }
+
+    @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
+    public static <T extends Node> void verifyThatIter(String nodeQuery,
+                                                       Matcher<Iterable<T>> nodesMatcher,
+                                                       FxRobot robot) {
+        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, robot);
     }
 
     // ASSERTIONS: NODE QUERY + MATCHER.
@@ -142,6 +179,13 @@ public final class FxAssert {
         verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, errorHandler);
     }
 
+    @Unstable(reason = "is missing apidocs")
+    public static <T extends Node> void verifyThat(NodeQuery nodeQuery,
+                                                   Matcher<T> nodeMatcher,
+                                                   FxRobot robot) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), nodeMatcher, robot);
+    }
+
     @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
     public static <T extends Node> void verifyThatIter(NodeQuery nodeQuery,
                                                        Matcher<Iterable<T>> nodesMatcher) {
@@ -153,6 +197,13 @@ public final class FxAssert {
                                                        Matcher<Iterable<T>> nodesMatcher,
                                                        UnaryOperator<AssertionError> errorHandler) {
         verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, errorHandler);
+    }
+
+    @Unstable(reason = "is missing apidocs; might change to simplify iterable handling")
+    public static <T extends Node> void verifyThatIter(NodeQuery nodeQuery,
+                                                       Matcher<Iterable<T>> nodesMatcher,
+                                                       FxRobot robot) {
+        verifyThatImpl(emptyReason(), toNodeSet(nodeQuery), nodesMatcher, robot);
     }
 
     // ASSERTIONS: {NODE, STRING QUERY, NODE QUERY} + PREDICATE.
@@ -171,6 +222,13 @@ public final class FxAssert {
     }
 
     @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
+    public static <T extends Node> void verifyThat(T node,
+                                                   Predicate<T> nodePredicate,
+                                                   FxRobot robot) {
+        verifyThatImpl(emptyReason(), node, toNodeMatcher(nodePredicate), robot);
+    }
+
+    @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
     public static <T extends Node> void verifyThat(String nodeQuery,
                                                    Predicate<T> nodePredicate) {
         verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), defaultErrorHandler());
@@ -184,6 +242,13 @@ public final class FxAssert {
     }
 
     @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
+    public static <T extends Node> void verifyThat(String nodeQuery,
+                                                   Predicate<T> nodePredicate,
+                                                   FxRobot robot) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), robot);
+    }
+
+    @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
     public static <T extends Node> void verifyThat(NodeQuery nodeQuery,
                                                    Predicate<T> nodePredicate) {
         verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), defaultErrorHandler());
@@ -194,6 +259,31 @@ public final class FxAssert {
                                                    Predicate<T> nodePredicate,
                                                    UnaryOperator<AssertionError> errorHandler) {
         verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), errorHandler);
+    }
+
+    @Unstable(reason = "is missing apidocs; might change if typing causes trouble")
+    public static <T extends Node> void verifyThat(NodeQuery nodeQuery,
+                                                   Predicate<T> nodePredicate,
+                                                   FxRobot robot) {
+        verifyThatImpl(emptyReason(), toNode(nodeQuery), toNodeMatcher(nodePredicate), robot);
+    }
+
+    public static <T> void verifyThatImpl(String reason, T value, Matcher<? super T> matcher,
+                                           FxRobot robot) {
+        verifyThatImpl(reason, value, matcher, informedErrorHandler(robot));
+    }
+
+    public static UnaryOperator<AssertionError> informedErrorHandler(FxRobot robot) {
+        return error -> {
+            Set<KeyCode> keysPressed = robot.robotContext().getKeyboardRobot().getPressedKeys();
+            Set<MouseButton> buttonsPressed = robot.robotContext().getMouseRobot().getPressedButtons();
+            StringBuilder sb = new StringBuilder(error.getMessage());
+            sb.append("\n\n").append("Context:")
+                    .append("\n   Keys pressed: ").append(keysPressed)
+                    .append("\n   Mouse Buttons pressed: ").append(buttonsPressed);
+
+            return new AssertionError(sb.toString());
+        };
     }
 
     // INTERNAL CONTEXT.

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkitContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkitContext.java
@@ -16,10 +16,14 @@
  */
 package org.testfx.api;
 
+import java.util.List;
+
 import javafx.application.Application;
+import javafx.event.Event;
 import javafx.stage.Stage;
 
 import org.testfx.api.annotation.Unstable;
+import org.testfx.service.support.FiredEvents;
 import org.testfx.toolkit.PrimaryStageApplication;
 import org.testfx.toolkit.PrimaryStageFuture;
 
@@ -62,6 +66,8 @@ public class FxToolkitContext {
     private String[] applicationArgs = new String[] {};
 
     private Stage registeredStage;
+
+    private FiredEvents firedEvents;
 
     /**
      * The number of milliseconds before timing out launch-related components. Default value: 60,000 (1 minute)
@@ -107,6 +113,14 @@ public class FxToolkitContext {
 
     public void setRegisteredStage(Stage registeredStage) {
         this.registeredStage = registeredStage;
+        if (firedEvents != null) {
+            firedEvents.stopStoringFiredEvents();
+        }
+        firedEvents = FiredEvents.beginStoringFiredEventsOf(registeredStage);
+    }
+
+    public List<Event> getFiredEvents() {
+        return firedEvents.getEvents();
     }
 
     public long getLaunchTimeoutInMillis() {

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/FiredEvents.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/FiredEvents.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.service.support;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
+import javafx.stage.Stage;
+
+/**
+ * Stores a list of events that have been fired since the start of a test; useful for debugging.
+ * Use {@link #beginStoringFiredEventsOf(Stage)} to start storing a stage's fired events and
+ * {@link #stopStoringFiredEvents()} when finished and cleaning up this object.
+ */
+public final class FiredEvents {
+
+    public static FiredEvents beginStoringFiredEventsOf(Stage stage) {
+        return new FiredEvents(stage);
+    }
+
+    private final List<Event> events = new LinkedList<>();
+    private final Runnable removeListener;
+
+    private FiredEvents(Stage stage) {
+        if (stage == null) {
+            removeListener = null;
+        } else {
+            EventHandler<Event> addFiredEvent = events::add;
+            stage.addEventFilter(EventType.ROOT, addFiredEvent);
+            removeListener = () -> stage.removeEventFilter(EventType.ROOT, addFiredEvent);
+        }
+    }
+
+    public final List<Event> getEvents() {
+        return Collections.unmodifiableList(events);
+    }
+
+    public final void clearEvents() {
+        events.clear();
+    }
+
+    public final void stopStoringFiredEvents() {
+        if (removeListener != null) {
+            removeListener.run();
+        }
+    }
+
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -51,19 +51,19 @@ public class FxAssertBasicTest extends TestCaseBase {
     @Test
     public void missing_is_null() {
         // expect:
-        verifyThat("#missing", isNull());
+        verifyThat("#missing", isNull(), this);
     }
 
     @Test
     public void button_is_not_null() {
         // expect:
-        verifyThat("#button", isNotNull());
+        verifyThat("#button", isNotNull(), this);
     }
 
     @Test
     public void button_is_enabled() {
         // expect:
-        verifyThat("#button", isEnabled());
+        verifyThat("#button", isEnabled(), this);
     }
 
     @Test
@@ -72,13 +72,13 @@ public class FxAssertBasicTest extends TestCaseBase {
         interact(() -> lookup("#button").query().setDisable(true));
 
         // then:
-        verifyThat("#button", isDisabled());
+        verifyThat("#button", isDisabled(), this);
     }
 
     @Test
     public void button_is_visible() {
         // expect:
-        verifyThat("#button", isVisible());
+        verifyThat("#button", isVisible(), this);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class FxAssertBasicTest extends TestCaseBase {
         interact(() -> lookup("#button").query().setVisible(false));
 
         // then:
-        verifyThat("#button", isInvisible());
+        verifyThat("#button", isInvisible(), this);
     }
 
     @Test
@@ -96,13 +96,13 @@ public class FxAssertBasicTest extends TestCaseBase {
         clickOn("#button");
 
         // then:
-        verifyThat("#button", hasText("clicked!"));
+        verifyThat("#button", hasText("clicked!"), this);
     }
 
     @Test
     public void button_has_not_label() {
         // expect:
-        verifyThat("#button", not(hasText("clicked!")));
+        verifyThat("#button", not(hasText("clicked!")), this);
     }
 
     //@Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxToolkitBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxToolkitBasicTest.java
@@ -28,7 +28,7 @@ import org.testfx.cases.TestCaseBase;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testfx.api.FxAssert.verifyThat;
 
 public class FxToolkitBasicTest extends TestCaseBase {
 
@@ -54,7 +54,7 @@ public class FxToolkitBasicTest extends TestCaseBase {
         Stage stage = FxToolkit.registerPrimaryStage();
 
         // then:
-        assertThat(stage, instanceOf(Stage.class));
+        verifyThat(stage, instanceOf(Stage.class));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class FxToolkitBasicTest extends TestCaseBase {
         Stage stage = FxToolkit.registerPrimaryStage();
 
         // then:
-        assertThat(FxToolkit.toolkitContext().getRegisteredStage(), is(stage));
+        verifyThat(FxToolkit.toolkitContext().getRegisteredStage(), is(stage));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class FxToolkitBasicTest extends TestCaseBase {
         Stage stage = FxToolkit.registerStage(Stage::new);
 
         // then:
-        assertThat(stage, instanceOf(Stage.class));
+        verifyThat(stage, instanceOf(Stage.class));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class FxToolkitBasicTest extends TestCaseBase {
         Stage stage = FxToolkit.registerStage(Stage::new);
 
         // then:
-        assertThat(FxToolkit.toolkitContext().getRegisteredStage(), is(stage));
+        verifyThat(FxToolkit.toolkitContext().getRegisteredStage(), is(stage));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class FxToolkitBasicTest extends TestCaseBase {
         FxToolkit.showStage();
 
         // then:
-        assertThat(stage.isShowing(), is(true));
+        verifyThat(stage.isShowing(), is(true));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class FxToolkitBasicTest extends TestCaseBase {
         FxToolkit.hideStage();
 
         // then:
-        assertThat(stage.isShowing(), is(false));
+        verifyThat(stage.isShowing(), is(false));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/SceneRootAssertionTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/SceneRootAssertionTest.java
@@ -27,8 +27,9 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testfx.TestFXRule;
-import org.testfx.api.FxAssert;
 import org.testfx.api.FxToolkit;
+
+import static org.testfx.api.FxAssert.verifyThat;
 
 @Ignore
 public class SceneRootAssertionTest {
@@ -51,7 +52,7 @@ public class SceneRootAssertionTest {
 
     @Test
     public void should_have_stage_root_with_label() {
-        FxAssert.verifyThat(stackPane, hasChild(label));
+        verifyThat(stackPane, hasChild(label));
     }
 
     private Predicate<Parent> hasChild(Node node) {

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
@@ -89,8 +89,8 @@ public class DragAndDropTest extends TestCaseBase {
     @Test
     public void should_have_initialized_items() {
         // expect:
-        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3"));
-        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3"));
+        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3"), this);
+        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3"), this);
     }
 
     @Test
@@ -101,8 +101,8 @@ public class DragAndDropTest extends TestCaseBase {
         drop();
 
         // then:
-        verifyThat(leftListView.getItems(), contains("L2", "L3"));
-        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3", "L1")); // gets added to end of ListView
+        verifyThat(leftListView.getItems(), contains("L2", "L3"), this);
+        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3", "L1"), this); // gets added to end of ListView
     }
 
     @Test
@@ -113,8 +113,8 @@ public class DragAndDropTest extends TestCaseBase {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3", "R3"));
-        verifyThat(rightListView.getItems(), contains("R1", "R2"));
+        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3", "R3"), this);
+        verifyThat(rightListView.getItems(), contains("R1", "R2"), this);
     }
 
     @Ignore("see #383")
@@ -126,8 +126,8 @@ public class DragAndDropTest extends TestCaseBase {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3"));
-        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3"));
+        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3"), this);
+        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3"), this);
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
@@ -38,8 +38,9 @@ import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 import org.testfx.robot.Motion;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+
+import static org.testfx.api.FxAssert.verifyThat;
 
 public class MenuBarTest {
 
@@ -99,12 +100,12 @@ public class MenuBarTest {
         // First we show that it is indeed the case that {@code editMenu} is triggered when moving directly:
         editMenu.setOnShown(event -> editMenuShownLatch.countDown());
         fxRobot.clickOn("#fileMenu").clickOn("#newItem", Motion.DIRECT);
-        assertThat(editMenuShownLatch.await(3, TimeUnit.SECONDS), is(true));
-        assertThat(newMenuShownLatch.getCount(), is(1L));
+        verifyThat(editMenuShownLatch.await(3, TimeUnit.SECONDS), is(true), fxRobot);
+        verifyThat(newMenuShownLatch.getCount(), is(1L), fxRobot);
 
         // Next we show that calling the "clickOn" method without specifying the type of motion automatically
         // uses Motion.VERTICAL_FIRST because "#newItem" is a MenuItem.
         fxRobot.clickOn("#fileMenu").clickOn("#newItem");
-        assertThat(newMenuShownLatch.await(3, TimeUnit.SECONDS), is(true));
+        verifyThat(newMenuShownLatch.await(3, TimeUnit.SECONDS), is(true), fxRobot);
     }
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -35,8 +35,9 @@ import static javafx.scene.input.KeyCode.COMMAND;
 import static javafx.scene.input.KeyCode.CONTROL;
 import static javafx.scene.input.KeyCode.SHORTCUT;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+
+import static org.testfx.api.FxAssert.verifyThat;
 
 /**
  * Tests whether pressing {@code KeyCode.SHORTCUT} will convert into the OS-specific KeyCode (i.e.
@@ -92,7 +93,7 @@ public class ShortcutKeyTest extends FxRobot {
         press(SHORTCUT);
 
         // then:
-        assertThat(field.getText(), equalTo(pressedText));
+        verifyThat(field.getText(), equalTo(pressedText), this);
     }
 
     @Test
@@ -101,12 +102,12 @@ public class ShortcutKeyTest extends FxRobot {
         press(osSpecificShortcutKey);
 
         // and:
-        assertThat(field.getText(), equalTo(pressedText));
+        verifyThat(field.getText(), equalTo(pressedText), this);
 
         // when:
         release(SHORTCUT);
 
         // then:
-        assertThat(field.getText(), equalTo(releasedText));
+        verifyThat(field.getText(), equalTo(releasedText), this);
     }
 }


### PR DESCRIPTION
Somewhat resolves #417. 

The commit history needs to be cleaned up a bit, but this might help us track down the issues behind those flaky tests.

Regardless, I can't set the default error handler to automatically show which keys and mouse buttons were pressed since there's no access to `FxRobot` somehow. The event list makes this somewhat irrelevant, but I think that might be easier to read than the huge number of events.

Also, I think the `errorHandler` should map the error's message. Otherwise, a person might return the original error and I'm not sure if that rethrows or not.