### PR TITLE
(chore) Update license header year.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         apt:
           packages:
             - oracle-java8-installer
-      script: ./gradlew checkstyleMain checkstyleTest spotbugsMain spotbugsTest :testfx-spock:codenarcMain :testfx-spock:codenarcTest
+      script: ./gradlew checkstyleMain checkstyleTest license spotbugsMain spotbugsTest :testfx-spock:codenarcMain :testfx-spock:codenarcTest
     - stage: test
      # Ubuntu Linux (trusty) / Java 8 / Headed
       os: linux
@@ -95,7 +95,7 @@ jobs:
         - secure: "McAqe7fSHacgoaf6EN2xsJtQl+7bHWJFaxt9KjLsX5An/LEqCOCVAgRQA7pVpoc3VQUw3Lq997aDGK4NyRco6SmKb+73/L6AF14W9KO7ItNX4HVq16JDEkTqlfDip+/1Jo/Z8UDoQ2J9/2HViZ4ZoZDdEP9CjGJGlfEyUaEnAQQ="
         - secure: "YzaXTwRHng74Uegz0COmH2/U6PZ4VghDeoXFog5Eds2ZSuUGG9NXBQTdCcBgTwA9KPmu1fvKhk4HqJeru4fpD3NqZ+Ks3znvXOPXgydr3SxgJUvWCJkRQljXOE5BlI07R1qVnDWwTqSDyt64ffaJo3XT0+3uOwnauJrMqexsniM="
         - secure: "eSQaOxDMfLW3V1cxtKcm0i/BesSrRw1bTi01fAjTR6RxsXP00YAylNgYBgoGRrED16kM5FkQzOf75CDCw6l7CanXky/A7quD0IMo0pkwX/q5OJWIK7NAGnV4DekDnYW0yrMTxuygR0ALMkgwT5S+CP3/1aY6BNO11LNSHgQUXiM="
-        - secure: "BXTn0eNI4ueday8ZMC4KPnbJxWy7HADRUc5pjLMC70W9j2P6T5P18zUYwXHFnRdNxAEPa3rkjCLXx3XyMezhm5twkHpUt/Hyb0kgN0CYzEm0fad23Dayn7HVdGlKh6WQnjC/VQ54k/MCHEk4F0W8ip7RrG1FpTfhpWAa3j1Tq00="  
+        - secure: "BXTn0eNI4ueday8ZMC4KPnbJxWy7HADRUc5pjLMC70W9j2P6T5P18zUYwXHFnRdNxAEPa3rkjCLXx3XyMezhm5twkHpUt/Hyb0kgN0CYzEm0fad23Dayn7HVdGlKh6WQnjC/VQ54k/MCHEk4F0W8ip7RrG1FpTfhpWAa3j1Tq00="
       if: tag =~ ^v[0-9]+.[0-9]+.[0-9]+(-alpha|-beta)?$ AND branch = master
 
 before_cache:

