### PR TITLE
(enhancement) Add module-info.java to testfx-core.

### DIFF
--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -6,20 +6,9 @@ JAVA_VER=$(java -version 2>&1 | grep -i version | sed 's/.*version ".*\.\(.*\)\.
 echo "Checking java version: ${JAVA_VER}"
 if [[ "${JAVA_VER}" == 8 ]]; then
   echo "Uploading code coverage results to codecov.io"
-  # Download codecov bash from master branch as codecov.io/bash lags behind
   curl -s https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov > codecov
   chmod +x codecov
-  script=$(cat ./codecov.yml)
-  export projects="testfx-core testfx-junit testfx-junit5 testfx-spock"
-  for project in ${projects};
-  do
-    # Add directory fixes for each subproject so source code navigation on codecov.io works correctly.
-    printf "%s\nfixes:\n  - \"::subprojects/%s/\"\n" "$script" "$project" >> ./codecov_"$project".yml
-    echo "------- Code Coverage File: --------"
-    cat ./codecov_"$project".yml
-    echo "------- End Code Coverage File --------"
-    ./codecov -f "subprojects/$project/build/reports/jacoco/test/jacocoTestReport.xml" -F ${project//-/_} -y codecov_"$project".yml
-  done
+  ./codecov
   .ci/update_snapshot_docs.sh
 fi
 

--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   brew update
   if [[ "${TRAVIS_JAVA_VERSION}" == 8 ]]; then
-    brew cask reinstall java8
+    brew cask reinstall caskroom/versions/java8
   elif [[ "${TRAVIS_JAVA_VERSION}" == 9 ]]; then
     brew cask reinstall java
   else

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "which java: $(which java)"
 ulimit -c unlimited -S
 
-./gradlew versions test jacocoTestReport --info
+./gradlew versions test jacocoRootReport --info
 
 # Print core dumps when JVM crashes.
 RESULT=$?

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "which java: $(which java)"
 ulimit -c unlimited -S
 
-./gradlew versions test jacocoRootReport --info
+./gradlew versions test jacocoRootReport coveralls --info
 
 # Print core dumps when JVM crashes.
 RESULT=$?

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Travis CI](https://img.shields.io/travis/TestFX/TestFX/master.svg?label=travis&style=flat-square)](https://travis-ci.org/TestFX/TestFX)
 [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/testfx/testfx/master.svg?style=flat-square)](https://ci.appveyor.com/project/testfx/testfx/branch/master)
-[![Codecov Test Coverage](https://img.shields.io/codecov/c/github/testfx/testfx/master.svg?style=flat-square)](https://codecov.io/gh/TestFX/TestFX)
-[![Coveralls Test Coverage](https://img.shields.io/coveralls/github/jekyll/jekyll/master.svg?style=flat-square)](https://coveralls.io/github/TestFX/TestFX)
+[![Coveralls Test Coverage](https://img.shields.io/coveralls/github/testfx/testfx/master.svg?style=flat-square)](https://coveralls.io/github/TestFX/TestFX)
 [![Bintray JCenter](https://img.shields.io/bintray/v/testfx/testfx/testfx-core.svg?label=bintray&style=flat-square)](https://bintray.com/testfx/testfx)
 [![Maven Central](https://img.shields.io/maven-central/v/org.testfx/testfx-core.svg?label=maven&style=flat-square)](https://search.maven.org/#search|ga|1|org.testfx)
 [![Chat on Gitter](https://img.shields.io/gitter/room/testfx/testfx-core.svg?style=flat-square)](https://gitter.im/TestFX/TestFX)
@@ -99,11 +98,9 @@ dependencies {
 
 ## Documentation
 
-- [How to use TestFX in your project][100]
 - [How to build and deploy TestFX][101]
 - [How to contribute][102]
 
-[100]: https://github.com/TestFX/TestFX/wiki/How-to-use-TestFX-in-your-project
 [101]: https://github.com/TestFX/TestFX/wiki/How-to-build-and-deploy-TestFX
 [102]: https://github.com/TestFX/TestFX/wiki/How-to-Contribute
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Travis CI](https://img.shields.io/travis/TestFX/TestFX/master.svg?label=travis&style=flat-square)](https://travis-ci.org/TestFX/TestFX)
 [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/testfx/testfx/master.svg?style=flat-square)](https://ci.appveyor.com/project/testfx/testfx/branch/master)
 [![Codecov Test Coverage](https://img.shields.io/codecov/c/github/testfx/testfx/master.svg?style=flat-square)](https://codecov.io/gh/TestFX/TestFX)
+[![Coveralls Test Coverage](https://img.shields.io/coveralls/github/jekyll/jekyll/master.svg?style=flat-square)](https://coveralls.io/github/TestFX/TestFX)
 [![Bintray JCenter](https://img.shields.io/bintray/v/testfx/testfx/testfx-core.svg?label=bintray&style=flat-square)](https://bintray.com/testfx/testfx)
 [![Maven Central](https://img.shields.io/maven-central/v/org.testfx/testfx-core.svg?label=maven&style=flat-square)](https://search.maven.org/#search|ga|1|org.testfx)
 [![Chat on Gitter](https://img.shields.io/gitter/room/testfx/testfx-core.svg?style=flat-square)](https://gitter.im/TestFX/TestFX)

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
         jcenter()
     }
 }
+
 plugins {
     id "com.github.hierynomus.license" version "0.14.0"
     id "com.jfrog.bintray" version "1.8.0"

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ plugins {
     id "com.github.hierynomus.license" version "0.14.0"
     id "com.jfrog.bintray" version "1.8.0"
     id 'com.github.ben-manes.versions' version '0.17.0'
+    id 'com.github.kt3k.coveralls' version '2.8.2'
 }
 
 rootProject.with { project ->
@@ -69,8 +70,10 @@ rootProject.with { project ->
 allprojects { project ->
     apply plugin: 'base'
     apply plugin: 'java'
+    apply plugin: 'com.github.kt3k.coveralls'
     apply plugin: 'jacoco'
     apply from: "${rootDir}/gradle/jacoco.gradle"
+    apply from: "${rootDir}/gradle/travis-helpers.gradle"
 
     configurations {
         providedCompile
@@ -96,7 +99,6 @@ subprojects { subproject ->
     apply from: "${rootDir}/gradle/publish-jar.gradle"
     apply from: "${rootDir}/gradle/publish-maven.gradle"
     apply from: "${rootDir}/gradle/publish-bintray.gradle"
-    apply from: "${rootDir}/gradle/travis-helpers.gradle"
 
     sourceSets.main.compileClasspath += configurations.providedCompile
     sourceSets.test.compileClasspath += configurations.providedCompile
@@ -263,8 +265,20 @@ task jacocoRootReport(type: JacocoReport, group: 'Coverage reports') {
     executionData = files(subprojects.jacocoTestReport.executionData).filter { it.exists() }
 
     reports {
-        html.enabled = true // human readable
-        xml.enabled = true // required by coveralls
+        html.enabled = true
+        xml.enabled = true
     }
 }
 
+coveralls {
+    sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
+    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
+}
+
+tasks.coveralls {
+    group = 'Coverage reports'
+    description = 'Uploads the aggregated coverage report to Coveralls'
+
+    dependsOn jacocoRootReport
+    onlyIf { isTravis && !JavaVersion.current().isJava9Compatible() }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2015 The TestFX Contributors
+ * Copyright 2014-2017 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -34,14 +34,8 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.17.0'
 }
 
-//-------------------------------------------------------------------------------------------------
-// ROOT PROJECT.
-//-------------------------------------------------------------------------------------------------
-
 rootProject.with { project ->
     // provide assemble and clean tasks.
-    apply(plugin: "base")
-
     // task to add gradle wrapper files.
     task("wrapper", type: Wrapper) {
         gradleVersion = '4.3.1'
@@ -67,48 +61,42 @@ rootProject.with { project ->
 
         // add java version and vendor to project attributes.
         javaVersion = System.properties["java.version"]
-
         usingJava9 = javaVersion.startsWith("9")
-        javaSourceAndTargetCompilation = usingJava9 ? "9" : "1.8"
-
-        if (usingJava9) {
-            javadocLinks = [
-                    "https://docs.oracle.com/javase/9/docs/api"
-            ]
-        } else {
-            javadocLinks = [
-                    "http://docs.oracle.com/javase/8/docs/api/",
-                    "http://docs.oracle.com/javase/8/javafx/api/"
-            ]
-        }
+        javaSourceCompat = usingJava9 ? "9" : "1.8"
     }
 }
+
 allprojects { project ->
+    apply plugin: 'base'
+    apply plugin: 'java'
+    apply plugin: 'jacoco'
+    apply from: "${rootDir}/gradle/jacoco.gradle"
+
     configurations {
         providedCompile
     }
+
+    repositories {
+        if (project.hasProperty("useMavenLocal")) {
+            mavenLocal()
+        }
+        jcenter()
+    }
 }
-//-------------------------------------------------------------------------------------------------
-// EACH SUBPROJECT.
-//-------------------------------------------------------------------------------------------------
 
 subprojects { subproject ->
-    apply(plugin: "java")
-    apply(plugin: "osgi")
+    apply plugin: 'osgi'
 
-    apply(from: rootProject.file("gradle/checkstyle.gradle"))
     if (!usingJava9) {
-        // throws an IllegalArgumentException on Java 9
-        apply(from: rootProject.file("gradle/findbugs.gradle"))
+        apply from: "${rootDir}/gradle/findbugs.gradle"
     }
-    apply(from: rootProject.file("gradle/jacoco.gradle"))
     //apply(from: rootProject.file("gradle/jdepend.gradle"))
-    apply(from: rootProject.file("gradle/license.gradle"))
-
-    apply(from: rootProject.file("gradle/publish-jar.gradle"))
-    apply(from: rootProject.file("gradle/publish-maven.gradle"))
-    apply(from: rootProject.file("gradle/publish-bintray.gradle"))
-    apply(from: rootProject.file("gradle/travis-helpers.gradle"))
+    apply from: "${rootDir}/gradle/checkstyle.gradle"
+    apply from: "${rootDir}/gradle/license.gradle"
+    apply from: "${rootDir}/gradle/publish-jar.gradle"
+    apply from: "${rootDir}/gradle/publish-maven.gradle"
+    apply from: "${rootDir}/gradle/publish-bintray.gradle"
+    apply from: "${rootDir}/gradle/travis-helpers.gradle"
 
     sourceSets.main.compileClasspath += configurations.providedCompile
     sourceSets.test.compileClasspath += configurations.providedCompile
@@ -136,17 +124,8 @@ subprojects { subproject ->
         javadocJar
     }
 
-    subproject.tasks.withType(JavaCompile) {
-        sourceCompatibility = javaSourceAndTargetCompilation
-        targetCompatibility = javaSourceAndTargetCompilation
-    }
-
-    // configure javadoc task.
-    if (JavaVersion.current().isJava8Compatible()) {
-        tasks.withType(Javadoc) {
-            options.addStringOption("Xdoclint:none", "-quiet")
-        }
-    }
+    sourceCompatibility = javaSourceCompat
+    targetCompatibility = javaSourceCompat
 
     // use utf-8 encoding for java compile.
     tasks.withType(JavaCompile) {
@@ -197,16 +176,20 @@ subprojects { subproject ->
 
 evaluationDependsOnChildren()
 
-subprojects { subproject ->
-    // maven repositories for dependencies.
-    repositories {
-        if (project.hasProperty("useMavenLocal")) {
-            mavenLocal()
-        }
-        jcenter()
+ext {
+    if (usingJava9) {
+        javadocLinks = [
+                "https://docs.oracle.com/javase/9/docs/api"
+        ]
+    } else {
+        javadocLinks = [
+                "http://docs.oracle.com/javase/8/docs/api/",
+                "http://docs.oracle.com/javase/8/javafx/api/"
+        ]
     }
+}
 
-    // configure javadoc task.
+subprojects { subproject ->
     javadoc {
         excludes = ["**/*.html", "META-INF/**"]
         classpath = configurations.compile + configurations.providedCompile + configurations.compileOnly
@@ -220,12 +203,11 @@ subprojects { subproject ->
         options.footer      = project.javadocFooter
         options.links       = javadocLinks
         options.noTimestamp = true
+        options.addStringOption("Xdoclint:none", "-quiet")
     }
 }
 
-evaluationDependsOnChildren()
-
-task("aggregateJavadoc", type: Javadoc) {
+task aggregateJavadoc(type: Javadoc) {
     group "Documentation"
     description "Generates aggregated Javadoc API documentation."
 
@@ -261,3 +243,28 @@ task("aggregateJavadoc", type: Javadoc) {
         logger.info "Destdir  : ${destinationDir}"
     }
 }
+
+task jacocoMerge(type: JacocoMerge) {
+    destinationFile = file("$buildDir/jacoco/jacoco-all.exec")
+    subprojects.each { subproject ->
+        executionData subproject.tasks.withType(Test)
+    }
+    doFirst {
+        executionData = files(executionData.findAll { it.exists() })
+    }
+}
+
+task jacocoRootReport(type: JacocoReport, group: 'Coverage reports') {
+    description = 'Generates an aggregate report from all subprojects'
+    dependsOn subprojects.test, jacocoMerge
+    additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories = files(subprojects.sourceSets.main.output)
+    executionData = files(subprojects.jacocoTestReport.executionData).filter { it.exists() }
+
+    reports {
+        html.enabled = true // human readable
+        xml.enabled = true // required by coveralls
+    }
+}
+

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -20,7 +20,13 @@
 
 apply plugin: "jacoco"
 
+jacoco {
+    toolVersion = "0.7.9"
+}
+
 jacocoTestReport {
+    group = 'Coverage reports'
+    description = 'Generates a test coverage report for a project'
     reports {
         html.enabled true
         xml.enabled true

--- a/subprojects/testfx-core/src/main/java/module-info.java
+++ b/subprojects/testfx-core/src/main/java/module-info.java
@@ -15,9 +15,13 @@
  * specific language governing permissions and limitations under the Licence.
  */
 
-module org.testfx.internal {
-    requires java.base;
+module org.testfx {
+    requires java.desktop;
+    requires javafx.controls;
+    requires javafx.fxml;
     requires javafx.graphics;
-
-    exports org.testfx.internal;
+    requires javafx.swing;
+    requires javafx.web;
+    requires hamcrest.core;
+    requires org.testfx.internal;
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
@@ -40,7 +40,7 @@ import org.testfx.toolkit.impl.ApplicationServiceImpl;
 import org.testfx.toolkit.impl.ToolkitServiceImpl;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.testfx.service.adapter.JavaVersionAdapter.getWindows;
+import static org.testfx.internal.JavaVersionAdapter.getWindows;
 import static org.testfx.util.WaitForAsyncUtils.waitFor;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
@@ -296,7 +296,7 @@ public final class FxToolkit {
 
     /**
      * Runs on the {@code JavaFX Application Thread}: Hides all windows returned from
-     * {@link org.testfx.service.adapter.JavaVersionAdapter#getWindows()} and returns once finished.
+     * {@link org.testfx.internal.JavaVersionAdapter#getWindows()} and returns once finished.
      */
     public static void cleanupStages()
             throws TimeoutException {

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
@@ -40,7 +40,7 @@ import javafx.scene.paint.Color;
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.adapter.RobotAdapter;
 
-import static org.testfx.service.adapter.JavaVersionAdapter.convertToKeyCodeId;
+import static org.testfx.internal.JavaVersionAdapter.convertToKeyCodeId;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
 
 @Unstable

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -36,7 +36,7 @@ import com.sun.glass.ui.Robot;
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.adapter.RobotAdapter;
 
-import static org.testfx.service.adapter.JavaVersionAdapter.convertToKeyCodeId;
+import static org.testfx.internal.JavaVersionAdapter.convertToKeyCodeId;
 import static org.testfx.util.WaitForAsyncUtils.asyncFx;
 import static org.testfx.util.WaitForAsyncUtils.waitForAsyncFx;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
@@ -78,7 +78,7 @@ public interface WindowFinder {
     //---------------------------------------------------------------------------------------------
 
     /**
-     * Calls {@link org.testfx.service.adapter.JavaVersionAdapter#getWindows()}
+     * Calls {@link org.testfx.internal.JavaVersionAdapter#getWindows()}
      */
     List<Window> listWindows();
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
@@ -31,7 +31,7 @@ import javafx.stage.Window;
 
 import org.testfx.service.finder.WindowFinder;
 
-import static org.testfx.service.adapter.JavaVersionAdapter.getWindows;
+import static org.testfx.internal.JavaVersionAdapter.getWindows;
 
 public class WindowFinderImpl implements WindowFinder {
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
@@ -41,7 +41,7 @@ import javafx.stage.Window;
 import org.hamcrest.Matcher;
 import org.testfx.api.annotation.Unstable;
 
-import static org.testfx.service.adapter.JavaVersionAdapter.isNotVisible;
+import static org.testfx.internal.JavaVersionAdapter.isNotVisible;
 
 @Unstable
 public final class NodeQueryUtils {

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.testfx.cases.TestCaseBase;
 import org.testfx.framework.junit.TestFXRule;
 
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.CoreMatchers.not;
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.api.FxToolkit.setupApplication;
 import static org.testfx.matcher.base.NodeMatchers.hasText;

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/MatcherReflectionDemo.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/MatcherReflectionDemo.java
@@ -18,14 +18,14 @@ package org.testfx.cases.acceptance;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Set;
 
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
+import org.junit.Ignore;
 
+@Ignore("requires hamcrest-library")
 public class MatcherReflectionDemo {
 
     public static void main(String[] args) {
+        /*
         Matcher matcherIterable = Matchers.emptyIterable();
         Matcher matcherCollection = Matchers.empty();
         Matcher matcherArray = Matchers.emptyArray();
@@ -40,6 +40,7 @@ public class MatcherReflectionDemo {
         System.out.println(isAssignableToType(Set.class, typeCollection));
         System.out.println(isAssignableToType(Set.class, typeArray));
         System.out.println(isAssignableToType(Set.class, typeString));
+        */
     }
 
     private static Type fetchGenericArgumentType(Object instance,

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
@@ -40,11 +40,11 @@ import org.testfx.framework.junit.TestFXRule;
 import org.testfx.service.query.NodeQuery;
 import org.testfx.service.query.PointQuery;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class NodeAndPointQueryTest {
 
@@ -96,7 +96,7 @@ public class NodeAndPointQueryTest {
         NodeQuery query = fx.lookup(".button");
 
         // then:
-        assertThat(query.queryAll(), contains(button0, button1));
+        assertThat(query.queryAll(), hasItems(button0, button1));
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
@@ -33,7 +33,7 @@ import org.testfx.framework.junit.TestFXRule;
 import org.testfx.util.WaitForAsyncUtils;
 
 import static javafx.collections.FXCollections.observableArrayList;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
@@ -89,8 +89,8 @@ public class DragAndDropTest extends TestCaseBase {
     @Test
     public void should_have_initialized_items() {
         // expect:
-        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3"), informedErrorMessage(this));
-        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3"), informedErrorMessage(this));
+        verifyThat(leftListView.getItems(), hasItems("L1", "L2", "L3"), informedErrorMessage(this));
+        verifyThat(rightListView.getItems(), hasItems("R1", "R2", "R3"), informedErrorMessage(this));
     }
 
     @Test
@@ -101,9 +101,9 @@ public class DragAndDropTest extends TestCaseBase {
         drop();
 
         // then:
-        verifyThat(leftListView.getItems(), contains("L2", "L3"), informedErrorMessage(this));
+        verifyThat(leftListView.getItems(), hasItems("L2", "L3"), informedErrorMessage(this));
         // gets added to end of ListView
-        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3", "L1"), informedErrorMessage(this));
+        verifyThat(rightListView.getItems(), hasItems("R1", "R2", "R3", "L1"), informedErrorMessage(this));
     }
 
     @Test
@@ -114,8 +114,8 @@ public class DragAndDropTest extends TestCaseBase {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3", "R3"), informedErrorMessage(this));
-        verifyThat(rightListView.getItems(), contains("R1", "R2"), informedErrorMessage(this));
+        verifyThat(leftListView.getItems(), hasItems("L1", "L2", "L3", "R3"), informedErrorMessage(this));
+        verifyThat(rightListView.getItems(), hasItems("R1", "R2"), informedErrorMessage(this));
     }
 
     @Ignore("see #383")
@@ -127,8 +127,8 @@ public class DragAndDropTest extends TestCaseBase {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(leftListView.getItems(), contains("L1", "L2", "L3"), informedErrorMessage(this));
-        verifyThat(rightListView.getItems(), contains("R1", "R2", "R3"), informedErrorMessage(this));
+        verifyThat(leftListView.getItems(), hasItems("L1", "L2", "L3"), informedErrorMessage(this));
+        verifyThat(rightListView.getItems(), hasItems("R1", "R2", "R3"), informedErrorMessage(this));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
@@ -38,7 +38,7 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 import org.testfx.robot.Motion;
 
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.CoreMatchers.is;
 
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.util.DebugUtils.informedErrorMessage;

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
@@ -35,9 +35,9 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 import org.testfx.service.query.NodeQuery;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasItem;
 
 public class NodeMatchersTest extends FxRobot {
 
@@ -119,11 +119,11 @@ public class NodeMatchersTest extends FxRobot {
 
         // expect:
         NodeQuery query1 = from(nodes).match(NodeMatchers.hasText("foo"));
-        assertThat(query1.queryAll(), contains(nodes.get(1)));
+        assertThat(query1.queryAll(), hasItems(nodes.get(1)));
 
         // and:
         NodeQuery query2 = from(nodes).match(NodeMatchers.hasText("bar"));
-        assertThat(query2.queryAll(), contains(nodes.get(2)));
+        assertThat(query2.queryAll(), hasItems(nodes.get(2)));
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
@@ -27,8 +27,8 @@ import org.junit.rules.ExpectedException;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
 
 public class LabeledMatchersTest extends FxRobot {
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -46,8 +46,8 @@ import org.testfx.framework.junit.TestFXRule;
 import org.testfx.util.WaitForAsyncUtils;
 
 import static javafx.collections.FXCollections.observableArrayList;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
 
 public class TableViewMatchersTest extends FxRobot {
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextInputControlMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextInputControlMatchersTest.java
@@ -28,8 +28,8 @@ import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
 
 public class TextInputControlMatchersTest extends FxRobot {
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
@@ -28,8 +28,8 @@ import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
 
 public class TextMatchersTest extends FxRobot {
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -36,7 +36,7 @@ import static javafx.scene.input.KeyCode.COMMAND;
 import static javafx.scene.input.KeyCode.CONTROL;
 import static javafx.scene.input.KeyCode.SHORTCUT;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.util.DebugUtils.informedErrorMessage;

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
@@ -49,13 +49,12 @@ import org.testfx.service.locator.PointLocator;
 import org.testfx.service.locator.impl.BoundsLocatorImpl;
 import org.testfx.service.locator.impl.PointLocatorImpl;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.Matchers.any;
@@ -191,8 +190,8 @@ public class AwtRobotAdapterTest {
         Point2D mouseLocation = robotAdapter.getMouseLocation();
 
         // then:
-        assertThat(mouseLocation.getX(), is(greaterThanOrEqualTo(0.0)));
-        assertThat(mouseLocation.getY(), is(greaterThanOrEqualTo(0.0)));
+        assertThat("mouseLocation.getX() is greater than or equal to 0.0", mouseLocation.getX() >= 0.0);
+        assertThat("mouseLocation.getY() is greater than or equal to 0.0", mouseLocation.getY() >= 0.0);
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
@@ -48,13 +48,12 @@ import org.testfx.service.locator.PointLocator;
 import org.testfx.service.locator.impl.BoundsLocatorImpl;
 import org.testfx.service.locator.impl.PointLocatorImpl;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -190,8 +189,8 @@ public class GlassRobotAdapterTest {
         Point2D mouseLocation = robotAdapter.getMouseLocation();
 
         // then:
-        assertThat(mouseLocation.getX(), is(greaterThanOrEqualTo(0.0)));
-        assertThat(mouseLocation.getY(), is(greaterThanOrEqualTo(0.0)));
+        assertThat("mouseLocation.getX() is greater than or equal to 0.0", mouseLocation.getX() >= 0.0);
+        assertThat("mouseLocation.getY() is greater than or equal to 0.0", mouseLocation.getY() >= 0.0);
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
@@ -50,10 +50,10 @@ import org.junit.Test;
 import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.testfx.api.FxAssert.verifyThat;

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
@@ -46,10 +46,11 @@ import org.testfx.framework.junit.TestFXRule;
 import org.testfx.service.finder.NodeFinderException;
 import org.testfx.service.finder.WindowFinder;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assume.assumeThat;
 
 public class NodeFinderImplTest {
@@ -237,7 +238,7 @@ public class NodeFinderImplTest {
     @Test
     public void nodes_string_cssQuery() {
         // expect:
-        assertThat(nodeFinder.lookup(".sub").queryAll(), contains(subLabel, subSubLabel));
+        assertThat(nodeFinder.lookup(".sub").queryAll(), hasItems(subLabel, subSubLabel));
     }
 
     @Test
@@ -261,15 +262,15 @@ public class NodeFinderImplTest {
     @Test
     public void nodes_string_cssQuery_parentNode() {
         // expect:
-        assertThat(nodeFinder.from(otherPane).lookup(".sub").queryAll(), contains(subLabel, subSubLabel));
-        assertThat(nodeFinder.from(otherSubPane).lookup(".sub").queryAll(), contains(subSubLabel));
+        assertThat(nodeFinder.from(otherPane).lookup(".sub").queryAll(), hasItems(subLabel, subSubLabel));
+        assertThat(nodeFinder.from(otherSubPane).lookup(".sub").queryAll(), hasItems(subSubLabel));
     }
 
     @Test
     public void nodes_string_labelQuery_parentNode() {
         // expect:
-        assertThat(nodeFinder.from(otherPane).lookup("#subLabel").queryAll(), contains(subLabel));
-        assertThat(nodeFinder.from(otherSubPane).lookup("#subSubLabel").queryAll(), contains(subSubLabel));
+        assertThat(nodeFinder.from(otherPane).lookup("#subLabel").queryAll(), hasItem(subLabel));
+        assertThat(nodeFinder.from(otherSubPane).lookup("#subSubLabel").queryAll(), hasItem(subSubLabel));
     }
 
     //---------------------------------------------------------------------------------------------

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
@@ -22,7 +22,7 @@ import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
-import org.hamcrest.Matchers;
+import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -100,10 +100,10 @@ public class WindowFinderImplTest {
         List<Window> windows = windowFinder.listWindows();
 
         // then:
-        assertThat(windows, Matchers.hasItems((Window) window));
-        assertThat(windows, Matchers.hasItems((Window) windowInWindow));
-        assertThat(windows, Matchers.hasItems((Window) windowInWindowInWindow));
-        assertThat(windows, Matchers.hasItems((Window) otherWindow));
+        assertThat(windows, CoreMatchers.hasItems((Window) window));
+        assertThat(windows, CoreMatchers.hasItems((Window) windowInWindow));
+        assertThat(windows, CoreMatchers.hasItems((Window) windowInWindowInWindow));
+        assertThat(windows, CoreMatchers.hasItems((Window) otherWindow));
     }
 
     @Test
@@ -113,10 +113,10 @@ public class WindowFinderImplTest {
         List<Window> orderedWindows = windowFinder.listTargetWindows();
 
         // then:
-        assertThat(orderedWindows, Matchers.hasItems((Window) window));
-        assertThat(orderedWindows, Matchers.hasItems((Window) windowInWindow));
-        assertThat(orderedWindows, Matchers.hasItems((Window) windowInWindowInWindow));
-        assertThat(orderedWindows, Matchers.hasItems((Window) otherWindow));
+        assertThat(orderedWindows, CoreMatchers.hasItems((Window) window));
+        assertThat(orderedWindows, CoreMatchers.hasItems((Window) windowInWindow));
+        assertThat(orderedWindows, CoreMatchers.hasItems((Window) windowInWindowInWindow));
+        assertThat(orderedWindows, CoreMatchers.hasItems((Window) otherWindow));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class WindowFinderImplTest {
         windowFinder.targetWindow(window);
 
         // then:
-        assertThat(windowFinder.targetWindow(), Matchers.is(window));
+        assertThat(windowFinder.targetWindow(), CoreMatchers.is(window));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class WindowFinderImplTest {
         windowFinder.targetWindow(1);
 
         // then:
-        assertThat(windowFinder.targetWindow(), Matchers.is(window));
+        assertThat(windowFinder.targetWindow(), CoreMatchers.is(window));
     }
 
     @Test
@@ -143,7 +143,7 @@ public class WindowFinderImplTest {
         windowFinder.targetWindow("window");
 
         // then:
-        assertThat(windowFinder.targetWindow(), Matchers.is(window));
+        assertThat(windowFinder.targetWindow(), CoreMatchers.is(window));
     }
 
     @Test
@@ -152,17 +152,17 @@ public class WindowFinderImplTest {
         windowFinder.targetWindow(scene);
 
         // then:
-        assertThat(windowFinder.targetWindow(), Matchers.is(otherWindow));
+        assertThat(windowFinder.targetWindow(), CoreMatchers.is(otherWindow));
     }
 
     @Test
     public void window_windowIndex() {
         // TODO: Assert that it throws an exception of index is out of range.
         // expect:
-        assertThat(windowFinder.window(1), Matchers.is(window));
-        assertThat(windowFinder.window(2), Matchers.is(windowInWindow));
-        assertThat(windowFinder.window(3), Matchers.is(windowInWindowInWindow));
-        assertThat(windowFinder.window(4), Matchers.is(otherWindow));
+        assertThat(windowFinder.window(1), CoreMatchers.is(window));
+        assertThat(windowFinder.window(2), CoreMatchers.is(windowInWindow));
+        assertThat(windowFinder.window(3), CoreMatchers.is(windowInWindowInWindow));
+        assertThat(windowFinder.window(4), CoreMatchers.is(otherWindow));
     }
 
     @Test
@@ -170,16 +170,16 @@ public class WindowFinderImplTest {
         // TODO: Assert that it thrown an exception of stage title regex does not match.
         // TODO: Assert that stages without title do not throw a NPE.
         // expect:
-        assertThat(windowFinder.window("window"), Matchers.is(window));
-        assertThat(windowFinder.window("windowInWindow"), Matchers.is(windowInWindow));
-        assertThat(windowFinder.window("windowInWindowInWindow"), Matchers.is(windowInWindowInWindow));
-        assertThat(windowFinder.window("otherWindow"), Matchers.is(otherWindow));
+        assertThat(windowFinder.window("window"), CoreMatchers.is(window));
+        assertThat(windowFinder.window("windowInWindow"), CoreMatchers.is(windowInWindow));
+        assertThat(windowFinder.window("windowInWindowInWindow"), CoreMatchers.is(windowInWindowInWindow));
+        assertThat(windowFinder.window("otherWindow"), CoreMatchers.is(otherWindow));
     }
 
     @Test
     public void window_scene() {
         // expect:
-        assertThat(windowFinder.window(scene), Matchers.is(otherWindow));
+        assertThat(windowFinder.window(scene), CoreMatchers.is(otherWindow));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
@@ -38,9 +38,9 @@ import org.testfx.framework.junit.TestFXRule;
 import org.testfx.service.locator.BoundsLocator;
 import org.testfx.service.locator.BoundsLocatorException;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 
 public class BoundsLocatorImplTest {
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
@@ -23,7 +23,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.Window;
 
-import org.hamcrest.Matchers;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,7 +70,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100, 100)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100, 100)));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100, 100)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100, 100)));
     }
 
     @Test
@@ -96,7 +96,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(topLeftPointFrom(nodeBounds)));
+        assertThat(point, CoreMatchers.equalTo(topLeftPointFrom(nodeBounds)));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(topLeftPointFrom(nodeBoundsAfterChange)));
+        assertThat(point, CoreMatchers.equalTo(topLeftPointFrom(nodeBoundsAfterChange)));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(topLeftPointFrom(sceneBounds)));
+        assertThat(point, CoreMatchers.equalTo(topLeftPointFrom(sceneBounds)));
     }
 
     @Test
@@ -137,7 +137,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(topLeftPointFrom(sceneBoundsAfterChange)));
+        assertThat(point, CoreMatchers.equalTo(topLeftPointFrom(sceneBoundsAfterChange)));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(topLeftPointFrom(windowBounds)));
+        assertThat(point, CoreMatchers.equalTo(topLeftPointFrom(windowBounds)));
     }
 
     @Test
@@ -164,7 +164,7 @@ public class PointLocatorImplTest {
         Point2D point = pointQuery.atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(topLeftPointFrom(windowBoundsAfterChange)));
+        assertThat(point, CoreMatchers.equalTo(topLeftPointFrom(windowBoundsAfterChange)));
     }
 
     //---------------------------------------------------------------------------------------------

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/BoundsPointQueryTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/BoundsPointQueryTest.java
@@ -21,7 +21,7 @@ import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
 
-import org.hamcrest.Matchers;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,7 +46,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atPosition(0.0, 0.0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100, 200)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100, 200)));
     }
 
     @Test
@@ -55,7 +55,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atPosition(1.0, 1.0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100 + 300, 200 + 400)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100 + 300, 200 + 400)));
     }
 
     @Test
@@ -64,7 +64,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atPosition(0.5, 0.5).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100 + 150, 200 + 200)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100 + 150, 200 + 200)));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atPosition(Pos.TOP_LEFT).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100, 200)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100, 200)));
     }
 
     @Test
@@ -82,7 +82,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atPosition(Pos.BOTTOM_RIGHT).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100 + 300, 200 + 400)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100 + 300, 200 + 400)));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atPosition(Pos.CENTER).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100 + 150, 200 + 200)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100 + 150, 200 + 200)));
     }
 
     @Test
@@ -100,7 +100,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atOffset(0, 0).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100, 200)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100, 200)));
     }
 
     @Test
@@ -109,7 +109,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atOffset(300, 400).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100 + 300, 200 + 400)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100 + 300, 200 + 400)));
     }
 
     @Test
@@ -118,7 +118,7 @@ public class BoundsPointQueryTest {
         Point2D point = new BoundsPointQuery(bounds).atOffset(150, 200).query();
 
         // then:
-        assertThat(point, Matchers.equalTo(new Point2D(100 + 150, 200 + 200)));
+        assertThat(point, CoreMatchers.equalTo(new Point2D(100 + 150, 200 + 200)));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
@@ -35,10 +35,9 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 import org.testfx.service.query.NodeQuery;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.testfx.util.NodeQueryUtils.bySelector;
 import static org.testfx.util.NodeQueryUtils.combine;
@@ -141,7 +140,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0, label1, label2));
+        assertThat(result, hasItems(label0, label1, label2));
     }
 
     @Test
@@ -151,7 +150,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, is(empty()));
+        assertThat(result.isEmpty(), is(true));
     }
 
     @Test
@@ -162,7 +161,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0, label1));
+        assertThat(result, hasItems(label0, label1));
     }
 
     @Test
@@ -173,7 +172,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label1, label0));
+        assertThat(result, hasItems(label1, label0));
     }
 
     @Test
@@ -184,7 +183,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0, label1));
+        assertThat(result, hasItems(label0, label1));
     }
 
     @Test
@@ -195,7 +194,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0));
+        assertThat(result, hasItems(label0));
     }
 
     @Test
