### PR TITLE
(fix) Add gdb apt package to each Travis matrix build.

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 echo "which java: $(which java)"
 ulimit -c unlimited -S

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: java
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - gdb
-
 # keep gradle cache.
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -41,6 +36,7 @@ matrix:
         apt:
           packages:
             - oracle-java8-installer
+            - gdb
     # Ubuntu Linux (trusty) / Java 9 / Headed
     - os: linux
       dist: trusty
@@ -51,6 +47,7 @@ matrix:
         apt:
           packages:
             - oracle-java9-installer
+            - gdb
     # Ubuntu Linux (trusty) / Java 9 / Headless
     - os: linux
       dist: trusty


### PR DESCRIPTION
If the list of needed apt packages was longer we could use YAML
references as in https://github.com/travis-ci/travis-ci/issues/3505
but because we only have gdb (which is only used if the JVM crashes)
the added complexity is uunnecessary.