### PR TITLE
Flaky test: org.testfx.cases.acceptance.FxAssertBasicTest > button_has_label 

### DIFF
--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -17,10 +17,8 @@
 package org.testfx.cases.acceptance;
 
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
 
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.stage.Stage;
@@ -96,10 +94,10 @@ public class FxAssertBasicTest extends TestCaseBase {
     }
 
     @Test
-    public void button_has_label() {
+    public void button_has_label() throws InterruptedException, ExecutionException {
         // when:
         clickOn("#button");
-
+        
         // then:
         verifyThat("#button", hasText("clicked!"), informedErrorMessage(this));
     }
@@ -124,28 +122,13 @@ public class FxAssertBasicTest extends TestCaseBase {
         public void start(Stage stage) {
             Button button = new Button("click me!");
             button.setId("button");
-            button.setOnAction(actionEvent -> {
-                invokeAndWait(() -> button.setText("clicked!")); });
+            button.setOnAction(action -> { 
+                button.setText("clicked!"); 
+                action.consume(); });
             Scene scene = new Scene(button, 600, 400);
             stage.setScene(scene);
             stage.setTitle(getClass().getSimpleName());
             stage.show();
-        }
-        
-        public void invokeAndWait(Runnable r) {
-            if (Platform.isFxApplicationThread()) {
-                r.run();
-            } else {
-                System.out.println("Not in JavaFX GUI Thread");
-                FutureTask<Void> task = new FutureTask<>(r, null);
-                Platform.runLater(task);
-                try {
-                    task.get();
-                } 
-                catch (InterruptedException | ExecutionException e) {
-                    throw new RuntimeException(e);
-                }
-            }
         }
     }
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -19,7 +19,6 @@ package org.testfx.cases.acceptance;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.input.MouseButton;
 import javafx.stage.Stage;
 
 import org.junit.Before;
@@ -95,7 +94,7 @@ public class FxAssertBasicTest extends TestCaseBase {
     @Test
     public void button_has_label() {
         // when:
-        moveTo("#button").sleep(5000).clickOn(MouseButton.PRIMARY);
+        clickOn("#button");
         
         // then:
         verifyThat("#button", hasText("clicked!"), informedErrorMessage(this));
@@ -125,8 +124,8 @@ public class FxAssertBasicTest extends TestCaseBase {
             Scene scene = new Scene(button, 600, 400);
             stage.setScene(scene);
             stage.setTitle(getClass().getSimpleName());
-            stage.setAlwaysOnTop(true);
             stage.show();
+            stage.setAlwaysOnTop(true);
         }
     }
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -19,6 +19,7 @@ package org.testfx.cases.acceptance;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.input.MouseButton;
 import javafx.stage.Stage;
 
 import org.junit.Before;
@@ -94,7 +95,7 @@ public class FxAssertBasicTest extends TestCaseBase {
     @Test
     public void button_has_label() {
         // when:
-        clickOn("#button");
+        moveTo("#button").sleep(5000).clickOn(MouseButton.PRIMARY);
         
         // then:
         verifyThat("#button", hasText("clicked!"), informedErrorMessage(this));
@@ -120,12 +121,11 @@ public class FxAssertBasicTest extends TestCaseBase {
         public void start(Stage stage) {
             Button button = new Button("click me!");
             button.setId("button");
-            button.setOnAction(action -> { 
-                button.setText("clicked!"); 
-                action.consume(); });
+            button.setOnAction(action -> button.setText("clicked!"));
             Scene scene = new Scene(button, 600, 400);
             stage.setScene(scene);
             stage.setTitle(getClass().getSimpleName());
+            stage.setAlwaysOnTop(true);
             stage.show();
         }
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -16,7 +16,11 @@
  */
 package org.testfx.cases.acceptance;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.stage.Stage;
@@ -120,12 +124,28 @@ public class FxAssertBasicTest extends TestCaseBase {
         public void start(Stage stage) {
             Button button = new Button("click me!");
             button.setId("button");
-            button.setOnAction(actionEvent -> button.setText("clicked!"));
+            button.setOnAction(actionEvent -> {
+                invokeAndWait(() -> button.setText("clicked!")); });
             Scene scene = new Scene(button, 600, 400);
             stage.setScene(scene);
             stage.setTitle(getClass().getSimpleName());
             stage.show();
         }
+        
+        public void invokeAndWait(Runnable r) {
+            if (Platform.isFxApplicationThread()) {
+                r.run();
+            } else {
+                System.out.println("Not in JavaFX GUI Thread");
+                FutureTask<Void> task = new FutureTask<>(r, null);
+                Platform.runLater(task);
+                try {
+                    task.get();
+                } 
+                catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
     }
-
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -16,8 +16,6 @@
  */
 package org.testfx.cases.acceptance;
 
-import java.util.concurrent.ExecutionException;
-
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -94,7 +92,7 @@ public class FxAssertBasicTest extends TestCaseBase {
     }
 
     @Test
-    public void button_has_label() throws InterruptedException, ExecutionException {
+    public void button_has_label() {
         // when:
         clickOn("#button");
         

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -120,7 +120,7 @@ public class FxAssertBasicTest extends TestCaseBase {
         public void start(Stage stage) {
             Button button = new Button("click me!");
             button.setId("button");
-            button.setOnAction(action -> button.setText("clicked!"));
+            button.setOnAction(actionEvent -> button.setText("clicked!"));
             Scene scene = new Scene(button, 600, 400);
             stage.setScene(scene);
             stage.setTitle(getClass().getSimpleName());

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -46,6 +46,7 @@ public class ApplicationLaunchTest extends FxRobot {
             button.setOnAction((actionEvent) -> button.setText("clicked!"));
             stage.setScene(new Scene(new StackPane(button), 100, 100));
             stage.show();
+            stage.setAlwaysOnTop(true);
         }
     }
 

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -46,6 +46,7 @@ public class ApplicationLaunchTest extends FxRobot {
             button.setOnAction((actionEvent) -> button.setText("clicked!"));
             stage.setScene(new Scene(new StackPane(button), 100, 100));
             stage.show();
+            stage.setAlwaysOnTop(true);
         }
     }
 


### PR DESCRIPTION
When the action is consumed, then on Window and MacOS the test will pass repeatedly.
I couldnt reproduce any failures to this test after the change.

However, I'm not sure yet if this is the right way, so I'm happy about feedback.
Thanks.