### PR TITLE
[WIP] (refactor) Use Java-version-independent adapter for internal API

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -6,12 +6,7 @@ echo "java_home: $(command -v "/usr/libexec/java_home")"
 ./gradlew --version
 ulimit -c unlimited -S
 
-# Increase build log verbosity for JDK 9.
-if [ "$TRAVIS_JDK_VERSION" == "oraclejdk9" ]; then
-  ./gradlew build --debug --stacktrace
-else
-  ./gradlew build --info
-fi
+./gradlew build --info
 
 # Print core dumps when JVM crashes.
 RESULT=$?

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ rootProject.with { project ->
         println "Java version: ${System.properties["java.version"]}"
         println "Gradle version: ${gradle.gradleVersion}"
         println "Groovy version: ${GroovySystem.version}"
+        println "Included projects are: ${rootProject.childProjects.keySet()}"
     }
 
     ext {
@@ -66,6 +67,10 @@ rootProject.with { project ->
         javaVersion = System.properties["java.version"]
         javaVendor = System.properties["java.vendor"]
         javaVmVersion = System.properties["java.vm.version"]
+
+        usingJava9 = javaVersion.startsWith("9")
+        javaSourceAndTargetCompilation = usingJava9 ? "9" : "1.8"
+        javadocVersion = usingJava9 ? "9" : "8"
     }
 }
 
@@ -139,10 +144,9 @@ subprojects { subproject ->
         javadocJar
     }
 
-    // source code compatible to java 8.
     subproject.tasks.withType(JavaCompile) {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+        sourceCompatibility = javaSourceAndTargetCompilation
+        targetCompatibility = javaSourceAndTargetCompilation
     }
 
     // configure javadoc task.
@@ -212,8 +216,8 @@ subprojects { subproject ->
         options.docTitle    = "${subproject.pomDescription} ${version} API"
         options.footer      = project.javadocFooter
         options.links       = [
-            "http://docs.oracle.com/javase/8/docs/api/",
-            "http://docs.oracle.com/javase/8/javafx/api/"
+            "http://docs.oracle.com/javase/${javadocVersion}/docs/api/",
+            "http://docs.oracle.com/javase/${javadocVersion}/javafx/api/"
         ]
     }
 }
@@ -241,8 +245,8 @@ task("aggregateJavadoc", type: Javadoc) {
         splitIndex = true
         encoding = "UTF-8"
         links = [
-            "http://docs.oracle.com/javase/8/docs/api/",
-            "http://docs.oracle.com/javase/8/javafx/api/"
+            "http://docs.oracle.com/javase/{$javadocVersion}/docs/api/",
+            "http://docs.oracle.com/javase/{$javadocVersion}/javafx/api/"
         ]
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,17 @@ rootProject.with { project ->
 
         usingJava9 = javaVersion.startsWith("9")
         javaSourceAndTargetCompilation = usingJava9 ? "9" : "1.8"
-        javadocVersion = usingJava9 ? "9" : "8"
+
+        if (usingJava9) {
+            javadocLinks = [
+                    "http://download.java.net/java/jdk9/docs/api/"
+            ]
+        } else {
+            javadocLinks = [
+                    "http://docs.oracle.com/javase/8/docs/api/",
+                    "http://docs.oracle.com/javase/8/javafx/api/"
+            ]
+        }
     }
 }
 
@@ -110,7 +120,10 @@ subprojects { subproject ->
     apply(plugin: "java")
 
     apply(from: rootProject.file("gradle/check-checkstyle.gradle"))
-    apply(from: rootProject.file("gradle/check-findbugs.gradle"))
+    if (!usingJava9) {
+        // throws an IllegalArgumentException on Java 9
+        apply(from: rootProject.file("gradle/check-findbugs.gradle"))
+    }
     //apply(from: rootProject.file("gradle/check-jdepend.gradle"))
     apply(from: rootProject.file("gradle/check-license.gradle"))
 
@@ -215,10 +228,7 @@ subprojects { subproject ->
         options.windowTitle = "${subproject.pomDescription} ${version} API"
         options.docTitle    = "${subproject.pomDescription} ${version} API"
         options.footer      = project.javadocFooter
-        options.links       = [
-            "http://docs.oracle.com/javase/${javadocVersion}/docs/api/",
-            "http://docs.oracle.com/javase/${javadocVersion}/javafx/api/"
-        ]
+        options.links = javadocLinks
     }
 }
 
