### PR TITLE
(enhancement) Issue #441 - OSGi Headers in Manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ allprojects { project ->
 subprojects { subproject ->
     // provide java configurations and tasks.
     apply(plugin: "java")
+    apply(plugin: "osgi")
 
     apply(from: rootProject.file("gradle/check-checkstyle.gradle"))
     if (!usingJava9) {

--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ subprojects { subproject ->
     // configure javadoc task.
     javadoc {
         excludes = ["**/*.html", "META-INF/**"]
-        classpath = configurations.compile + configurations.providedCompile
+        classpath = configurations.compile + configurations.providedCompile + configurations.compileOnly
         options.use         = true
         options.splitIndex  = true
         options.encoding    = "UTF-8"

--- a/subprojects/testfx-core/src/main/java/org/testfx/osgi/Activator.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/osgi/Activator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2017 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+
+package org.testfx.osgi;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.testfx.osgi.service.TestFx;
+
+public class Activator implements BundleActivator {
+
+    private ServiceRegistration<TestFx> serviceRegistration;
+
+    @Override
+    public void start(final BundleContext context) throws Exception {
+        serviceRegistration = context.registerService(TestFx.class, () -> true, null);
+    }
+
+    @Override
+    public void stop(final BundleContext context) throws Exception {
+        serviceRegistration.unregister();
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/osgi/service/TestFx.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/osgi/service/TestFx.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2015 The TestFX Contributors
+ * Copyright 2014-2017 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
  * not use this work except in compliance with the Licence.
  *
  * You may obtain a copy of the Licence at:
- * http://ec.europa.eu/idabc/eupl
+ * http://ec.europa.eu/idabc/eupl.html
  *
  * Unless required by applicable law or agreed to in writing, software distributed
  * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
@@ -15,11 +15,12 @@
  * specific language governing permissions and limitations under the Licence.
  */
 
-ext.pomDescription = "TestFX Internal Java 9"
+package org.testfx.osgi.service;
 
-jar {
-    manifest {
-        instruction 'Fragment-Host', 'org.testfx.core'
-        instruction 'Provide-Capability', 'org.testfx.osgi.versionadapter'
-    }
+/**
+ * Always returns true once the TestFx core bundle has been resolved and this interface has therefore been
+ * registered as a service.
+ */
+public interface TestFx {
+    boolean isActive();
 }

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -28,6 +28,7 @@ dependencies {
     compile "com.google.guava:guava:21.0"
     compile "org.hamcrest:hamcrest-core:1.3"
     compile 'com.google.code.findbugs:annotations:3.0.1u2'
+    compile 'org.osgi:org.osgi.core:6.0.0'
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.7.22"
@@ -66,3 +67,29 @@ compileTestJava {
     }
 }
 
+jar {
+    manifest {
+        instruction 'Import-Package', 'javax.annotation;bundle-symbolic-name=\"findbugsAnnotations\",*'
+        instruction 'Export-Package', 'org.testfx.api,\n' +
+                '                            org.testfx.matcher.base,\n' +
+                '                            org.testfx.matcher.control,\n' +
+                '                            org.testfx.robot,\n' +
+                '                            org.testfx.robot.impl,\n' +
+                '                            org.testfx.service.adapter,\n' +
+                '                            org.testfx.service.adapter.impl,\n' +
+                '                            org.testfx.service.finder,\n' +
+                '                            org.testfx.service.finder.impl,\n' +
+                '                            org.testfx.service.locator,\n' +
+                '                            org.testfx.service.locator.impl,\n' +
+                '                            org.testfx.service.query,\n' +
+                '                            org.testfx.service.query.impl,\n' +
+                '                            org.testfx.service.support,\n' +
+                '                            org.testfx.service.support.impl,\n' +
+                '                            org.testfx.toolkit,\n' +
+                '                            org.testfx.toolkit.impl,\n' +
+                '                            org.testfx.util,\n' +
+                '                            org.testfx.osgi.service'
+        instruction 'Bundle-Activator', 'org.testfx.osgi.Activator'
+        instruction 'Require-Capability', 'org.testfx.osgi.versionadapter'
+    }
+}

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile "com.google.guava:guava:21.0"
     compile "org.hamcrest:hamcrest-core:1.3"
     compile 'com.google.code.findbugs:annotations:3.0.1u2'
-    compile 'org.osgi:org.osgi.core:6.0.0'
+    compileOnly 'org.osgi:org.osgi.core:6.0.0'
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.7.22"
@@ -70,25 +70,7 @@ compileTestJava {
 jar {
     manifest {
         instruction 'Import-Package', 'javax.annotation;bundle-symbolic-name=\"findbugsAnnotations\",*'
-        instruction 'Export-Package', 'org.testfx.api,\n' +
-                '                            org.testfx.matcher.base,\n' +
-                '                            org.testfx.matcher.control,\n' +
-                '                            org.testfx.robot,\n' +
-                '                            org.testfx.robot.impl,\n' +
-                '                            org.testfx.service.adapter,\n' +
-                '                            org.testfx.service.adapter.impl,\n' +
-                '                            org.testfx.service.finder,\n' +
-                '                            org.testfx.service.finder.impl,\n' +
-                '                            org.testfx.service.locator,\n' +
-                '                            org.testfx.service.locator.impl,\n' +
-                '                            org.testfx.service.query,\n' +
-                '                            org.testfx.service.query.impl,\n' +
-                '                            org.testfx.service.support,\n' +
-                '                            org.testfx.service.support.impl,\n' +
-                '                            org.testfx.toolkit,\n' +
-                '                            org.testfx.toolkit.impl,\n' +
-                '                            org.testfx.util,\n' +
-                '                            org.testfx.osgi.service'
+        instruction 'Export-Package', '*'
         instruction 'Bundle-Activator', 'org.testfx.osgi.Activator'
         instruction 'Require-Capability', 'org.testfx.osgi.versionadapter'
     }

--- a/subprojects/testfx-internal-java8/testfx-internal-java8.gradle
+++ b/subprojects/testfx-internal-java8/testfx-internal-java8.gradle
@@ -20,3 +20,10 @@ ext.pomDescription = "TestFX Internal Java 8"
 dependencies {
     compile "com.google.guava:guava:21.0"
 }
+
+jar {
+    manifest {
+        instruction 'Fragment-Host', 'org.testfx.core'
+        instruction 'Provide-Capability', 'org.testfx.osgi.versionadapter'
+    }
+}


### PR DESCRIPTION
Modifies the Gradle build files in -core, -java8 and -java9 to build OSGi compatible bundles and introduces OSGi specific class 'Activator'.

-core bundle acts as a Host to either -java8 or -java9 (Fragment) bundles and one of the Fragments must be installed during test for -core to become active.

Dependency on findbugs.annotations caused issues as JSR305 is not yet official and shares package space, javax.annotations,  with annotations 1.2. Explicitly forced version dependency but there can be issues with Guava which has an optional dependency on java.annotations which unless handled carefully can be resolved to annotations 1.2.

No existing TestFx code has been modified and only a single OSGi specific Activator class has been introduced. This provides an injectable service which can be used to prevent any tests (e.g. Pax-Exam) from running until TestFx has been resolved.