--- a/subprojects/testfx-core/src/main/java/module-info.java
+++ b/subprojects/testfx-core/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -14,7 +14,6 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-
 module org.testfx {
     exports org.testfx.api;
     exports org.testfx.api.annotation;

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssertContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssertContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotException.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxServiceContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxServiceContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkitContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkitContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/annotation/Stable.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/annotation/Stable.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/annotation/Unstable.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/annotation/Unstable.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeneralMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeneralMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeometryMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeometryMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/NodeMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/NodeMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ParentMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ParentMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/WindowMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/WindowMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ButtonMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ButtonMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/LabeledMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/LabeledMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextInputControlMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextInputControlMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/osgi/Activator.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/osgi/Activator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -14,7 +14,6 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-
 package org.testfx.osgi;
 
 import org.osgi.framework.BundleActivator;

--- a/subprojects/testfx-core/src/main/java/org/testfx/osgi/service/TestFx.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/osgi/service/TestFx.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -14,7 +14,6 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-
 package org.testfx.osgi.service;
 
 /**

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/BaseRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/BaseRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/ClickRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/ClickRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/DragRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/DragRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/KeyboardRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/KeyboardRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/Motion.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/Motion.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -14,7 +14,6 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-
 package org.testfx.robot;
 
 /**

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/MouseRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/MouseRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/MoveRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/MoveRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/ScrollRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/ScrollRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/SleepRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/SleepRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/TypeRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/TypeRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/WriteRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/WriteRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/DragRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/DragRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MoveRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MoveRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ScrollRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ScrollRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/SleepRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/SleepRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/TypeRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/TypeRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/WriteRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/WriteRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/RobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/RobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/NodeFinder.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/NodeFinder.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocator.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocatorException.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocatorException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/PointLocator.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/PointLocator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/BoundsLocatorImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/BoundsLocatorImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/CallableBoundsPointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/CallableBoundsPointQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/Capture.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/Capture.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureSupport.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureSupport.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/FiredEvents.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/FiredEvents.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcher.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcher.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcherResult.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcherResult.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/CaptureSupportImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/CaptureSupportImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherBase.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherBase.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationLauncher.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationLauncher.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/PrimaryStageApplication.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/PrimaryStageApplication.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/PrimaryStageFuture.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/PrimaryStageFuture.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ToolkitService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ToolkitService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationLauncherImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationLauncherImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationServiceImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsQueryUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/DebugUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/DebugUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/CustomStageFixtureDemo.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/CustomStageFixtureDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxToolkitBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxToolkitBasicTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/PrimaryStageFixtureDemo.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/PrimaryStageFixtureDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/SceneRootAssertionTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/SceneRootAssertionTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/SimpleLabelTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/SimpleLabelTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/GlassRobotClipboardBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/GlassRobotClipboardBug.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/StageHideDeadlockBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/StageHideDeadlockBug.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeneralMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeneralMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeometryMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeometryMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ParentMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ParentMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/WindowMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/WindowMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextInputControlMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextInputControlMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/DragRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/DragRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/KeyboardRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/KeyboardRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MouseRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MouseRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MoveRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MoveRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ScrollRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ScrollRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/TypeRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/TypeRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/WriteRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/WriteRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -361,8 +361,8 @@ public class JavafxRobotAdapterTest {
 
     private Point2D pointInCenterFor(Bounds bounds) {
         return new Point2D(
-            bounds.getMinX() + (bounds.getWidth() * 0.5),
-            bounds.getMinY() + (bounds.getHeight() * 0.5)
+                bounds.getMinX() + (bounds.getWidth() * 0.5),
+                bounds.getMinY() + (bounds.getHeight() * 0.5)
         );
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/BoundsPointQueryTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/BoundsPointQueryTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/toolkit/impl/ToolkitServiceImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/toolkit/impl/ToolkitServiceImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/DebugUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/DebugUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsFxTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsFxTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-internal-java8/src/main/java/org/testfx/internal/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java8/src/main/java/org/testfx/internal/JavaVersionAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-internal-java9/src/main/java/module-info.java
+++ b/subprojects/testfx-internal-java9/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -14,7 +14,6 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-
 module org.testfx.internal {
     requires java.base;
     requires javafx.graphics;

--- a/subprojects/testfx-internal-java9/src/main/java/org/testfx/internal/JavaVersionAdapter.java
+++ b/subprojects/testfx-internal-java9/src/main/java/org/testfx/internal/JavaVersionAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/module-info.java
+++ b/subprojects/testfx-junit/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
@@ -14,7 +14,6 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-
 module org.testfx.junit {
     exports org.testfx.framework.junit;
 

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationAdapter.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationFixture.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationFixture.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/TestFXRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/TestFXRule.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/module-info.java
+++ b/subprojects/testfx-junit5/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationAdapter.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationFixture.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationFixture.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Init.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Init.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Start.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Start.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Stop.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Stop.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/ApplicationRuleTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/KeyAndButtonReleaseTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/KeyAndButtonReleaseTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationAdapter.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationAdapter.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationFixture.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationFixture.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationSpec.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2018 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may


### PR DESCRIPTION
Made simple by "./gradlew licenseFormat".

Happy New Year!

Also added the license check to the travis lint stage so it is
caught earlier in the build lifecycle.