@@ -244,10 +254,7 @@ task("aggregateJavadoc", type: Javadoc) {
         use = true
         splitIndex = true
         encoding = "UTF-8"
-        links = [
-            "http://docs.oracle.com/javase/{$javadocVersion}/docs/api/",
-            "http://docs.oracle.com/javase/{$javadocVersion}/javafx/api/"
-        ]
+        links = javadocLinks
     }
 
     // disable java 8 overly pedantic lint checking.

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,9 @@ subprojects { subproject ->
     // provide java configurations and tasks.
     apply(plugin: "java")
 
-    apply(from: rootProject.file("gradle/check-checkstyle.gradle"))
+    if (subproject.name != "testfx-internal-java9") {
+        apply(from: rootProject.file("gradle/check-checkstyle.gradle"))
+    }
     if (!usingJava9) {
         // throws an IllegalArgumentException on Java 9
         apply(from: rootProject.file("gradle/check-findbugs.gradle"))

--- a/build.gradle
+++ b/build.gradle
@@ -119,9 +119,7 @@ subprojects { subproject ->
     // provide java configurations and tasks.
     apply(plugin: "java")
 
-    if (subproject.name != "testfx-internal-java9") {
-        apply(from: rootProject.file("gradle/check-checkstyle.gradle"))
-    }
+    apply(from: rootProject.file("gradle/check-checkstyle.gradle"))
     if (!usingJava9) {
         // throws an IllegalArgumentException on Java 9
         apply(from: rootProject.file("gradle/check-findbugs.gradle"))

--- a/gradle/check-checkstyle.gradle
+++ b/gradle/check-checkstyle.gradle
@@ -27,3 +27,7 @@ checkstyle {
     ignoreFailures = false
     toolVersion = "7.6.1"
 }
+
+// exclude module info files for Java 9
+checkstyleMain.exclude "**/module-info.java"
+checkstyleTest.exclude "**/module-info.java"

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,11 +19,22 @@
 rootProject.name = "TestFX"
 
 // list of projects.
+if (System.properties["java.version"].startsWith("9")) {
+    include("subprojects/testfx-internal-java9")
+
+    // projects that only work on Java 9 right now
+
+} else {
+    include("subprojects/testfx-internal-java8")
+
+    // projects that only work on Java 8 right now
+    include "subprojects/testfx-spock"
+    include "subprojects/testfx-legacy"
+}
+// projects that work on Java 8 or 9 right now
 include "subprojects/testfx-core"
 include "subprojects/testfx-junit"
 include "subprojects/testfx-junit5"
-include "subprojects/testfx-legacy"
-include "subprojects/testfx-spock"
 
 // location of the build files.
 rootProject.children.each { project ->

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
@@ -39,6 +39,7 @@ import org.testfx.toolkit.impl.ApplicationServiceImpl;
 import org.testfx.toolkit.impl.ToolkitServiceImpl;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testfx.service.adapter.JavaVersionAdapter.getWindows;
 import static org.testfx.util.WaitForAsyncUtils.waitFor;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
 
@@ -294,7 +295,7 @@ public final class FxToolkit {
 
     /**
      * Runs on the {@code JavaFX Application Thread}: Hides all windows returned from
-     * {@link Window#impl_getWindows()} and returns once finished.
+     * {@link org.testfx.service.adapter.JavaVersionAdapter#getWindows()} and returns once finished.
      */
     public static void cleanupStages()
             throws TimeoutException {
@@ -350,7 +351,7 @@ public final class FxToolkit {
 
     @SuppressWarnings("deprecation")
     private static Set<Window> fetchAllWindows() {
-        return ImmutableSet.copyOf(Window.impl_getWindows());
+        return ImmutableSet.copyOf(getWindows());
     }
 
     private static void preventShutdownWhenLastWindowIsClosed() {

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.adapter.RobotAdapter;
 
+import static org.testfx.service.adapter.JavaVersionAdapter.convertToKeyCodeId;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
 
 @Unstable
@@ -89,12 +90,12 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
 
     @Override
     public void keyPress(KeyCode key) {
-        useRobot().keyPress(convertToAwtKey(key));
+        useRobot().keyPress(convertToKeyCodeId(key));
     }
 
     @Override
     public void keyRelease(KeyCode key) {
-        useRobot().keyRelease(convertToAwtKey(key));
+        useRobot().keyRelease(convertToKeyCodeId(key));
     }
 
     // MOUSE.
@@ -192,11 +193,6 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
             (int) rectangle.getMinX(), (int) rectangle.getMinY(),
             (int) rectangle.getWidth(), (int) rectangle.getHeight()
         );
-    }
-
-    @SuppressWarnings("deprecation")
-    private int convertToAwtKey(KeyCode keyCode) {
-        return keyCode.impl_getCode();
     }
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -35,6 +35,7 @@ import com.sun.glass.ui.Robot;
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.adapter.RobotAdapter;
 
+import static org.testfx.service.adapter.JavaVersionAdapter.convertToKeyCodeId;
 import static org.testfx.util.WaitForAsyncUtils.asyncFx;
 import static org.testfx.util.WaitForAsyncUtils.waitForAsyncFx;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
@@ -172,11 +173,6 @@ public class GlassRobotAdapter implements RobotAdapter<Robot> {
 
     private Robot createGlassRobot() {
         return Application.GetApplication().createRobot();
-    }
-
-    @SuppressWarnings("deprecation")
-    private int convertToKeyCodeId(KeyCode keyCode) {
-        return keyCode.impl_getCode();
     }
 
     private Point2D convertFromCoordinates(int pointX,

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
@@ -78,7 +78,7 @@ public interface WindowFinder {
     //---------------------------------------------------------------------------------------------
 
     /**
-     * Calls {@link Window#impl_getWindows()}
+     * Calls {@link org.testfx.service.adapter.JavaVersionAdapter#getWindows()}
      */
     List<Window> listWindows();
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
@@ -34,6 +34,8 @@ import com.google.common.collect.Lists;
 
 import org.testfx.service.finder.WindowFinder;
 
+import static org.testfx.service.adapter.JavaVersionAdapter.getWindows;
+
 public class WindowFinderImpl implements WindowFinder {
 
     //---------------------------------------------------------------------------------------------
@@ -138,7 +140,7 @@ public class WindowFinderImpl implements WindowFinder {
 
     @SuppressWarnings("deprecation")
     private List<Window> fetchWindowsInQueue() {
-        List<Window> windows = Lists.newArrayList(Window.impl_getWindows());
+        List<Window> windows = Lists.newArrayList(getWindows());
         return ImmutableList.copyOf(Lists.reverse(windows));
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
@@ -30,7 +30,6 @@ import javafx.stage.Stage;
 import javafx.stage.Window;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import org.testfx.service.finder.WindowFinder;
 
@@ -140,8 +139,7 @@ public class WindowFinderImpl implements WindowFinder {
 
     @SuppressWarnings("deprecation")
     private List<Window> fetchWindowsInQueue() {
-        List<Window> windows = Lists.newArrayList(getWindows());
-        return ImmutableList.copyOf(Lists.reverse(windows));
+        return ImmutableList.copyOf(getWindows());
     }
 
     private List<Window> fetchWindowsByProximityTo(Window targetWindow) {

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
@@ -43,6 +43,8 @@ import com.google.common.collect.Sets;
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
 
+import static org.testfx.service.adapter.JavaVersionAdapter.isNotVisible;
+
 @Unstable
 public final class NodeQueryUtils {
 
@@ -250,7 +252,7 @@ public final class NodeQueryUtils {
 
     @SuppressWarnings("deprecation")
     private static boolean isNodeVisible(Node node) {
-        if (!node.isVisible() || !node.impl_isTreeVisible()) {
+        if (isNotVisible(node)) {
             return false;
         }
         else if (!isNodeWithinSceneBounds(node)) {

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
@@ -16,6 +16,8 @@
  */
 package org.testfx.util;
 
+import java.util.concurrent.TimeoutException;
+
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.Dimension2D;
@@ -44,6 +46,7 @@ import javafx.stage.StageStyle;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.testfx.api.FxToolkit;
@@ -122,6 +125,11 @@ public class BoundsQueryUtilsTest {
         // stage.setY(0);
         stage.setScene(scene);
         stage.show();
+    }
+
+    @AfterClass
+    public static void cleanupStage() throws TimeoutException {
+        FxToolkit.setupFixture(() -> stage.close());
     }
 
     //---------------------------------------------------------------------------------------------

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -18,6 +18,13 @@
 ext.pomDescription = "TestFX Core"
 
 dependencies {
+    // use correct API internally depending on which Java version is being used
+    if (usingJava9) {
+        compile project(":testfx-internal-java9")
+    } else {
+        compile project(":testfx-internal-java8")
+    }
+
     compile "com.google.guava:guava:21.0"
     compile "org.hamcrest:hamcrest-core:1.3"
     compile 'com.google.code.findbugs:annotations:3.0.1u2'
@@ -28,3 +35,19 @@ dependencies {
     testCompile "org.controlsfx:controlsfx:8.40.12"
     testCompile "org.testfx:openjfx-monocle:8u76-b04"
 }
+
+
+compileJava {
+    if (usingJava9) {
+        options.compilerArgs += [
+                "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+                "--add-opens", "java.base/java.util=ALL-UNNAMED",
+                "--add-exports", "javafx.graphics/com.sun.glass.ui=ALL-UNNAMED"
+        ]
+
+        javadoc {
+            options.addStringOption('-add-exports', 'javafx.graphics/com.sun.glass.ui=ALL-UNNAMED')
+        }
+    }
+}
+

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -51,3 +51,14 @@ compileJava {
     }
 }
 
+compileTestJava {
+    if (usingJava9) {
+        options.compilerArgs += [
+                "--add-opens", "org.testfx.internal/org.testfx.service.adapter=ALL-UNNAMED",
+                "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+                "--add-opens", "java.base/java.util=ALL-UNNAMED",
+                "--add-exports", "javafx.graphics/com.sun.glass.ui=ALL-UNNAMED"
+        ]
+    }
+}
+

--- a/subprojects/testfx-internal-java8/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java8/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
@@ -16,11 +16,13 @@
  */
 package org.testfx.service.adapter;
 
-import java.util.Iterator;
+import java.util.List;
 
 import javafx.scene.Node;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Window;
+
+import com.google.common.collect.Lists;
 
 /**
  * Provides consistent API for TestFX-Core subproject regardless of whether Java 8 or Java 9 is being used.
@@ -33,8 +35,8 @@ public final class JavaVersionAdapter {
     }
 
     @SuppressWarnings("deprecated")
-    public static Iterator<Window> getWindows() {
-        return Window.impl_getWindows();
+    public static List<Window> getWindows() {
+        return Lists.reverse(Lists.newArrayList(Window.impl_getWindows()));
     }
 
     @SuppressWarnings("deprecated")

--- a/subprojects/testfx-internal-java8/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java8/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.service.adapter;
+
+import java.util.Iterator;
+
+import javafx.scene.Node;
+import javafx.scene.input.KeyCode;
+import javafx.stage.Window;
+
+/**
+ * Provides consistent API for TestFX-Core subproject regardless of whether Java 8 or Java 9 is being used.
+ */
+public final class JavaVersionAdapter {
+
+    @SuppressWarnings("deprecated")
+    public static int convertToKeyCodeId(KeyCode keyCode) {
+        return keyCode.impl_getCode();
+    }
+
+    @SuppressWarnings("deprecated")
+    public static Iterator<Window> getWindows() {
+        return Window.impl_getWindows();
+    }
+
+    @SuppressWarnings("deprecated")
+    public static boolean isNotVisible(Node node) {
+        return !node.isVisible() || !node.impl_isTreeVisible();
+    }
+
+}

--- a/subprojects/testfx-internal-java8/testfx-internal-java8.gradle
+++ b/subprojects/testfx-internal-java8/testfx-internal-java8.gradle
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+
+ext.pomDescription = "TestFX Internal Java 8"

--- a/subprojects/testfx-internal-java8/testfx-internal-java8.gradle
+++ b/subprojects/testfx-internal-java8/testfx-internal-java8.gradle
@@ -16,3 +16,7 @@
  */
 
 ext.pomDescription = "TestFX Internal Java 8"
+
+dependencies {
+    compile "com.google.guava:guava:21.0"
+}

--- a/subprojects/testfx-internal-java9/src/main/java/module-info.java
+++ b/subprojects/testfx-internal-java9/src/main/java/module-info.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+
 module org.testfx.internal {
     requires java.base;
 

--- a/subprojects/testfx-internal-java9/src/main/java/module-info.java
+++ b/subprojects/testfx-internal-java9/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module org.testfx.internal {
+    requires java.base;
+
+    requires javafx.graphics;
+}

--- a/subprojects/testfx-internal-java9/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java9/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.service.adapter;
+
+import java.util.Iterator;
+
+import javafx.scene.Node;
+import javafx.scene.input.KeyCode;
+import javafx.stage.Window;
+
+/**
+ * Provides consistent API for TestFX-Core subproject regardless of whether Java 8 or Java 9 is being used.
+ */
+public final class JavaVersionAdapter {
+
+    public static int convertToKeyCodeId(KeyCode keyCode) {
+        return keyCode.getCode();
+    }
+
+    public static Iterator<Window> getWindows() {
+        return Window.getWindows().iterator();
+    }
+
+    public static boolean isNotVisible(Node node) {
+        return !node.isVisible();
+    }
+
+}

--- a/subprojects/testfx-internal-java9/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java9/src/main/java/org/testfx/service/adapter/JavaVersionAdapter.java
@@ -16,7 +16,8 @@
  */
 package org.testfx.service.adapter;
 
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.List;
 
 import javafx.scene.Node;
 import javafx.scene.input.KeyCode;
@@ -31,8 +32,8 @@ public final class JavaVersionAdapter {
         return keyCode.getCode();
     }
 
-    public static Iterator<Window> getWindows() {
-        return Window.getWindows().iterator();
+    public static List<Window> getWindows() {
+        return new ArrayList<>(Window.getWindows());
     }
 
     public static boolean isNotVisible(Node node) {

--- a/subprojects/testfx-internal-java9/testfx-internal-java9.gradle
+++ b/subprojects/testfx-internal-java9/testfx-internal-java9.gradle
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2015 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+
+ext.pomDescription = "TestFX Internal Java 9"

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
@@ -29,9 +29,17 @@ public class ApplicationRule extends FxRobot
         implements ApplicationFixture, TestRule {
 
     private final Consumer<Stage> start;
+    private final Consumer<Stage> stop;
+
+    private Stage stage;
 
     public ApplicationRule(Consumer<Stage> start) {
+        this(start, doNothing -> {});
+    }
+
+    public ApplicationRule(Consumer<Stage> start, Consumer<Stage> stop) {
         this.start = start;
+        this.stop = stop;
     }
 
     @Override
@@ -42,11 +50,12 @@ public class ApplicationRule extends FxRobot
     @Override
     public void start(Stage stage) throws Exception {
         start.accept(stage);
+        this.stage = stage;
     }
 
     @Override
     public void stop() throws Exception {
-        // do nothing
+        stop.accept(stage);
     }
 
     private void before() throws Exception {

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -31,6 +31,7 @@ import org.testfx.framework.junit.ApplicationTest;
 
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 public class ApplicationLaunchTest extends FxRobot {
 
@@ -69,7 +70,7 @@ public class ApplicationLaunchTest extends FxRobot {
     @Test
     public void should_contain_button() {
         // expect:
-        verifyThat(".button", hasText("click me!"));
+        verifyThat(".button", hasText("click me!"), informedErrorMessage(this));
     }
 
     @Test
@@ -78,7 +79,7 @@ public class ApplicationLaunchTest extends FxRobot {
         clickOn(".button");
 
         // then:
-        verifyThat(".button", hasText("clicked!"));
+        verifyThat(".button", hasText("clicked!"), informedErrorMessage(this));
     }
 
 }

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -27,6 +27,7 @@ import org.testfx.framework.junit.ApplicationTest;
 
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 public class ApplicationStartTest extends ApplicationTest {
 
@@ -59,7 +60,7 @@ public class ApplicationStartTest extends ApplicationTest {
     @Test
     public void should_contain_button() {
         // expect:
-        verifyThat(".button", hasText("click me!"));
+        verifyThat(".button", hasText("click me!"), informedErrorMessage(this));
     }
 
     @Test
@@ -68,7 +69,7 @@ public class ApplicationStartTest extends ApplicationTest {
         clickOn(".button");
 
         // then:
-        verifyThat(".button", hasText("clicked!"));
+        verifyThat(".button", hasText("clicked!"), informedErrorMessage(this));
     }
 
 }

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
@@ -19,6 +19,7 @@ package org.testfx.framework.junit;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,12 +30,15 @@ import static org.testfx.matcher.base.NodeMatchers.hasText;
 public class ApplicationRuleTest {
 
     @Rule
-    public ApplicationRule robot = new ApplicationRule(stage -> {
-        Button button = new Button("click me!");
-        button.setOnAction(actionEvent -> button.setText("clicked!"));
-        stage.setScene(new Scene(new StackPane(button), 100, 100));
-        stage.show();
-    });
+    public ApplicationRule robot = new ApplicationRule(
+        stage -> {
+            Button button = new Button("click me!");
+            button.setOnAction(actionEvent -> button.setText("clicked!"));
+            stage.setScene(new Scene(new StackPane(button), 100, 100));
+            stage.show();
+        },
+        Stage::close
+    );
 
     @Test
     public void should_contain_button() {

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -31,6 +31,7 @@ import org.testfx.framework.junit5.ApplicationTest;
 
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 public class ApplicationLaunchTest extends FxRobot {
 
@@ -69,7 +70,7 @@ public class ApplicationLaunchTest extends FxRobot {
     @Test
     void should_contain_button() {
         // expect:
-        verifyThat(".button", hasText("click me!"));
+        verifyThat(".button", hasText("click me!"), informedErrorMessage(this));
     }
 
     @Test
@@ -78,7 +79,7 @@ public class ApplicationLaunchTest extends FxRobot {
         clickOn(".button");
 
         // then:
-        verifyThat(".button", hasText("clicked!"));
+        verifyThat(".button", hasText("clicked!"), informedErrorMessage(this));
     }
 
 }

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -27,6 +27,7 @@ import org.testfx.framework.junit5.ApplicationTest;
 
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 class ApplicationStartTest extends ApplicationTest {
 
@@ -59,7 +60,7 @@ class ApplicationStartTest extends ApplicationTest {
     @Test
     void should_contain_button() {
         // expect:
-        verifyThat(".button", hasText("click me!"));
+        verifyThat(".button", hasText("click me!"), informedErrorMessage(this));
     }
 
     @Test
@@ -68,7 +69,7 @@ class ApplicationStartTest extends ApplicationTest {
         clickOn(".button");
 
         // then:
-        verifyThat(".button", hasText("clicked!"));
+        verifyThat(".button", hasText("clicked!"), informedErrorMessage(this));
     }
 
 }


### PR DESCRIPTION
There's a number of issues with the current state of this PR only because I'm not yet familiar with how to set up some things with Java 9 or integrate it into this project's somewhat complex build system.

- Tests don't work correctly due to not having access to things
- Javadoc warns of bad javadoc (using `&` instead `&amp;` and `>` instead of `&gt;`)
- CI files need to be updated

At least that was the issues it raised. I changed something in the build file and now it doesn't work due to 
````
* What went wrong:
Execution failed for task ':testfx-internal-java9:javadoc'.
> Could not write to file 
    'TestFX/subprojects/testfx-internal-java9/build/tmp/javadoc/javadoc.options'.
`````
