### PR TITLE
(fix) Remove Findbugs annotations.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
@@ -23,8 +23,6 @@ import javafx.scene.paint.Color;
 import org.testfx.service.support.PixelMatcher;
 import org.testfx.util.ColorUtils;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
 
     //---------------------------------------------------------------------------------------------
@@ -57,8 +55,6 @@ public class PixelMatcherRgb extends PixelMatcherBase implements PixelMatcher {
     //---------------------------------------------------------------------------------------------
 
     @Override
-    @SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY", justification = "checking for initialized value " +
-            "(not result of computation)")
     public boolean matchColors(Color color0, Color color1) {
         if (minColorDistSq == Double.MIN_VALUE) {
             double maxColorDistSq = ColorUtils.calculateColorDistSq(Color.BLACK, Color.WHITE);

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -35,8 +35,6 @@ import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableBooleanValue;
 
-import javax.annotation.Nonnull;
-
 import com.google.common.base.Stopwatch;
 import org.testfx.api.annotation.Unstable;
 
@@ -117,7 +115,7 @@ public class WaitForAsyncUtils {
      * unhandled exceptions in any Thread.
      */
     public static boolean checkAllExceptions = true;
-    
+
     /**
      * If {@literal true} exceptions will be printed when they are fetched by a caller.
      * Even when they are handled properly. This field is mainly for development debug purposes.
@@ -126,13 +124,13 @@ public class WaitForAsyncUtils {
 
     /**
      * Static initialization of WaitForAsyncUtils.
-     * Should be initialized with the FXToolkit, but the static initialization ensures, 
+     * Should be initialized with the FXToolkit, but the static initialization ensures,
      * that it is setup before the first use.
      */
     static {
         setup();
     }
-    
+
 
     // ---------------------------------------------------------------------------------------------
     // STATIC METHODS.
@@ -141,7 +139,7 @@ public class WaitForAsyncUtils {
     // GLOBAL EXCEPTION HANDLING
     /**
      * Needs to be called to setup WaitForAsyncUtils before the first use.
-     * Currently it installs/removes the handler for uncaught exceptions depending on the flag 
+     * Currently it installs/removes the handler for uncaught exceptions depending on the flag
      * {@link checkAllExceptions}.
      */
     public static void setup() {
@@ -154,7 +152,7 @@ public class WaitForAsyncUtils {
             Thread.setDefaultUncaughtExceptionHandler((t, e) -> {});
         }
     }
-    
+
     /**
      * Used to add an exception on the stack. Used by the global exception handler.
      * @param throwable the throwable to add on the local exception buffer.
@@ -173,7 +171,7 @@ public class WaitForAsyncUtils {
             exceptions.add(new RuntimeException(throwable));
         }
     }
-    
+
 
     // ASYNC METHODS.
 
@@ -737,7 +735,7 @@ public class WaitForAsyncUtils {
         }
 
         @Override
-        public X get(long timeout, @Nonnull TimeUnit unit)
+        public X get(long timeout, TimeUnit unit)
                 throws InterruptedException, ExecutionException, TimeoutException {
             try {
                 return super.get(timeout, unit);

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -27,7 +27,6 @@ dependencies {
 
     compile "com.google.guava:guava:21.0"
     compile "org.hamcrest:hamcrest-core:1.3"
-    compile 'com.google.code.findbugs:annotations:3.0.1u2'
     compileOnly 'org.osgi:org.osgi.core:6.0.0'
 
     testCompile "junit:junit:4.12"
@@ -69,7 +68,6 @@ compileTestJava {
 
 jar {
     manifest {
-        instruction 'Import-Package', 'javax.annotation;bundle-symbolic-name=\"findbugsAnnotations\",*'
         instruction 'Export-Package', '*'
         instruction 'Bundle-Activator', 'org.testfx.osgi.Activator'
         instruction 'Require-Capability', 'org.testfx.osgi.versionadapter'


### PR DESCRIPTION
This is done so that the dreaded jsr305 dependency is not pulled
in transitively for TestFX. This particular dependency has caused many
issues with Java 9 migration because of it using the "javax.annotation"
package. It is easiest for us just to drop the one usage we have of it.

Ping @jtkb - does this break your work on osgi or is it okay?