### PR TITLE
Correct usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ online (these are auto-generated from `master`) or by running `gradle javadoc`.
 
 ~~~java
 public class DesktopPaneTest extends ApplicationTest {
-    @Override
-    public void start(Stage stage) {
-        Scene scene = new Scene(new DesktopPane(), 800, 600);
-        stage.setScene(scene);
-        stage.show();
+
+    @BeforeEach
+    public void setup() throws Exception {
+        ApplicationTest.launch(DesktopPane.class);
     }
 
     @Test


### PR DESCRIPTION
As shown in #475, the current code example in the readme is misleading.

Overriding `start` is not enough to test the UI. It is necessary to launch the application under test with `ApplicationTest.launch()`