@@ -206,7 +205,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0));
+        assertThat(result, hasItems(label0));
     }
 
     @Test
@@ -218,7 +217,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0, label1, label2));
+        assertThat(result, hasItems(label0, label1, label2));
     }
 
     @Test
@@ -231,7 +230,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0, label1, label2));
+        assertThat(result, hasItems(label0, label1, label2));
     }
 
     @Test
@@ -243,7 +242,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label0, label1, label2, button0, button1, button2));
+        assertThat(result, hasItems(label0, label1, label2, button0, button1, button2));
     }
 
     @Test
@@ -256,7 +255,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label1));
+        assertThat(result, hasItems(label1));
     }
 
     @Test
@@ -271,7 +270,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(label2));
+        assertThat(result, hasItems(label2));
     }
 
     @Test
@@ -284,7 +283,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, empty());
+        assertThat(result.isEmpty(), is(true));
     }
 
     @Test
@@ -299,7 +298,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, empty());
+        assertThat(result.isEmpty(), is(true));
     }
 
     @Test
@@ -312,7 +311,7 @@ public class NodeQueryImplTest {
             .queryAll();
 
         // then:
-        assertThat(result, contains(button1));
+        assertThat(result, hasItems(button1));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
@@ -32,6 +32,10 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -43,9 +47,8 @@ import org.testfx.robot.impl.BaseRobotImpl;
 import org.testfx.service.support.CaptureSupport;
 import org.testfx.service.support.PixelMatcherResult;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
 import static org.testfx.api.FxAssert.verifyThat;
 
 public class CaptureSupportImplTest extends FxRobot {
@@ -166,6 +169,70 @@ public class CaptureSupportImplTest extends FxRobot {
         }
         catch (URISyntaxException exception) {
             throw new RuntimeException(exception);
+        }
+    }
+
+    /*
+     * Note: Taken from hamcrest-library:
+     * https://github.com/hamcrest/JavaHamcrest/tree/master/hamcrest-library
+     * <p>
+     * This portion of code is Copyright (c) 2000-2015 www.hamcrest.org and BSD
+     * licensed: https://github.com/hamcrest/JavaHamcrest/blob/master/LICENSE.txt
+     */
+
+    /**
+     * Creates a matcher of {@link Double}s that matches when an examined double is equal
+     * to the specified <code>operand</code>, within a range of +/- <code>error</code>.
+     * For example:
+     * <pre>assertThat(1.03, is(closeTo(1.0, 0.03)))</pre>
+     *
+     * @param operand
+     *     the expected value of matching doubles
+     * @param error
+     *     the delta (+/-) within which matches will be allowed
+     */
+    public static Matcher<Double> closeTo(double operand, double error) {
+        return new IsCloseTo(operand, error);
+    }
+
+    /**
+     * Is the value a number equal to a value within some range of
+     * acceptable error?
+     *
+     */
+    static class IsCloseTo extends TypeSafeMatcher<Double> {
+        private final double delta;
+        private final double value;
+
+        private IsCloseTo(double value, double error) {
+            this.delta = error;
+            this.value = value;
+        }
+
+        @Override
+        public boolean matchesSafely(Double item) {
+            return actualDelta(item) <= 0.0;
+        }
+
+        @Override
+        public void describeMismatchSafely(Double item, Description mismatchDescription) {
+            mismatchDescription.appendValue(item)
+                    .appendText(" differed by ")
+                    .appendValue(actualDelta(item))
+                    .appendText(" more than delta ")
+                    .appendValue(delta);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("a numeric value within ")
+                    .appendValue(delta)
+                    .appendText(" of ")
+                    .appendValue(value);
+        }
+
+        private double actualDelta(Double item) {
+            return Math.abs(item - value) - delta;
         }
     }
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
@@ -44,8 +44,8 @@ import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -330,7 +330,7 @@ public class BoundsQueryUtilsTest {
                                       double minY,
                                       double width,
                                       double height) {
-        return Matchers.is(new BoundingBox(minX, minY, width, height));
+        return CoreMatchers.is(new BoundingBox(minX, minY, width, height));
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/DebugUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/DebugUtilsTest.java
@@ -37,11 +37,11 @@ import org.testfx.cases.TestCaseBase;
 import org.testfx.framework.junit.TestFXRule;
 import org.testfx.service.support.FiredEvents;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.util.DebugUtils.compose;
 import static org.testfx.util.DebugUtils.insertHeader;

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
@@ -22,8 +22,8 @@ import javafx.geometry.Pos;
 
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.testfx.util.PointQueryUtils.atPosition;
 import static org.testfx.util.PointQueryUtils.atPositionFactors;
 import static org.testfx.util.PointQueryUtils.computePositionFactors;

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsFxTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsFxTest.java
@@ -29,7 +29,7 @@ import org.junit.rules.Timeout;
 import org.testfx.api.FxToolkit;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -50,9 +50,9 @@ public class WaitForAsyncUtilsFxTest {
             e.printStackTrace();
         }
     }
-    
+
     /**
-     * Tests that nested calls of async method triggers a exception. 
+     * Tests that nested calls of async method triggers a exception.
      * @throws Throwable
      */
     @Test
@@ -63,7 +63,7 @@ public class WaitForAsyncUtilsFxTest {
         thrown.expectCause(instanceOf(ExecutionException.class));
         Callable<Void> callable = () -> {
             Future<Void> future = WaitForAsyncUtils.asyncFx(() -> {
-                throw new UnsupportedOperationException(); 
+                throw new UnsupportedOperationException();
             });
             return future.get();
         };
@@ -94,7 +94,7 @@ public class WaitForAsyncUtilsFxTest {
         WaitForAsyncUtils.printException = false;
         thrown.expectCause(instanceOf(UnsupportedOperationException.class));
         Callable<Void> callable = () -> {
-            throw new UnsupportedOperationException(); 
+            throw new UnsupportedOperationException();
         };
         WaitForAsyncUtils.clearExceptions();
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
@@ -23,15 +23,15 @@ import java.util.concurrent.TimeoutException;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 
-import org.hamcrest.Matchers;
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -59,7 +59,7 @@ public class WaitForAsyncUtilsTest {
 
         // then:
         WaitForAsyncUtils.sleepWithException(10, MILLISECONDS);
-        assertThat(future.get(), Matchers.is("foo"));
+        assertThat(future.get(), CoreMatchers.is("foo"));
         waitForThreads(future);
     }
 
@@ -72,9 +72,9 @@ public class WaitForAsyncUtilsTest {
         });
 
         // then:
-        assertThat(future.isDone(), Matchers.is(false));
+        assertThat(future.isDone(), CoreMatchers.is(false));
         WaitForAsyncUtils.sleep(250, MILLISECONDS);
-        assertThat(future.get(), Matchers.is("foo"));
+        assertThat(future.get(), CoreMatchers.is("foo"));
         waitForThreads(future);
     }
 
@@ -272,7 +272,7 @@ public class WaitForAsyncUtilsTest {
     @Test
     public void waitFor_with_booleanCallable_with_exception() throws Exception {
         // expect:
-        thrown.expectCause(instanceOf(UnsupportedOperationException.class));
+        thrown.expectCause(isA(UnsupportedOperationException.class));
         WaitForAsyncUtils.waitFor(250, MILLISECONDS, () -> {
             throw new UnsupportedOperationException();
         });
@@ -315,7 +315,7 @@ public class WaitForAsyncUtilsTest {
     public void daemonThreads() throws Exception {
         final Future<Thread> future = WaitForAsyncUtils.async(Thread::currentThread);
         final Thread thread = future.get();
-        assertThat(thread.isDaemon(), Matchers.is(true));
+        assertThat(thread.isDaemon(), CoreMatchers.is(true));
     }
 
     protected void waitForException(Future<?> f) throws InterruptedException {

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -14,6 +14,12 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+ext.moduleName = 'org.testfx'
+
+
+repositories {
+    jcenter()
+}
 
 dependencies {
     // use correct API internally depending on which Java version is being used
@@ -28,7 +34,6 @@ dependencies {
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.12.0"
-    testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile project(":testfx-junit")
     if (usingJava9) {
         testCompile "org.testfx:openjfx-monocle:jdk-9+181"
@@ -37,34 +42,56 @@ dependencies {
     }
 }
 
+sourceSets {
+    if (!usingJava9) {
+        main {
+            java {
+                exclude '**/module-info.java'
+            }
+        }
+    }
+}
 
 compileJava {
     if (usingJava9) {
-        options.compilerArgs += [
-                "--add-opens", "java.base/java.lang=ALL-UNNAMED",
-                "--add-opens", "java.base/java.util=ALL-UNNAMED",
-                "--add-exports", "javafx.graphics/com.sun.glass.ui=ALL-UNNAMED"
-        ]
+        inputs.property("moduleName", moduleName)
+        doFirst {
+            options.compilerArgs = [
+                    '--module-path', classpath.asPath,
+                    "--add-exports", "javafx.graphics/com.sun.glass.ui=org.testfx"
+            ]
+            classpath = files()
+        }
 
         javadoc {
-            options.addStringOption('-add-exports', 'javafx.graphics/com.sun.glass.ui=ALL-UNNAMED')
+            exclude "**/module-info.java"
+            options.addStringOption('-module-path', classpath.asPath)
+            options.addStringOption('-add-exports', 'javafx.graphics/com.sun.glass.ui=org.testfx')
         }
     }
 }
 
 compileTestJava {
     if (usingJava9) {
-        options.compilerArgs += [
-                "--add-opens", "org.testfx.internal/org.testfx.service.adapter=ALL-UNNAMED",
-                "--add-opens", "java.base/java.lang=ALL-UNNAMED",
-                "--add-opens", "java.base/java.util=ALL-UNNAMED",
-                "--add-exports", "javafx.graphics/com.sun.glass.ui=ALL-UNNAMED"
-        ]
+        inputs.property("moduleName", moduleName)
+        doFirst {
+            options.compilerArgs = [
+                    '--module-path', classpath.asPath,
+                    '--add-modules', 'junit',
+                    '--add-reads', "$moduleName=junit",
+                    '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath,
+                    "--add-exports", "javafx.graphics/com.sun.glass.ui=org.testfx",
+            ]
+            classpath = files()
+        }
     }
 }
 
 jar {
+    inputs.property("moduleName", moduleName)
+
     manifest {
+        attributes('Automatic-Module-Name': moduleName)
         instruction 'Export-Package', '*'
         instruction 'Bundle-Activator', 'org.testfx.osgi.Activator'
         instruction 'Require-Capability', 'org.testfx.osgi.versionadapter'

--- a/subprojects/testfx-internal-java8/src/main/java/org/testfx/internal/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java8/src/main/java/org/testfx/internal/JavaVersionAdapter.java
@@ -14,9 +14,10 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-package org.testfx.service.adapter;
+package org.testfx.internal;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javafx.scene.Node;
@@ -28,16 +29,22 @@ import javafx.stage.Window;
  */
 public final class JavaVersionAdapter {
 
+    @SuppressWarnings("deprecated")
     public static int convertToKeyCodeId(KeyCode keyCode) {
-        return keyCode.getCode();
+        return keyCode.impl_getCode();
     }
 
+    @SuppressWarnings("deprecated")
     public static List<Window> getWindows() {
-        return new ArrayList<>(Window.getWindows());
+        List<Window> windows = new ArrayList<>();
+        Window.impl_getWindows().forEachRemaining(windows::add);
+        Collections.reverse(windows);
+        return windows;
     }
 
+    @SuppressWarnings("deprecated")
     public static boolean isNotVisible(Node node) {
-        return !node.isVisible();
+        return !node.isVisible() || !node.impl_isTreeVisible();
     }
 
 }

--- a/subprojects/testfx-internal-java9/src/main/java/org/testfx/internal/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java9/src/main/java/org/testfx/internal/JavaVersionAdapter.java
@@ -14,38 +14,30 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-package org.testfx.service.adapter;
+package org.testfx.internal;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javafx.scene.Node;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Window;
 
-
 /**
  * Provides consistent API for TestFX-Core subproject regardless of whether Java 8 or Java 9 is being used.
  */
 public final class JavaVersionAdapter {
 
-    @SuppressWarnings("deprecated")
     public static int convertToKeyCodeId(KeyCode keyCode) {
-        return keyCode.impl_getCode();
+        return keyCode.getCode();
     }
 
-    @SuppressWarnings("deprecated")
     public static List<Window> getWindows() {
-        List<Window> windows = new ArrayList<>();
-        Window.impl_getWindows().forEachRemaining(windows::add);
-        Collections.reverse(windows);
-        return windows;
+        return new ArrayList<>(Window.getWindows());
     }
 
-    @SuppressWarnings("deprecated")
     public static boolean isNotVisible(Node node) {
-        return !node.isVisible() || !node.impl_isTreeVisible();
+        return !node.isVisible();
     }
 
 }

--- a/subprojects/testfx-internal-java9/testfx-internal-java9.gradle
+++ b/subprojects/testfx-internal-java9/testfx-internal-java9.gradle
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2015 The TestFX Contributors
+ * Copyright 2014-2017 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -14,7 +14,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-ext.moduleName = 'org.testfx.internal9'
+ext.moduleName = 'org.testfx.internal'
 
 jar {
     inputs.property("moduleName", moduleName)

--- a/subprojects/testfx-internal-java9/testfx-internal-java9.gradle
+++ b/subprojects/testfx-internal-java9/testfx-internal-java9.gradle
@@ -14,10 +14,11 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-
-ext.pomDescription = "TestFX Internal Java 9"
+ext.moduleName = 'org.testfx.internal9'
 
 jar {
+    inputs.property("moduleName", moduleName)
+
     manifest {
         instruction 'Fragment-Host', 'org.testfx.core'
         instruction 'Provide-Capability', 'org.testfx.osgi.versionadapter'

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
@@ -32,13 +32,13 @@ import org.junit.rules.Timeout;
 import org.testfx.api.FxToolkit;
 import org.testfx.util.WaitForAsyncUtils;
 
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.fail;
 
 
 /**
  * This class tests exception handling of the GUI within the JUnit framework.
- * 
+ *
  */
 public class JUnitExceptionTest  extends ApplicationTest {
     @Rule
@@ -47,7 +47,7 @@ public class JUnitExceptionTest  extends ApplicationTest {
     @Rule
     public Timeout globalTimeout = Timeout.millis(10000);
 
-    
+
     @BeforeClass
     public static void setUpClass() {
         try {
@@ -89,7 +89,7 @@ public class JUnitExceptionTest  extends ApplicationTest {
             clickOn("Throws Exception"); // does already handle all the async stuff...
             WaitForAsyncUtils.checkException(); // need to check Exception, as event is executed after click
             fail("checkException didn't detect Exception");
-        } 
+        }
         catch (Exception e) { //clean up...
             release(MouseButton.PRIMARY);
             moveBy(100, 100); //otherwise the press release test fails?!

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
@@ -24,8 +24,8 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 /**
  * Tests to see if pressed keys/buttons are released after a test is run.

--- a/subprojects/testfx-junit/testfx-junit.gradle
+++ b/subprojects/testfx-junit/testfx-junit.gradle
@@ -14,6 +14,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+ext.moduleName = 'org.testfx.junit'
 
 dependencies {
     compile project(":testfx-core")

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/KeyAndButtonReleaseTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/KeyAndButtonReleaseTest.java
@@ -23,8 +23,8 @@ import javafx.stage.Stage;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 /**
  * Tests to see if pressed keys/buttons are released after a test is run.

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -14,6 +14,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+ext.moduleName = 'org.testfx.junit5'
 
 buildscript {
     repositories {

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
@@ -21,7 +21,7 @@ import javafx.scene.input.MouseButton
 import javafx.stage.Stage
 
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.Matchers.is
+import static org.hamcrest.CoreMatchers.is
 
 class KeyAndButtonReleaseSpec extends ApplicationSpec {
 

--- a/subprojects/testfx-spock/testfx-spock.gradle
+++ b/subprojects/testfx-spock/testfx-spock.gradle
@@ -14,6 +14,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+ext.moduleName = 'org.testfx.spock'
 
 apply plugin: 'groovy'
 


### PR DESCRIPTION
This is an attempt to begin the process of jigsaw modularization for
Java 9. Currently we are not taking advantage of modules for the
different parts of testfx-core, we are simply making everything one big
module but it's the first step.

hamcrest-core and hamcrest-library were used in the compileTestJava
phase of the build and these two artifacts have a split package (both
use the same org.hamcrest package). Instead of messing about with
--patch-modules and the like we replaced all usages of hamcrest-library
with hamcrest-core CoreMatchers where possible. The only place where
this was not feasible was the "closeTo" matcher, which we copied into
CaptureSupportImplTest wholesale. If it turns out we need this Matcher
across the tests we will use a different method of "fixing" this.