### PR TITLE
Propagate uncaught exceptions

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -600,6 +600,7 @@ public class FxRobot implements FxRobotInterface {
     // IMPLEMENTATION OF SCROLL ROBOT.
     //---------------------------------------------------------------------------------------------
 
+    @Override
     @Deprecated
     public FxRobot scroll(int amount) {
         context.getScrollRobot().scroll(amount);

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -53,6 +53,7 @@ public class KeyboardRobotImpl implements KeyboardRobot {
     //---------------------------------------------------------------------------------------------
 
     private final Set<KeyCode> pressedKeys = new HashSet<>();
+    @Override
     public final Set<KeyCode> getPressedKeys() {
         return Collections.unmodifiableSet(pressedKeys);
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
@@ -42,6 +42,7 @@ public class MouseRobotImpl implements MouseRobot {
     //---------------------------------------------------------------------------------------------
 
     private final Set<MouseButton> pressedButtons = new HashSet<>();
+    @Override
     public final Set<MouseButton> getPressedButtons() {
         return Collections.unmodifiableSet(pressedButtons);
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -102,6 +102,7 @@ public class WaitForAsyncUtils {
     /**
      * If {@literal true} any exceptions encountered during execution of the
      * {@code async} methods will be printed to stderr.
+     * The exceptions will be printed at the time they occur (not when fetched).
      */
     public static boolean printException = true;
 
@@ -116,6 +117,12 @@ public class WaitForAsyncUtils {
      * unhandled exceptions in any Thread.
      */
     public static boolean checkAllExceptions = true;
+    
+    /**
+     * If {@literal true} exceptions will be printed when they are fetched by a caller.
+     * Even when they are handled properly. This field is mainly for development debug purposes.
+     */
+    public static final boolean TRACE_FETCH = false;
 
     /**
      * Static initialization of WaitForAsyncUtils.
@@ -138,7 +145,6 @@ public class WaitForAsyncUtils {
      * {@link checkAllExceptions}.
      */
     public static void setup() {
-        System.out.println("Setup Async");
         if (checkAllExceptions) {
             //install handler
             Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
@@ -155,6 +161,11 @@ public class WaitForAsyncUtils {
      */
     private static void registerException(Throwable throwable) {
         if (checkAllExceptions) {
+            //Workaround for #411 see discussion in #440
+            if (throwable.getStackTrace()[0].getClassName().equals("com.sun.javafx.tk.quantum.PaintCollector")) {
+                //TODO more general version of filter after refactoring
+                return;
+            }
             if (printException) {
                 printException(throwable, null);
             }
@@ -523,12 +534,15 @@ public class WaitForAsyncUtils {
     // ---------------------------------------------------------------------------------------------
 
     /**
-     * Internal function that allows throws Exceptions. It does not require handling
+     * Internal function that throws Exceptions. It does not require handling
      * of the Exceptions.
      */
     private static void checkExceptionWrapped() {
         Throwable throwable = getCheckException();
         if (throwable instanceof RuntimeException) {
+            if (TRACE_FETCH) {
+                printException(throwable, Thread.currentThread().getStackTrace());
+            }
             throw (RuntimeException) throwable;
         } else if (throwable instanceof Error) {
             throw (Error) throwable;
@@ -714,6 +728,9 @@ public class WaitForAsyncUtils {
                 if (exception != null) {
                     exceptions.remove(exception);
                     exception = null;
+                }
+                if (TRACE_FETCH) {
+                    printException(e, Thread.currentThread().getStackTrace());
                 }
                 throw e;
             }

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
@@ -182,30 +182,37 @@ public class PointLocatorImplTest {
     public static class BoundsLocatorStub implements BoundsLocator {
         public Bounds bounds;
 
+        @Override
         public Bounds boundsInSceneFor(Node node) {
             return bounds;
         }
 
+        @Override
         public Bounds boundsInWindowFor(Scene scene) {
             return bounds;
         }
 
+        @Override
         public Bounds boundsInWindowFor(Bounds boundsInScene, Scene scene) {
             return bounds;
         }
 
+        @Override
         public Bounds boundsOnScreenFor(Node node) {
             return bounds;
         }
 
+        @Override
         public Bounds boundsOnScreenFor(Scene scene) {
             return bounds;
         }
 
+        @Override
         public Bounds boundsOnScreenFor(Window window) {
             return bounds;
         }
 
+        @Override
         public Bounds boundsOnScreenFor(Bounds boundsInScene, Scene scene) {
             return bounds;
         }

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
@@ -73,7 +73,7 @@ public class WaitForAsyncUtilsTest {
 
         // then:
         assertThat(future.isDone(), Matchers.is(false));
-        WaitForAsyncUtils.sleep(100, MILLISECONDS);
+        WaitForAsyncUtils.sleep(250, MILLISECONDS);
         assertThat(future.get(), Matchers.is("foo"));
         waitForThreads(future);
     }
@@ -205,14 +205,14 @@ public class WaitForAsyncUtilsTest {
 
     @Test
     public void waitFor_with_future_with_sleep() throws Exception {
+        thrown.expect(TimeoutException.class);
         // when:
         Future<Void> future = WaitForAsyncUtils.async(() -> {
-            WaitForAsyncUtils.sleepWithException(100, MILLISECONDS);
+            WaitForAsyncUtils.sleepWithException(250, MILLISECONDS);
             return null;
         });
 
         // then:
-        thrown.expect(TimeoutException.class);
         WaitForAsyncUtils.waitFor(50, MILLISECONDS, future);
         waitForThreads(future);
     }
@@ -224,7 +224,7 @@ public class WaitForAsyncUtilsTest {
 
         // when:
         Future<Void> future = WaitForAsyncUtils.async(() -> {
-            WaitForAsyncUtils.sleepWithException(100, MILLISECONDS);
+            WaitForAsyncUtils.sleepWithException(250, MILLISECONDS);
             return null;
         });
         try {

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit;
+
+import java.util.concurrent.TimeoutException;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+import org.testfx.api.FxToolkit;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.fail;
+
+
+/**
+ * This class tests exception handling of the GUI within the JUnit framework.
+ * 
+ */
+public class JUnitExceptionTest  extends ApplicationTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public Timeout globalTimeout = Timeout.millis(10000);
+
+    
+    @BeforeClass
+    public static void setUpClass() {
+        try {
+            FxToolkit.registerPrimaryStage();
+        }
+        catch (TimeoutException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        Button button = new Button("Throws Exception");
+        button.setOnAction(e ->  {
+            throw new UnsupportedOperationException("Something Went Wrong: Notice me");
+        });
+        StackPane root = new StackPane(button);
+
+        Scene scene = new Scene(root, 200, 150);
+        primaryStage.setScene(scene);
+        primaryStage.setTitle("Hello World");
+        primaryStage.show();
+    }
+
+    /**
+     * This test checks if the exceptions triggered by a mouse click are correctly thrown.
+     * Tests issue 155.
+     * @throws Throwable
+     */
+    @Test
+    public void exceptionOnClickTest() throws Throwable {
+        // Hints for failing tests: Timing might be an issue increase also the
+        // time in checkException()
+        // given:
+        WaitForAsyncUtils.printException = false; // do not print expected exception to log
+        thrown.expectCause(instanceOf(UnsupportedOperationException.class));
+        WaitForAsyncUtils.clearExceptions(); // just ensure no other test put an exception into the buffer
+        try{
+            clickOn("Throws Exception"); // does already handle all the async stuff...
+            WaitForAsyncUtils.checkException(); // need to check Exception, as event is executed after click
+            fail("checkException didn't detect Exception");
+        }catch(Exception e){ //clean up...
+            release(MouseButton.PRIMARY);
+            moveBy(100,100); //otherwise the press release test fails?!
+            WaitForAsyncUtils.printException = true; // enable printing for other tests
+            WaitForAsyncUtils.clearExceptions(); // just ensure no pending exceptions in buffer
+            throw e;
+        }
+    }
+
+
+}

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
@@ -85,13 +85,14 @@ public class JUnitExceptionTest  extends ApplicationTest {
         WaitForAsyncUtils.printException = false; // do not print expected exception to log
         thrown.expectCause(instanceOf(UnsupportedOperationException.class));
         WaitForAsyncUtils.clearExceptions(); // just ensure no other test put an exception into the buffer
-        try{
+        try {
             clickOn("Throws Exception"); // does already handle all the async stuff...
             WaitForAsyncUtils.checkException(); // need to check Exception, as event is executed after click
             fail("checkException didn't detect Exception");
-        }catch(Exception e){ //clean up...
+        } 
+        catch (Exception e) { //clean up...
             release(MouseButton.PRIMARY);
-            moveBy(100,100); //otherwise the press release test fails?!
+            moveBy(100, 100); //otherwise the press release test fails?!
             WaitForAsyncUtils.printException = true; // enable printing for other tests
             WaitForAsyncUtils.clearExceptions(); // just ensure no pending exceptions in buffer
             throw e;


### PR DESCRIPTION
## Issue
When using the FXRobot for actions causing exceptions, these can not be caught by TestFX.
See #155 for detailed discussion.

## Analysis
Currently the `WaitForAsyncUtilsFx` do support fetching of a method on any thread. But when using the `FXRobotInterface` (e.g. click) the events are enqueued on the `FXApplicationThread` by the underlying Robot implementation. This way the calling method may not receive any exceptions depending on the implementation (tested with `AWTRobotAdapter` on Mac).

As I couldn't find a way to provide a custom event implementation, that forwards the exception, the only way to implement this feature is to fetch all exceptions.

## Proposed Solution
The `WaitForAsyncUtilsFx` have been extended to provide a default exception handler, that integrates into the existing exception handling of the asynchronous method calls and is used for all uncaught exceptions in any thread. As with the existing process, those exceptions are wrapped in a `RuntimeException` put in an internal exception buffer by the executing thread. This buffer needs to be checked on the (JUnit-) test thread by calling the method `WaitForAsyncUtils.checkException()` or any of the `waitFor` methods.

This behaviour may be disabled by the static field `WaitForAsyncUtils.checkAllExceptions`. A example can be found in `org.testfx.framework.junit.JUnitExceptionTest`.

## Open issues

- Asynchronous exception handling regarding tests: If one test causes an exception, but it is not handled in this test, the exception will be thrown on the next test that handles exceptions (or uses the wait methods).
- Missing stack trace to line in test code: In contrast to the existing exception handling, that supports a stacktrace to the cause of the exception itself and a trace to the line of the asynchronous call, the exceptions fetched by the default handler only support a trace to the cause of the exception in the executing thread. This is particularly impractical if the exception was triggered by another test case (see above).
- Multi exceptions: Each call to one of the exception checking methods throws only the first exception occurred. The remaining Exceptions remain in the buffer and will be thrown on subsequent calls. So if the buffer is not fully cleared, exceptions are forwarded to the next test.
- Timing: As the events are enqueued by the Robot implementation, the timing of the exceptions can not be guaranteed (tested only on my system). Timeouts may be increased in the future.