### PR TITLE
(chore) Fix codecov paths for core project.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,6 @@ coverage:
         url: "https://webhooks.gitter.im/e/2532276e31bee9ba82b7"
 
 comment: false
+
+fixes:
+  - "::subprojects/testfx-core/" # FIXME: This will only fix paths for testfx-core project


### PR DESCRIPTION
We want to fix the paths for every subproject but I am not sure how to
do this currently because we lose information when copying all the
jacoco reports to the same directory.