### PR TITLE
(enhancement) Add support for AssertJ assertions.

### DIFF
--- a/gradle/check/checkstyle.xml
+++ b/gradle/check/checkstyle.xml
@@ -132,7 +132,9 @@
         </module>
 
         <!-- Naming -->
-        <module name="ClassTypeParameterName"/>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z]$|SELF"/>
+        </module>
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>

--- a/subprojects/testfx-core/src/main/java/module-info.java
+++ b/subprojects/testfx-core/src/main/java/module-info.java
@@ -17,6 +17,7 @@
 module org.testfx {
     exports org.testfx.api;
     exports org.testfx.api.annotation;
+    exports org.testfx.assertions.api;
     exports org.testfx.matcher.base;
     exports org.testfx.matcher.control;
     exports org.testfx.service.adapter;
@@ -38,4 +39,5 @@ module org.testfx {
     requires javafx.web;
     requires hamcrest.core;
     requires org.testfx.internal;
+    requires assertj.core;
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractButtonAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractButtonAssert.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.Button;
+
+import org.testfx.matcher.control.ButtonMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.control.Button} assertions.
+ */
+public class AbstractButtonAssert<SELF extends AbstractButtonAssert<SELF>> extends AbstractLabeledAssert<SELF> {
+
+    protected AbstractButtonAssert(Button actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Button} is a cancel button.
+     *
+     * @return this assertion object
+     */
+    public SELF isCancelButton() {
+        assertThat(actual).is(fromMatcher(ButtonMatchers.isCancelButton()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Button} is not a cancel button.
+     *
+     * @return this assertion object
+     */
+    public SELF isNotCancelButton() {
+        assertThat(actual).is(fromInverseMatcher(ButtonMatchers.isCancelButton()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Button} is a default button.
+     *
+     * @return this assertion object
+     */
+    public SELF isDefaultButton() {
+        assertThat(actual).is(fromMatcher(ButtonMatchers.isDefaultButton()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Button} is not a default button.
+     *
+     * @return this assertion object
+     */
+    public SELF isNotDefaultButton() {
+        assertThat(actual).is(fromInverseMatcher(ButtonMatchers.isDefaultButton()));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractColorAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractColorAssert.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.paint.Color;
+
+import org.assertj.core.api.AbstractAssert;
+import org.testfx.matcher.base.ColorMatchers;
+import org.testfx.service.support.ColorMatcher;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.paint.Color} assertions.
+ */
+public class AbstractColorAssert<SELF extends AbstractColorAssert<SELF>> extends AbstractAssert<SELF, Color> {
+
+    protected AbstractColorAssert(Color color, Class<?> selfType) {
+        super(color, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} is exactly equal to the given {@code color}.
+     *
+     * @param color the given color to compare the actual color to
+     * @return this assertion object
+     */
+    public SELF isColor(Color color) {
+        assertThat(actual).is(fromMatcher(ColorMatchers.isColor(color)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} is not exactly equal to the given {@code color}.
+     *
+     * @param color the given color to compare the actual color to
+     * @return this assertion object
+     */
+    public SELF isNotColor(Color color) {
+        assertThat(actual).is(fromInverseMatcher(ColorMatchers.isColor(color)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} is matched by the given {@code color}
+     * with respect to the given {@code colorMatcher}.
+     * <p>
+     * For example, to match colors using a custom matcher that considers two colors equal if they
+     * have the same red components:
+     * <pre>{@code
+     * assertThat(Color.rgb(0.3, 0.2, 0.1)).isColor(Color.rgb(0.3, 0.8, 0.7),
+     *      (c1, c2) -> c1.getRed() == c2.getRed());
+     * }</pre>
+     *
+     * @param color the given color to compare the actual color to
+     * @param colorMatcher the color matcher to use for comparison
+     * @return this assertion object
+     */
+    public SELF isColor(Color color, ColorMatcher colorMatcher) {
+        assertThat(actual).is(fromMatcher(ColorMatchers.isColor(color, colorMatcher)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} is not matched by the given {@code color}
+     * with respect to the given {@code colorMatcher}.
+     *
+     * @param color the given color to compare the actual color to
+     * @param colorMatcher the color matcher to use for comparison
+     * @return this assertion object
+     */
+    public SELF isNotColor(Color color, ColorMatcher colorMatcher) {
+        assertThat(actual).is(fromInverseMatcher(ColorMatchers.isColor(color, colorMatcher)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} is exactly equal to the given
+     * named color.
+     *
+     * @param namedColor the given named color to compare the actual color to
+     * @return this assertion object
+     * @throws AssertionError if the given named {@code Color} is not a JavaFX named color
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">JavaFX Named Colors</a>
+     */
+    public SELF isColor(String namedColor) {
+        assertThat(actual).is(fromMatcher(ColorMatchers.isColor(namedColor)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} is not exactly equal to the given
+     * {@code namedColor}.
+     *
+     * @param namedColor the given named color to compare the actual color to
+     * @return this assertion object
+     * @throws AssertionError if the given named {@code Color} is not a JavaFX named color
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">JavaFX Named Colors</a>
+     */
+    public SELF isNotColor(String namedColor) {
+        assertThat(actual).is(fromInverseMatcher(ColorMatchers.isColor(namedColor)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} has the given {@code namedColor} as their
+     * closest named color. The {@code namedColor} is <em>not</em> case sensitive.
+     *
+     * @param namedColor the given named color to compare the actual color to
+     * @return this assertion object
+     * @throws AssertionError if the given named {@code Color} is not a JavaFX named color
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">JavaFX Named Colors</a>
+     */
+    public SELF hasClosestNamedColor(Color namedColor) {
+        assertThat(actual).is(fromMatcher(ColorMatchers.hasClosestNamedColor(namedColor)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} does not have the given {@code namedColor} as their
+     * closest named color. The {@code namedColor} is <em>not</em> case sensitive.
+     *
+     * @param namedColor the given named {@code Color} to compare the actual color to
+     * @return this assertion object
+     * @throws AssertionError if the given named {@code Color} is not a JavaFX named color
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">JavaFX Named Colors</a>
+     */
+    public SELF doesNotHaveClosestNamedColor(Color namedColor) {
+        assertThat(actual).is(fromInverseMatcher(ColorMatchers.hasClosestNamedColor(namedColor)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} has the given {@code namedColor} as their
+     * closest named color. The {@code namedColor} is <em>not</em> case sensitive.
+     *
+     * @param namedColor the given named color {@code String} to compare the actual color to
+     * @return this assertion object
+     * @throws AssertionError if the given named color is not a JavaFX named color
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">JavaFX Named Colors</a>
+     */
+    public SELF hasClosestNamedColor(String namedColor) {
+        assertThat(actual).is(fromMatcher(ColorMatchers.hasClosestNamedColor(namedColor)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.paint.Color} does not have the given {@code namedColor} as their
+     * closest named color. The {@code namedColor} is <em>not</em> case sensitive.
+     *
+     * @param namedColor the given named color {@code String} to compare the actual color to
+     * @return this assertion object
+     * @throws AssertionError if the given named coloris not a JavaFX named color
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">JavaFX Named Colors</a>
+     */
+    public SELF doesNotHaveClosestNamedColor(String namedColor) {
+        assertThat(actual).is(fromInverseMatcher(ColorMatchers.hasClosestNamedColor(namedColor)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractComboBoxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractComboBoxAssert.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.ComboBox;
+
+import org.testfx.matcher.control.ComboBoxMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.ComboBox} type.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(ComboBox)}</code>.
+ *
+ * <h4>Example</h4>
+ *
+ * The following code:
+ *
+ * <pre>{@code
+ *   ComboBox<String> fruits = new ComboBox<>();
+ *   fruits.getItems().addAll("Apple", "Banana", "Cherry");
+ *   assertThat(fruits).containsExactlyItemsInOrder("Apple", "Banana", "Cherry");
+ * }</pre>
+ *
+ * will assert that {@code fruits} contains exactly (only) the {@code String}'s
+ * "Apple", "Banana", and "Cherry" in order.
+ */
+public class AbstractComboBoxAssert<SELF extends AbstractComboBoxAssert<SELF, T>, T>
+        extends AbstractNodeAssert<SELF> {
+
+    protected AbstractComboBoxAssert(ComboBox<T> actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} has exactly the given {@code amount}
+     * of items.
+     *
+     * @param amount the given amount of items to compare the actual amount of items to
+     * @return this assertion object
+     */
+    public SELF hasExactlyNumItems(int amount) {
+        assertThat(actual).is(fromMatcher(ComboBoxMatchers.hasItems(amount)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} does not have exactly the
+     * given {@code amount} of items.
+     *
+     * @param amount the given amount of items to compare the actual amount of items to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveExactlyNumItems(int amount) {
+        assertThat(actual).is(fromInverseMatcher(ComboBoxMatchers.hasItems(amount)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} has the given {@code selection}
+     * as its' selected item.
+     *
+     * @param selection the given selection to compare the actual selected item to
+     * @return this assertion object
+     */
+    public SELF hasSelectedItem(T selection) {
+        assertThat(actual).is(fromMatcher(ComboBoxMatchers.hasSelectedItem(selection)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} does not have the given
+     * {@code selection} as its' selected item.
+     *
+     * @param selection the given selection to compare the actual selected item to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveSelectedItem(T selection) {
+        assertThat(actual).is(fromInverseMatcher(ComboBoxMatchers.hasSelectedItem(selection)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} contains at least the given
+     * {@code items} in any order.
+     *
+     * @param items the given items to ensure are at least contained in the {@code ComboBox} in
+     * any order
+     * @return this assertion object
+     */
+    public SELF containsItems(T... items) {
+        assertThat(actual).is(fromMatcher(ComboBoxMatchers.containsItems(items)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} contains exactly the given
+     * {@code items} in any order.
+     *
+     * @param items the given items to ensure are the only ones contained in the {@code ComboBox}
+     * in any order
+     * @return this assertion object
+     */
+    public SELF containsExactlyItems(T... items) {
+        assertThat(actual).is(fromMatcher(ComboBoxMatchers.containsExactlyItems(items)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} contains at least the given
+     * {@code items} in order.
+     *
+     * @param items the given items to ensure are at least contained in the {@code ComboBox} in order
+     * @return this assertion object
+     */
+    public SELF containsItemsInOrder(T... items) {
+        assertThat(actual).is(fromMatcher(ComboBoxMatchers.containsItemsInOrder(items)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ComboBox} contains exactly the given
+     * {@code items} in order.
+     *
+     * @param items the given items to ensure are the only ones contained in the {@code ComboBox}
+     * in order
+     * @return this assertion object
+     */
+    public SELF containsExactlyItemsInOrder(T... items) {
+        assertThat(actual).is(fromMatcher(ComboBoxMatchers.containsExactlyItemsInOrder(items)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractDimension2DAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractDimension2DAssert.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.geometry.Dimension2D;
+
+import org.assertj.core.api.AbstractAssert;
+import org.testfx.matcher.base.GeometryMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.geometry.Dimension2D} assertions.
+ */
+public class AbstractDimension2DAssert<SELF extends AbstractDimension2DAssert<SELF>>
+        extends AbstractAssert<SELF, Dimension2D> {
+
+    protected AbstractDimension2DAssert(Dimension2D dimension2D, Class<?> selfType) {
+        super(dimension2D, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.geometry.Dimension2D} has the given {@code width}
+     * and {@code height}.
+     *
+     * @param width the given width to compare the actual width to
+     * @param height the given height to compare the actual height to
+     * @return this assertion object
+     */
+    public SELF hasDimension(double width, double height) {
+        assertThat(actual).is(fromMatcher(GeometryMatchers.hasDimension(width, height)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.geometry.Dimension2D} does not have either the
+     * given {@code width} and/or {@code height}.
+     *
+     * @param width the given width to compare the actual width to
+     * @param height the given height to compare the actual height to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveDimension(double width, double height) {
+        assertThat(actual).is(fromInverseMatcher(GeometryMatchers.hasDimension(width, height)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractLabeledAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractLabeledAssert.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.Labeled;
+
+import org.hamcrest.Matcher;
+import org.testfx.matcher.control.LabeledMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.control.Labeled} assertions.
+ */
+public class AbstractLabeledAssert<SELF extends AbstractLabeledAssert<SELF>> extends AbstractParentAssert<SELF> {
+
+    protected AbstractLabeledAssert(Labeled actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Labeled} has exactly the given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF hasText(String text) {
+        assertThat(actual).is(fromMatcher(LabeledMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Labeled} does not have exactly the given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(String text) {
+        assertThat(actual).is(fromInverseMatcher(LabeledMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Labeled} is matched by the given {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF hasText(Matcher<String> matcher) {
+        assertThat(actual).is(fromMatcher(LabeledMatchers.hasText(matcher)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Labeled} is not matched by the given {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(Matcher<String> matcher) {
+        assertThat(actual).is(fromInverseMatcher(LabeledMatchers.hasText(matcher)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractListViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractListViewAssert.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.Node;
+import javafx.scene.control.ListView;
+
+import org.testfx.matcher.control.ListViewMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.control.ListView} assertions.
+ */
+public class AbstractListViewAssert<SELF extends AbstractListViewAssert<SELF, T>, T>
+        extends AbstractNodeAssert<SELF> {
+
+    protected AbstractListViewAssert(ListView<T> actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} contains the given list cell
+     * {@code value}.
+     *
+     * @param value the given list cell value to ensure the {@code ListView} contains
+     * @return this assertion object
+     */
+    public SELF hasListCell(Object value) {
+        assertThat(actual).is(fromMatcher(ListViewMatchers.hasListCell(value)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} does not contain the
+     * given list cell {@code value}.
+     *
+     * @param value the given list cell value to ensure the {@code ListView} does not contain
+     * @return this assertion object
+     */
+    public SELF doesNotHaveListCell(Object value) {
+        assertThat(actual).is(fromInverseMatcher(ListViewMatchers.hasListCell(value)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} has exactly the given {@code amount}
+     * of items.
+     *
+     * @param amount the given amount of items to compare the actual amount of items to
+     * @return this assertion object
+     */
+    public SELF hasExactlyNumItems(int amount) {
+        assertThat(actual).is(fromMatcher(ListViewMatchers.hasItems(amount)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} does not have exactly the
+     * given {@code amount} of items.
+     *
+     * @param amount the given amount of items to compare the actual amount of items to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveExactlyNumItems(int amount) {
+        assertThat(actual).is(fromInverseMatcher(ListViewMatchers.hasItems(amount)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} is empty (does not contain
+     * any items).
+     *
+     * @return this assertion object
+     */
+    public SELF isEmpty() {
+        assertThat(actual).is(fromMatcher(ListViewMatchers.isEmpty()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} is not empty (contains at
+     * least one item).
+     *
+     * @return this assertion object
+     */
+    public SELF isNotEmpty() {
+        assertThat(actual).is(fromInverseMatcher(ListViewMatchers.isEmpty()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} has the given {@code placeHolder}
+     * node.
+     *
+     * @param placeHolder the given place holder {@code Node} to compare the actual place holder to
+     * @return this assertion object
+     */
+    public SELF hasPlaceholder(Node placeHolder) {
+        assertThat(actual).is(fromMatcher(ListViewMatchers.hasPlaceholder(placeHolder)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} does not have the given
+     * {@code placeHolder} node.
+     *
+     * @param placeHolder the given place holder {@code Node} to compare the actual place holder to
+     * @return this assertion object
+     */
+    public SELF doesNotHavePlaceholder(Node placeHolder) {
+        assertThat(actual).is(fromInverseMatcher(ListViewMatchers.hasPlaceholder(placeHolder)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} has the given {@code placeHolder}
+     * node and that the node is visible.
+     *
+     * @param placeHolder the given place holder {@code Node} to compare the actual place holder to
+     * @return this assertion object
+     */
+    public SELF hasVisiblePlaceholder(Node placeHolder) {
+        assertThat(actual).is(fromMatcher(ListViewMatchers.hasVisiblePlaceholder(placeHolder)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.ListView} does not have the given visible
+     * {@code placeHolder}. This assertion will pass for any invisible place holder.
+     *
+     * @param placeHolder the given place holder {@code Node} to compare the actual place holder to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveVisiblePlaceholder(Node placeHolder) {
+        assertThat(actual).is(fromInverseMatcher(ListViewMatchers.hasVisiblePlaceholder(placeHolder)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractNodeAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractNodeAssert.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.Node;
+
+import org.assertj.core.api.AbstractAssert;
+import org.testfx.matcher.base.NodeMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.Node} assertions.
+ */
+public class AbstractNodeAssert<SELF extends AbstractNodeAssert<SELF>> extends AbstractAssert<SELF, Node> {
+
+    protected AbstractNodeAssert(Node actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} is visible.
+     *
+     * @return this assertion object
+     */
+    public SELF isVisible() {
+        assertThat(actual).is(fromMatcher(NodeMatchers.isVisible()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} is not visible.
+     *
+     * @return this assertion object
+     */
+    public SELF isInvisible() {
+        assertThat(actual).is(fromMatcher(NodeMatchers.isInvisible()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} is enabled.
+     *
+     * @return this assertion object
+     */
+    public SELF isEnabled() {
+        assertThat(actual).is(fromMatcher(NodeMatchers.isEnabled()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} is disabled.
+     *
+     * @return this assertion object
+     */
+    public SELF isDisabled() {
+        assertThat(actual).is(fromMatcher(NodeMatchers.isDisabled()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} has focus.
+     *
+     * @return this assertion object
+     */
+    public SELF isFocused() {
+        assertThat(actual).is(fromMatcher(NodeMatchers.isFocused()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} does not have focus.
+     *
+     * @return this assertion object
+     */
+    public SELF isNotFocused() {
+        assertThat(actual).is(fromMatcher(NodeMatchers.isNotFocused()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} has a specific child {@code Node}.
+     * The child {@code Node} to look for is specified by the given {@code query}, which
+     * is passed to {@link org.testfx.service.query.NodeQuery#lookup(String)}.
+     *
+     * @param query the node query that specifies the child to look for in the actual {@link Node}
+     * @return this assertion object
+     */
+    public SELF hasChild(String query) {
+        assertThat(actual).is(fromMatcher(NodeMatchers.hasChild(query)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} does not have a specific child {@code Node}.
+     * The child {@code Node} to look for is specified by the given {@code query}, which
+     * is passed to {@link org.testfx.service.query.NodeQuery#lookup(String)}.
+     *
+     * @param query the node query that specifies the child to look for in the actual {@link Node}
+     * @return this assertion object
+     */
+    public SELF doesNotHaveChild(String query) {
+        assertThat(actual).is(fromInverseMatcher(NodeMatchers.hasChild(query)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Node} has exactly the given {@code amount}
+     * of children that are looked up by the given {@code query}, which is passed to
+     * is passed to {@link org.testfx.service.query.NodeQuery#lookup(String)}.
+     *
+     * @param amount the given amount of children the actual {@code Node} must exactly have
+     * @param query the node query that specifies the children to look for in the actual {@link Node}
+     * @return this assertion object
+     */
+    public SELF hasExactlyChildren(int amount, String query) {
+        assertThat(actual).is(fromMatcher(NodeMatchers.hasChildren(amount, query)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractParentAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractParentAssert.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.Parent;
+
+import org.testfx.matcher.base.ParentMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.Parent} assertions.
+ */
+public class AbstractParentAssert<SELF extends AbstractParentAssert<SELF>> extends AbstractNodeAssert<SELF> {
+
+    protected AbstractParentAssert(Parent actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Parent} has at least one child.
+     *
+     * @return this assertion object
+     */
+    public SELF hasAnyChild() {
+        assertThat(actual).is(fromMatcher(ParentMatchers.hasChild()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Parent} has no children.
+     *
+     * @return this assertion object
+     */
+    public SELF hasNoChildren() {
+        assertThat(actual).is(fromInverseMatcher(ParentMatchers.hasChild()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Parent} has exactly the given
+     * {@code amount} of children.
+     *
+     * @param amount the given amount of children that the actual {@code Parent} should
+     * exactly have
+     * @return this assertion object
+     */
+    public SELF hasExactlyNumChildren(int amount) {
+        assertThat(actual).is(fromMatcher(ParentMatchers.hasChildren(amount)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.Parent} does not have exactly the given
+     * {@code amount} of children.
+     *
+     * @param amount the given amount of children that the actual {@code Parent} should not
+     * exactly have
+     * @return this assertion object
+     */
+    public SELF doesNotHaveExactlyNumChildren(int amount) {
+        assertThat(actual).is(fromInverseMatcher(ParentMatchers.hasChildren(amount)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTableViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTableViewAssert.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.TableView;
+
+import org.testfx.matcher.control.TableViewMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.control.TableView} assertions.
+ */
+public class AbstractTableViewAssert<SELF extends AbstractTableViewAssert<SELF, T>, T>
+        extends AbstractNodeAssert<SELF> {
+
+    protected AbstractTableViewAssert(TableView<T> actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} contains the given table cell
+     * {@code expectedValue}.
+     *
+     * @param expectedValue the given table cell value to ensure the {@code TableView} contains
+     * @return this assertion object
+     */
+    public SELF hasTableCell(Object expectedValue) {
+        assertThat(actual).is(fromMatcher(TableViewMatchers.hasTableCell(expectedValue)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} does not contain the given table
+     * cell {@code expectedValue}.
+     *
+     * @param expectedValue the given table cell value to ensure the {@code TableView} does not contain
+     * @return this assertion object
+     */
+    public SELF doesNotHaveTableCell(Object expectedValue) {
+        assertThat(actual).is(fromInverseMatcher(TableViewMatchers.hasTableCell(expectedValue)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} has exactly the given {@code amount}
+     * of rows.
+     *
+     * @param rows the given amount of rows to compare the actual amount of rows to
+     * @return this assertion object
+     */
+    public SELF hasExactlyNumRows(int rows) {
+        assertThat(actual).is(fromMatcher(TableViewMatchers.hasNumRows(rows)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} does not have exactly the given
+     * {@code amount} of rows.
+     *
+     * @param rows the given amount of rows to compare the actual amount of rows to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveExactlyNumRows(int rows) {
+        assertThat(actual).is(fromInverseMatcher(TableViewMatchers.hasNumRows(rows)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} contains the given table {@code cells}
+     * at the given {@code rowIndex}.
+     * <p>
+     * For example, given a {@code TableView} that has three columns:
+     * <pre>{@code
+     * TableColumn<RegularPolygon, String> nameColumn = new TableColumn<>("Name");
+     * TableColumn<RegularPolygon, Integer> numSidesColumn = new TableColumn<>("Number of Sides");
+     * TableColumn<RegularPolygon, Double> unitAreaColumn = new TableColumn<>("Area when Side = 1");
+     * polygonsTable.getColumns().setAll(nameColumn, numSidesColumn, unitAreaColumn);
+     * }</pre>
+     * Then to verify that such a {@code TableView}, contains, at index 3, a row for a {@code RegularPolygon}
+     * that has the name {@literal "Pentagon"}, the number of sides {@literal 5}, and a unit area of
+     * {@literal 1.720477401} one would use:
+     * <pre>{@code
+     * assertThat(polygonsTable).containsRowAtIndex(3, "Pentagon", 5, 1.720477401);
+     * }</pre>
+     * Where the types of each argument, after the row index, correspond to the types of the {@code TableColumn}s
+     * which in our example is {@code (String, Integer, Double)}.
+     *
+     * @param rowIndex the given row index that the actual {@code TableView} should contain the given cells on
+     * @param cells the cells that should be contained at the given row index
+     * @return this assertion object
+     */
+    public SELF containsRowAtIndex(int rowIndex, Object... cells) {
+        assertThat(actual).is(fromMatcher(TableViewMatchers.containsRowAtIndex(rowIndex, cells)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} does not contain the given
+     * table {@code cells} at the given {@code rowIndex}.
+     *
+     * @param rowIndex the given row index that the actual {@code TableView} should not contain
+     * the given cells on
+     * @param cells the cells that should not be contained at the given row index
+     * @return this assertion object
+     */
+    public SELF doesNotContainRowAtIndex(int rowIndex, Object... cells) {
+        assertThat(actual).is(fromInverseMatcher(TableViewMatchers.containsRowAtIndex(rowIndex, cells)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} contains the given table {@code cells}
+     * at any row index.
+     * <p>
+     * For example, given a {@code TableView} that has three columns:
+     * <pre>{@code
+     * TableColumn<Person, String> nameColumn = new TableColumn<>("Name");
+     * TableColumn<Person, Double> bmiColumn = new TableColumn<>("Body Mass Index");
+     * TableColumn<Person, Boolean> membershipColumn = new TableColumn<>("Gym Membership Valid");
+     * fitnessTable.getColumns().setAll(nameColumn, bmiColumn, membershipColumn);
+     * }</pre>
+     * Then to verify that such a {@code TableView}, contains at least one row with a {@code Person}
+     * that has the name {@literal "Dan Anderson"}, the body mass index {@literal 28.83}, and a valid
+     * gym membership ({@literal true}) one would use:
+     * <pre>{@code
+     * assertThat(fitnessTable).containsRow("Dan Anderson", 28.83, true);
+     * }</pre>
+     * Where the types of each argument correspond to the types of the {@code TableColumn}s which
+     * in our example is {@code (String, Double, Boolean)}.
+     *
+     * @param cells the cells that should be contained at any (at least one) row index
+     * @return this assertion object
+     */
+    public SELF containsRow(Object...cells) {
+        assertThat(actual).is(fromMatcher(TableViewMatchers.containsRow(cells)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TableView} does not contain the given
+     * table {@code cells} at any row index.
+     *
+     * @param cells the cells that should not be contained at any (at least one) row index
+     * @return this assertion object
+     */
+    public SELF doesNotContainRow(Object... cells) {
+        assertThat(actual).is(fromInverseMatcher(TableViewMatchers.containsRow(cells)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextAssert.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.text.Text;
+
+import org.hamcrest.Matcher;
+import org.testfx.matcher.control.TextMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.text.Text} assertions.
+ */
+public class AbstractTextAssert<SELF extends AbstractTextAssert<SELF>> extends AbstractNodeAssert<SELF> {
+
+    protected AbstractTextAssert(Text actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.Text} has exactly the given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF hasText(String text) {
+        assertThat(actual).is(fromMatcher(TextMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.Text} does not have exactly the given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(String text) {
+        assertThat(actual).is(fromInverseMatcher(TextMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.Text} is matched by the given {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF hasText(Matcher<String> matcher) {
+        assertThat(actual).is(fromMatcher(TextMatchers.hasText(matcher)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.Text} is not matched by the given {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(Matcher<String> matcher) {
+        assertThat(actual).is(fromInverseMatcher(TextMatchers.hasText(matcher)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextFlowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextFlowAssert.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.text.TextFlow;
+
+import org.testfx.matcher.control.TextFlowMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.text.TextFlow} assertions.
+ */
+public class AbstractTextFlowAssert<SELF extends AbstractTextFlowAssert<SELF>> extends AbstractParentAssert<SELF> {
+
+    protected AbstractTextFlowAssert(TextFlow actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.TextFlow} has exactly the given {@code text}
+     * (the result of combining all of its text-based children's text together).
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF hasText(String text) {
+        assertThat(actual).is(fromMatcher(TextFlowMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.TextFlow} does not have exactly the given
+     * {@code text} (the result of combining all of its text-based children's text together).
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(String text) {
+        assertThat(actual).is(fromInverseMatcher(TextFlowMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.TextFlow} has the given {@code coloredTextMarkup}.
+     * The color is matched by using the closest named color, as described below.
+     * <p>
+     * Colors are specified using the following markup:
+     * <pre>{@code <COLOR>text</COLOR>}</pre>
+     * <p>
+     * Where {@literal COLOR} is one of JavaFX's named colors.
+     * <p>
+     * Here is an example for verifying that a TextFlow contains the text
+     * "hello" and that the named color that has the closest value to the
+     * color of the text is {@literal Colors.RED}:
+     * <p>
+     * <pre>{@code
+     *   Text text = new Text("hello");
+     *   text.setFill(Colors.RED);
+     *   TextFlow textFlow = new TextFlow(text);
+     *   assertThat(textFlow).hasColoredText("<RED>hello</RED>");
+     * }</pre>
+     *
+     * @param coloredTextMarkup the given colored text markup to compare the actual colored text to
+     * @return this assertion object
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">Named Colors</a>
+     */
+    public SELF hasColoredText(String coloredTextMarkup) {
+        assertThat(actual).is(fromMatcher(TextFlowMatchers.hasColoredText(coloredTextMarkup)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.TextFlow} does not have the given {@code coloredTextMarkup}.
+     * The color is matched by using the closest named color, as described below.
+     * <p>
+     * Colors are specified using the following markup:
+     * <pre>{@code <COLOR>text</COLOR>}</pre>
+     * <p>
+     * Where {@literal COLOR} is one of JavaFX's named colors.
+     * <p>
+     * Here is an example for verifying that a TextFlow does not contain the text
+     * "hello" with any color that has the closest named color {@literal Colors.RED}:
+     * <p>
+     * <pre>{@code
+     *   Text text = new Text("hello");
+     *   text.setFill(Colors.BLUE);
+     *   TextFlow textFlow = new TextFlow(text);
+     *   assertThat(textFlow).doesNotHaveColoredText("<RED>hello</RED>");
+     * }</pre>
+     *
+     * @param coloredTextMarkup the given colored text markup to compare the actual colored text to
+     * @return this assertion object
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">Named Colors</a>
+     */
+    public SELF doesNotHaveColoredText(String coloredTextMarkup) {
+        assertThat(actual).is(fromInverseMatcher(TextFlowMatchers.hasColoredText(coloredTextMarkup)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.TextFlow} has exactly the given {@code coloredTextMarkup}.
+     * The color is matched in an exact way, as described below.
+     * <p>
+     * Colors are specified using the following markup:
+     * <pre>{@code <COLOR>text</COLOR>}</pre>
+     * <p>
+     * Where {@literal COLOR} is one of JavaFX's named colors.
+     * <p>
+     * Here is an example for verifying that a TextFlow contains the text
+     * "hello" and that the color of the text is <em>exactly</em> {@literal Colors.BLUE}
+     * (that is, it has an RGB value of (0, 0, 255)).
+     *
+     * <pre><code>
+     *   Text text = new Text("hello");
+     *   text.setFill(Colors.BLUE); // or: text.setFill(Colors.rgb(0, 0, 255));
+     *   TextFlow textFlow = new TextFlow(text);
+     *   assertThat(textFlow).hasExactlyColoredText("<BLUE>hello</BLUE>");
+     * </code></pre>
+     *
+     * @param coloredTextMarkup the given colored text markup to compare the actual colored text to
+     * @return this assertion object
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">Named Colors</a>
+     */
+    public SELF hasExactlyColoredText(String coloredTextMarkup) {
+        assertThat(actual).is(fromMatcher(TextFlowMatchers.hasExactlyColoredText(coloredTextMarkup)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.text.TextFlow} does not have exactly the given
+     * {@code coloredTextMarkup}. The color is matched in an exact way, as described below.
+     * <p>
+     * Colors are specified using the following markup:
+     * <pre>{@code <COLOR>text</COLOR>}</pre>
+     * <p>
+     * Where {@literal COLOR} is one of JavaFX's named colors.
+     * <p>
+     * Here is an example for verifying that a TextFlow does not contain the text
+     * "hello" and that the color of the text is not <em>exactly</em> {@literal Colors.BLUE}
+     * (that is, it does not have an RGB value of (0, 0, 255)).
+     *
+     * <pre><code>
+     *   Text text = new Text("hello");
+     *   text.setFill(Colors.rgb(0, 0, 254));
+     *   TextFlow textFlow = new TextFlow(text);
+     *   assertThat(textFlow).doesNotHaveExactlyColoredText("<BLUE>hello</BLUE>");
+     * </code></pre>
+     *
+     * @param coloredTextMarkup the given colored text markup to compare the actual colored text to
+     * @return this assertion object
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">Named Colors</a>
+     */
+    public SELF doesNotHaveExactlyColoredText(String coloredTextMarkup) {
+        assertThat(actual).is(fromMatcher(TextFlowMatchers.hasExactlyColoredText(coloredTextMarkup)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextInputControlAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextInputControlAssert.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.TextInputControl;
+
+import org.hamcrest.Matcher;
+import org.testfx.matcher.control.TextInputControlMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.control.TextInputControl} assertions.
+ */
+public class AbstractTextInputControlAssert<SELF extends AbstractTextInputControlAssert<SELF>>
+        extends AbstractParentAssert<SELF> {
+
+    protected AbstractTextInputControlAssert(TextInputControl actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TextInputControl} has exactly the given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF hasText(String text) {
+        assertThat(actual).is(fromMatcher(TextInputControlMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TextInputControl} does not have exactly the
+     * given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(String text) {
+        assertThat(actual).is(fromInverseMatcher(TextInputControlMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TextInputControl} is matched by the given {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF hasText(Matcher<String> matcher) {
+        assertThat(actual).is(fromMatcher(TextInputControlMatchers.hasText(matcher)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.TextInputControl} is not matched by the given
+     * {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(Matcher<String> matcher) {
+        assertThat(actual).is(fromInverseMatcher(TextInputControlMatchers.hasText(matcher)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractWindowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractWindowAssert.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.stage.Window;
+
+import org.assertj.core.api.AbstractAssert;
+import org.testfx.matcher.base.WindowMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.stage.Window} assertions.
+ */
+public class AbstractWindowAssert<SELF extends AbstractWindowAssert<SELF>> extends AbstractAssert<SELF, Window> {
+
+    protected AbstractWindowAssert(Window window, Class<?> selfType) {
+        super(window, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.stage.Window} is showing.
+     *
+     * @return this assertion object
+     */
+    public SELF isShowing() {
+        assertThat(actual).is(fromMatcher(WindowMatchers.isShowing()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.stage.Window} is not showing.
+     *
+     * @return this assertion object
+     */
+    public SELF isNotShowing() {
+        assertThat(actual).is(fromMatcher(WindowMatchers.isNotShowing()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.stage.Window} is focused.
+     *
+     * @return this assertion object
+     */
+    public SELF isFocused() {
+        assertThat(actual).is(fromMatcher(WindowMatchers.isFocused()));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.stage.Window} is not focused.
+     *
+     * @return this assertion object
+     */
+    public SELF isNotFocused() {
+        assertThat(actual).is(fromMatcher(WindowMatchers.isNotFocused()));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Assertions.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Assertions.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.geometry.Dimension2D;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+import javafx.stage.Window;
+
+/**
+ * The entry point for all TestFX assertions for different JavaFX types.
+ */
+public class Assertions extends org.assertj.core.api.Assertions {
+
+    protected Assertions() {}
+
+    /**
+     * Create assertion for {@link Button}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static ButtonAssert assertThat(Button actual) {
+        return new ButtonAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link Color}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static ColorAssert assertThat(Color actual) {
+        return new ColorAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link ComboBox}.
+     *
+     * @param actual the actual value
+     * @param <T> the type of the value contained in the {@link ComboBox}
+     * @return the created assertion object
+     */
+    public static <T> ComboBoxAssert<T> assertThat(ComboBox<T> actual) {
+        return new ComboBoxAssert<>(actual);
+    }
+
+    /**
+     * Create assertion for {@link Dimension2D}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static Dimension2DAssert assertThat(Dimension2D actual) {
+        return new Dimension2DAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link Button}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static LabeledAssert assertThat(Labeled actual) {
+        return new LabeledAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link ListView}.
+     *
+     * @param actual the actual value
+     * @param <T> the type of the value contained in the {@link ListView}
+     * @return the created assertion object
+     */
+    public static <T> ListViewAssert<T> assertThat(ListView<T> actual) {
+        return new ListViewAssert<>(actual);
+    }
+
+    /**
+     * Create assertion for {@link Button}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static NodeAssert assertThat(Node actual) {
+        return new NodeAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link Parent}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static ParentAssert assertThat(Parent actual) {
+        return new ParentAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link TableView}.
+     *
+     * @param actual the actual value
+     * @param <T> the type of the value contained in the {@link TableView}
+     * @return the created assertion object
+     */
+    public static <T> TableViewAssert<T> assertThat(TableView<T> actual) {
+        return new TableViewAssert<>(actual);
+    }
+
+    /**
+     * Create assertion for {@link Text}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static TextAssert assertThat(Text actual) {
+        return new TextAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link TextFlow}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static TextFlowAssert assertThat(TextFlow actual) {
+        return new TextFlowAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link TextInputControl}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static TextInputControlAssert assertThat(TextInputControl actual) {
+        return new TextInputControlAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link Window}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static WindowAssert assertThat(Window actual) {
+        return new WindowAssert(actual);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ButtonAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ButtonAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.Button;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.Button}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Button)}</code>.
+ */
+public class ButtonAssert extends AbstractButtonAssert<ButtonAssert> {
+
+    protected ButtonAssert(Button actual) {
+        super(actual, ButtonAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ColorAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ColorAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.paint.Color;
+
+/**
+ * Assertion methods for {@link javafx.scene.paint.Color}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Color)}</code>.
+ */
+public class ColorAssert extends AbstractColorAssert<ColorAssert> {
+
+    protected ColorAssert(Color actual) {
+        super(actual, ColorAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ComboBoxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ComboBoxAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.ComboBox;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.ComboBox}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(ComboBox)}</code>.
+ */
+public class ComboBoxAssert<T> extends AbstractComboBoxAssert<ComboBoxAssert<T>, T> {
+
+    protected ComboBoxAssert(ComboBox<T> actual) {
+        super(actual, ComboBoxAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Dimension2DAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Dimension2DAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.geometry.Dimension2D;
+
+/**
+ * Assertion methods for {@link javafx.geometry.Dimension2D}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Dimension2D)}</code>.
+ */
+public class Dimension2DAssert extends AbstractDimension2DAssert<Dimension2DAssert> {
+
+    protected Dimension2DAssert(Dimension2D actual) {
+        super(actual, Dimension2DAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/LabeledAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/LabeledAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.Labeled;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.Labeled}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Labeled)}</code>.
+ */
+public class LabeledAssert extends AbstractLabeledAssert<LabeledAssert> {
+
+    protected LabeledAssert(Labeled actual) {
+        super(actual, LabeledAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ListViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ListViewAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.ListView;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.ListView}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(ListView)}</code>.
+ */
+public class ListViewAssert<T> extends AbstractListViewAssert<ListViewAssert<T>, T> {
+
+    protected ListViewAssert(ListView<T> actual) {
+        super(actual, ListViewAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/NodeAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/NodeAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.Node;
+
+/**
+ * Assertion methods for {@link javafx.scene.Node}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Node)}</code>.
+ */
+public class NodeAssert extends AbstractNodeAssert<NodeAssert> {
+
+    protected NodeAssert(Node actual) {
+        super(actual, NodeAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ParentAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ParentAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.Parent;
+
+/**
+ * Assertion methods for {@link javafx.scene.Parent}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Parent)}</code>.
+ */
+public class ParentAssert extends AbstractParentAssert<ParentAssert> {
+
+    protected ParentAssert(Parent actual) {
+        super(actual, ParentAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TableViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TableViewAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.TableView;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.TableView}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(TableView)}</code>.
+ */
+public class TableViewAssert<T> extends AbstractTableViewAssert<TableViewAssert<T>, T> {
+
+    protected TableViewAssert(TableView<T> actual) {
+        super(actual, TableViewAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextAssert.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.text.Text;
+
+/**
+ * Assertion methods for {@link javafx.scene.text.Text}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Text)}</code>.
+ */
+public class TextAssert extends AbstractTextAssert<TextAssert> {
+
+    protected TextAssert(Text actual) {
+        super(actual, TextAssert.class);
+    }
+}
+

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextFlowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextFlowAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.text.TextFlow;
+
+/**
+ * Assertion methods for {@link javafx.scene.text.TextFlow}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(TextFlow)}</code>.
+ */
+public class TextFlowAssert extends AbstractTextFlowAssert<TextFlowAssert> {
+
+    protected TextFlowAssert(TextFlow actual) {
+        super(actual, TextFlowAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextInputControlAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextInputControlAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.TextInputControl;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.TextInputControl}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(TextInputControl)}</code>.
+ */
+public class TextInputControlAssert extends AbstractTextInputControlAssert<TextInputControlAssert> {
+
+    protected TextInputControlAssert(TextInputControl actual) {
+        super(actual, TextInputControlAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/WindowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/WindowAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.stage.Window;
+
+/**
+ * Assertion methods for {@link javafx.stage.Window}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Window)}</code>.
+ */
+public class WindowAssert extends AbstractWindowAssert<WindowAssert> {
+
+    protected WindowAssert(Window actual) {
+        super(actual, WindowAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/impl/Adapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/impl/Adapter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.impl;
+
+import org.assertj.core.api.Condition;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Provides static utility methods for converting a hamcrest matcher to an AssertJ
+ * condition. We use this internally in the implementation of AssertJ assertions.
+ * <p>
+ * This class is not part of the TestFX API and is not expected to be useful outside
+ * of our specific context.
+ */
+public class Adapter {
+
+    public static <T> Condition<? super T> fromInverseMatcher(Matcher<? extends T> matcher) {
+        return adaptMatcher(matcher, true);
+    }
+
+    public static <T> Condition<? super T> fromMatcher(Matcher<? extends T> matcher) {
+        return adaptMatcher(matcher, false);
+    }
+
+    private static <T> Condition<? super T> adaptMatcher(Matcher<? extends T> matcher, boolean invert) {
+        return new Condition<T>() {
+            @Override public boolean matches(T t) {
+
+                boolean matches = matcher.matches(t);
+                if (invert) {
+                    matches = !matches;
+                }
+                if (!matches) {
+                    StringDescription reasonDescription = new StringDescription();
+                    matcher.describeTo(reasonDescription);
+                    // This is hacky, we essentially short-circuit AssertJ exception throwing in order to
+                    // use the same error messages as Hamcrest matchers without having to call "overridingErrorMessage"
+                    // at each "assertThat" call site.
+                    throw new AssertionError(getErrorMessage(matcher, t, invert));
+                }
+                return true;
+            }
+        };
+    }
+
+    private static <T> String getErrorMessage(Matcher<? extends T> matcher, T actual, boolean invert) {
+        StringBuilder errorMessageBuilder = new StringBuilder();
+        errorMessageBuilder.append("Expected: ");
+        StringDescription reasonDescription = new StringDescription();
+        matcher.describeTo(reasonDescription);
+        errorMessageBuilder.append(reasonDescription.toString())
+                .append(invert ? " to be false" : "")
+                .append("\n     but: ")
+                .append(getActual(matcher, actual));
+        return errorMessageBuilder.toString();
+    }
+
+    private static <T> String getActual(Matcher<? extends T> matcher, T actual) {
+        String actualStr = actual.toString();
+        if (matcher instanceof TypeSafeMatcher) {
+            TypeSafeMatcher typeSafeMatcher = (TypeSafeMatcher) matcher;
+            StringDescription valueDescription = new StringDescription();
+            typeSafeMatcher.describeMismatch(actual, valueDescription);
+            actualStr = valueDescription.toString();
+        }
+        return actualStr;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
@@ -104,7 +104,7 @@ public class ColorMatchers {
 
     /**
      * Creates a matcher that matches all {@link Color}s that have the given named color {@code String}
-     * their closest JavaFX named color. The {@code namedColor} is <em>not</em> case sensitive.
+     * as their closest JavaFX named color. The {@code namedColor} is <em>not</em> case sensitive.
      *
      * @throws AssertionError if the given named color {@code String} is not a JavaFX named color
      * @see <a href="https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor">JavaFX Named Colors</a>

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/NodeMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/NodeMatchers.java
@@ -19,17 +19,11 @@ package org.testfx.matcher.base;
 import java.util.Objects;
 
 import javafx.scene.Node;
-import javafx.scene.control.Labeled;
-import javafx.scene.control.TextInputControl;
-import javafx.scene.text.Text;
 
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.testfx.api.FxAssert;
 import org.testfx.api.annotation.Unstable;
-import org.testfx.matcher.control.LabeledMatchers;
-import org.testfx.matcher.control.TextInputControlMatchers;
-import org.testfx.matcher.control.TextMatchers;
 import org.testfx.service.finder.NodeFinder;
 import org.testfx.service.query.NodeQuery;
 
@@ -118,27 +112,7 @@ public class NodeMatchers {
     }
 
     /**
-     * Creates a matcher that matches all {@link javafx.scene.control.Labeled}, {@link TextInputControl},
-     * and {@link Text} objects that have the given {@code string}.
-     */
-    @Factory
-    public static Matcher<Node> hasText(String string) {
-        String descriptionText = "Node has text \"" + string + "\"";
-        return baseMatcher(descriptionText, node -> hasText(node, string));
-    }
-
-    /**
-     * Creates a matcher that matches all {@link javafx.scene.control.Labeled}, {@link TextInputControl},
-     * and {@link Text} objects whose {@code text} matches the given {@code matcher}.
-     */
-    @Factory
-    public static Matcher<Node> hasText(Matcher<String> matcher) {
-        String descriptionText = "Node has " + matcher.toString();
-        return baseMatcher(descriptionText, node -> hasText(node, matcher));
-    }
-
-    /**
-     * Creates a matcher that matches all {@link Node}s that have at least one node that is found via
+     * Creates a matcher that matches all {@link Node}s that have at least one child node that is found via
      * {@link org.testfx.service.query.NodeQuery#lookup(String)}.
      */
     @Factory
@@ -148,39 +122,13 @@ public class NodeMatchers {
     }
 
     /**
-     * Creates a matcher that matches all {@link Node}s that have exactly {@code amount} nodes that are found via
-     * {@link org.testfx.service.query.NodeQuery#lookup(String)}.
+     * Creates a matcher that matches all {@link Node}s that have exactly {@code amount} child nodes that are found
+     * via {@link org.testfx.service.query.NodeQuery#lookup(String)}.
      */
     @Factory
     public static Matcher<Node> hasChildren(int amount, String query) {
         String descriptionText = "Node has " + amount + " children \"" + query + "\"";
         return baseMatcher(descriptionText, node -> hasChildren(node, amount, query));
-    }
-
-    private static boolean hasText(Node node, String string) {
-        if (node instanceof Labeled) {
-            return LabeledMatchers.hasText(string).matches(node);
-        }
-        else if (node instanceof TextInputControl) {
-            return TextInputControlMatchers.hasText(string).matches(node);
-        }
-        else if (node instanceof Text) {
-            return TextMatchers.hasText(string).matches(node);
-        }
-        return false;
-    }
-
-    private static boolean hasText(Node node, Matcher<String> matcher) {
-        if (node instanceof Labeled) {
-            return LabeledMatchers.hasText(matcher).matches(node);
-        }
-        else if (node instanceof TextInputControl) {
-            return TextInputControlMatchers.hasText(matcher).matches(node);
-        }
-        else if (node instanceof Text) {
-            return TextMatchers.hasText(matcher).matches(node);
-        }
-        return false;
     }
 
     private static boolean hasChild(Node node, String query) {

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ParentMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ParentMatchers.java
@@ -16,6 +16,10 @@
  */
 package org.testfx.matcher.base;
 
+import java.util.stream.Collectors;
+
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 
 import org.hamcrest.Factory;
@@ -37,8 +41,9 @@ public class ParentMatchers {
      */
     @Factory
     public static Matcher<Parent> hasChild() {
-        String descriptionText = "has child";
+        String descriptionText = "has at least one child";
         return typeSafeMatcher(Parent.class, descriptionText,
+            parent -> toText(parent.getChildrenUnmodifiable()),
             parent -> !parent.getChildrenUnmodifiable().isEmpty());
     }
 
@@ -47,9 +52,20 @@ public class ParentMatchers {
      */
     @Factory
     public static Matcher<Parent> hasChildren(int amount) {
-        String descriptionText = "has " + amount + " children";
+        String descriptionText = "has exactly " + amount + " children";
         return typeSafeMatcher(Parent.class, descriptionText,
+            parent -> toText(parent.getChildrenUnmodifiable()),
             parent -> parent.getChildrenUnmodifiable().size() == amount);
+    }
+
+    private static String toText(ObservableList<Node> children) {
+        if (children.isEmpty()) {
+            return "empty (contained no children)";
+        } else {
+            return '[' + children.stream().map(node -> node.getClass().getSimpleName())
+                    .collect(Collectors.joining(", ")) + ']' +
+                    " (which has " + children.size() + ' ' + (children.size() == 1 ? "child" : "children") + ')';
+        }
     }
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ButtonMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ButtonMatchers.java
@@ -16,7 +16,6 @@
  */
 package org.testfx.matcher.control;
 
-import javafx.scene.Node;
 import javafx.scene.control.Button;
 
 import org.hamcrest.Factory;
@@ -32,7 +31,7 @@ public class ButtonMatchers {
     private ButtonMatchers() {}
 
     /**
-     * Creates a matcher that matches all {@link Button}s that are considered cancel buttons.
+     * Creates a matcher that matches all {@link Button}s that are cancel buttons.
      */
     @Factory
     public static Matcher<Button> isCancelButton() {
@@ -40,10 +39,10 @@ public class ButtonMatchers {
     }
 
     /**
-     * Creates a matcher that matches all {@link Button}s that are considered default buttons.
+     * Creates a matcher that matches all {@link Button}s that are default buttons.
      */
     @Factory
-    public static Matcher<Node> isDefaultButton() {
+    public static Matcher<Button> isDefaultButton() {
         return typeSafeMatcher(Button.class, "is default button", Button::isDefaultButton);
     }
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
@@ -28,15 +28,17 @@ import static org.testfx.matcher.base.GeneralMatchers.typeSafeMatcher;
 
 /**
  * TestFX matchers for {@link ComboBox} controls.
- * <p>
+ *
  * <h4>Example</h4>
- * <p>
+ *
  * The following code:
+ *
  * <pre>{@code
  *   ComboBox<String> fruits = new ComboBox<>();
  *   fruits.getItems().addAll("Apple", "Banana", "Cherry");
  *   assertThat(fruits, ComboBoxMatchers.containsExactlyItemsInOrder("Apple", "Banana", "Cherry"));
  * }</pre>
+ *
  * will verify that {@code fruits} contains exactly (only) the {@code String}'s
  * "Apple", "Banana", and "Cherry" in order.
  */
@@ -52,7 +54,7 @@ public class ComboBoxMatchers {
      */
     @Factory
     public static Matcher<ComboBox> hasItems(int amount) {
-        String descriptionText = "has " + amount + " items";
+        String descriptionText = "has exactly " + amount + " items";
         return typeSafeMatcher(ComboBox.class, descriptionText,
             comboBox -> String.valueOf(comboBox.getItems().size()),
             comboBox -> comboBox.getItems().size() == amount);
@@ -66,9 +68,9 @@ public class ComboBoxMatchers {
      */
     @Factory
     public static <T> Matcher<ComboBox> hasSelectedItem(T selection) {
-        String descriptionText = "has selection " + selection;
+        String descriptionText = String.format("has selection \"%s\"", selection);
         return typeSafeMatcher(ComboBox.class, descriptionText,
-            comboBox -> comboBox.getSelectionModel().getSelectedItem().toString(),
+            comboBox -> "\"" + comboBox.getSelectionModel().getSelectedItem().toString() + "\"",
             comboBox -> hasSelectedItem(comboBox, selection));
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
@@ -61,7 +61,7 @@ public class ListViewMatchers {
      */
     @Factory
     public static Matcher<ListView> hasItems(int amount) {
-        String descriptionText = "has " + amount + " items";
+        String descriptionText = "has exactly " + amount + ' ' + (amount == 1 ? "item" : "items");
         return typeSafeMatcher(ListView.class, descriptionText,
             listView -> String.valueOf(listView.getItems().size()),
             listView -> listView.getItems().size() == amount);
@@ -73,9 +73,9 @@ public class ListViewMatchers {
      */
     @Factory
     public static Matcher<ListView> isEmpty() {
-        String descriptionText = "is empty (contains 0 (zero) items)";
+        String descriptionText = "is empty (contains no items)";
         return typeSafeMatcher(ListView.class, descriptionText,
-            listView -> "contains " + listView.getItems().size() + " items",
+            listView -> listView.getItems().size() == 0 ? "empty" : "contains " + listView.getItems().size() + " items",
             listView -> listView.getItems().isEmpty());
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
@@ -56,8 +56,7 @@ public class TableViewMatchers {
     @Factory
     public static Matcher<TableView> hasTableCell(Object value) {
         String descriptionText = "has table cell \"" + value + "\"";
-        return typeSafeMatcher(TableView.class, descriptionText,
-            tableView -> toText(tableView) + "\nwhich does not contain a cell with the given value",
+        return typeSafeMatcher(TableView.class, descriptionText, TableViewMatchers::toText,
             tableView -> hasTableCell(tableView, value));
     }
 
@@ -82,13 +81,14 @@ public class TableViewMatchers {
     public static Matcher<TableView> hasNumRows(int rows) {
         String descriptionText = "has " + rows + " rows";
         return typeSafeMatcher(TableView.class, descriptionText,
-            tableView -> String.valueOf(tableView.getItems().size()),
+            tableView -> "contained " + (tableView.getItems().isEmpty() ? "no" : String.valueOf(
+                    tableView.getItems().size()) + ' ' + (tableView.getItems().size() == 1 ? "row" : "rows")),
             tableView -> tableView.getItems().size() == rows);
     }
 
     /**
      * Creates a matcher that matches all {@link TableView}s that have a row at the given {@code index} that
-     * contains the given calues for each column of a {@code TableView}.
+     * contains the given values for each column of a {@code TableView}.
      * <p>
      * For example, given a {@code TableView} that has three columns:
      * <pre>{@code
@@ -117,12 +117,12 @@ public class TableViewMatchers {
         return typeSafeMatcher(TableView.class, descriptionText,
             tableView -> {
                 if (rowIndex < 0) {
-                    return "given negative row index";
+                    return "given negative row index: " + rowIndex;
                 } else if (rowIndex >= tableView.getItems().size()) {
                     return "given out-of-bounds row index: " + rowIndex +
                             " (table only has " + tableView.getItems().size() + " rows)";
                 } else {
-                    return toText(tableView, rowIndex);
+                    return toText(tableView, rowIndex) + " at index: " + rowIndex;
                 }
             },
             tableView -> containsRowAtIndex(tableView, rowIndex, cells));

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
@@ -59,7 +59,7 @@ public class TextFlowMatchers {
     /**
      * Allows one to verify both the content and color of the text that makes
      * up a TextFlow. The color is matched by using the closest named color,
-     * as described further on.
+     * as described below.
      * <p>
      * Colors are specified using the following markup:
      * <pre>{@code <COLOR>text</COLOR>}</pre>
@@ -93,8 +93,7 @@ public class TextFlowMatchers {
 
     /**
      * Allows one to verify both the content and color of the text that makes
-     * up a TextFlow. The color is matched in an exact way, as described fruther
-     * on.
+     * up a TextFlow. The color is matched in an exact way, as described below.
      * <p>
      * Colors are specified using the following markup:
      * <pre>{@code <COLOR>text</COLOR>}</pre>
@@ -102,7 +101,7 @@ public class TextFlowMatchers {
      * Where {@literal COLOR} is one of JavaFX's named colors.
      * <p>
      * Here is an example for verifying that a TextFlow contains the text
-     * "hello" and that the color of the text is *exactly* {@literal Colors.BLUE}
+     * "hello" and that the color of the text is <em>exactly</em> {@literal Colors.BLUE}
      * (that is, it has an RGB value of (0, 0, 255)).
      *
      * <pre><code>

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
@@ -21,7 +21,17 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
 import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 
 import org.hamcrest.Matcher;
 
@@ -31,7 +41,7 @@ public interface NodeQuery {
      * Stores all given {@code parentNodes} within this NodeQuery.
      *
      * @param parentNodes the parentNodes to store
-     * @return itself
+     * @return itself for more method chaining
      */
     NodeQuery from(Node... parentNodes);
 
@@ -39,7 +49,7 @@ public interface NodeQuery {
      * Stores all given {@code parentNodes} within this NodeQuery.
      *
      * @param parentNodes the parentNodes to store
-     * @return itself
+     * @return itself for more method chaining
      */
     NodeQuery from(Collection<Node> parentNodes);
 
@@ -48,7 +58,7 @@ public interface NodeQuery {
      * depending on the query used, and keeps only those {@code Node}s that meet the query.
      *
      * @param query the query to use
-     * @return itself
+     * @return itself for more method chaining
      */
     NodeQuery lookup(String query);
 
@@ -57,7 +67,7 @@ public interface NodeQuery {
      *
      * @param matcher the matcher used to determine which {@code Node}s to keep and which to remove
      * @param <T> matcher type
-     * @return itself
+     * @return itself for more method chaining
      */
     <T> NodeQuery lookup(Matcher<T> matcher);
 
@@ -66,7 +76,7 @@ public interface NodeQuery {
      *
      * @param predicate the predicate used to determine which {@code Node}s to keep and which to remove.
      * @param <T> type that extends {@code Node}
-     * @return itself
+     * @return itself for more method chaining
      */
     <T extends Node> NodeQuery lookup(Predicate<T> predicate);
 
@@ -74,7 +84,7 @@ public interface NodeQuery {
      * Sifts through stored nodes and uses {@code function} to determine which nodes to keep and which to remove.
      *
      * @param function that returns the {@code Node}s to keep
-     * @return itself
+     * @return itself for more method chaining
      */
     NodeQuery lookup(Function<Node, Set<Node>> function);
 
@@ -83,7 +93,7 @@ public interface NodeQuery {
      *
      * @param matcher that determines which {@code Node}s to remove
      * @param <T> matcher type
-     * @return itself
+     * @return itself for more method chaining
      */
     <T> NodeQuery match(Matcher<T> matcher);
 
@@ -92,7 +102,7 @@ public interface NodeQuery {
      *
      * @param predicate that indicates which {@code Node}s to remove
      * @param <T> predicate type
-     * @return itself
+     * @return itself for more method chaining
      */
     <T extends Node> NodeQuery match(Predicate<T> predicate);
 
@@ -100,29 +110,145 @@ public interface NodeQuery {
      * Keeps the nth {@code Node} in stored nodes and removes all others.
      *
      * @param index within the collection of {@code Node}s
-     * @return itself
+     * @return itself for more method chaining
      */
     NodeQuery nth(int index);
 
     /**
+     * Executes this {@code NodeQuery} and returns the first {@code Node} found that matches
+     * this query or {@literal null} if no nodes match this query.
      *
-     * @param <T> type that extends {@code Node}
-     * @return the first node found or null.
+     * @param <T> the type that extends {@code Node}
+     * @return the first node found or {@literal null}
      */
     <T extends Node> T query();
 
     /**
+     * Executes this {@code NodeQuery} and returns the first {@link Button} found that matches
+     * this query or {@literal null} if no buttons match this query.
      *
-     * @param <T> type that extends {@code Node}
-     * @return the first node found or null
+     * @return the first {@code Button} found or {@literal null}
+     */
+    Button queryButton();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link ComboBox} found that matches
+     * this query or {@literal null} if no combo-boxes match this query.
+     *
+     * @return the first {@code ComboBox} found or {@literal null}
+     */
+    <T> ComboBox<T> queryComboBox();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link Labeled} found that matches
+     * this query or {@literal null} if no labeleds match this query.
+     *
+     * @return the first {@code Labeled} found or {@literal null}
+     */
+    Labeled queryLabeled();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link ListView} found that matches
+     * this query or {@literal null} if no list views match this query.
+     *
+     * @return the first {@code ListView} found or {@literal null}
+     */
+    <T> ListView<T> queryListView();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link Parent} found that matches
+     * this query or {@literal null} if no parents match this query.
+     *
+     * @return the first {@code Parent} found or {@literal null}
+     */
+    Parent queryParent();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link TableView} found that matches
+     * this query or {@literal null} if no table views match this query.
+     *
+     * @return the first {@code TableView} found or {@literal null}
+     */
+    <T> TableView<T> queryTableView();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link Text} found that matches
+     * this query or {@literal null} if no texts match this query.
+     *
+     * @return the first {@code Text} found or {@literal null}
+     */
+    Text queryText();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link TextFlow} found that matches
+     * this query or {@literal null} if no text flows match this query.
+     *
+     * @return the first {@code TextFlow} found or {@literal null}
+     */
+    TextFlow queryTextFlow();
+
+    /**
+     * Executes this {@code NodeQuery} and returns the first {@link TextInputControl} found that matches
+     * this query or {@literal null} if no text input controls match this query.
+     *
+     * @return the first {@code TextInputControl} found or {@literal null}
+     */
+    TextInputControl queryTextInputControl();
+
+    /**
+     * Type-safe version of {@link #query()} that executes this {@code NodeQuery} and returns
+     * the first {@code Node} found that matches this query or {@literal null} if no nodes
+     * match this query.
+     *
+     * @param clazz the concrete sub-type of {@code Node} that should be returned by this query
+     * so as to avoid extraneous casting when used inside an "assertThat" assertion
+     * @param <T> the type that extends {@code Node}
+     * @return the first node found or {@literal null}
+     */
+    <T extends Node> T queryAs(Class<T> clazz);
+
+    /**
+     * Executes this {@code NodeQuery} and returns an {@code Optional} that either contains
+     * the first {@code Node} found that matches this query or nothing (e.g. {@link Optional#empty()}
+     * returns {@literal true}) if no nodes match this query.
+     *
+     * @param <T> the type that extends {@code Node}
+     * @return the first node found or {@literal null}
      */
     <T extends Node> Optional<T> tryQuery();
 
     /**
+     * Type-safe version of {@link #tryQuery()} that executes this {@code NodeQuery} and returns an
+     * {@code Optional} that either contains the first {@code Node} found that matches this query or
+     * nothing (e.g. {@link Optional#empty()} returns {@literal true}) if no nodes match this query.
      *
-     * @param <T> type that extends {@code Node}
-     * @return all nodes found
+     * @param clazz the concrete sub-type of {@code Node} that should be contained in the
+     * {@code Optional} returned by this query so as to avoid extraneous casting when used inside
+     * an "assertThat" assertion
+     * @param <T> the type that extends {@code Node}
+     * @return the first node found or {@literal null}
+     */
+    <T extends Node> Optional<T> tryQueryAs(Class<T> clazz);
+
+    /**
+     * Executes this {@code NodeQuery} and returns the {@code Set} of all the {@code Node}s that
+     * match this query. If no nodes match this query, the empty set is returned.
+     *
+     * @param <T> the type that extends {@code Node}
+     * @return the set of nodes that match this query
      */
     <T extends Node> Set<T> queryAll();
+
+    /**
+     * Type-safe version of {@link #queryAll()} that executes this {@code NodeQuery} and returns
+     * the {@code Set} of all the {@code Node}s that match this query. If no nodes match this query,
+     * the empty set is returned.
+     *
+     * @param clazz the concrete sub-type of {@code Node} the set of which should be returned by
+     * this query so as to avoid extraneous casting when used inside an "assertThat" assertion
+     * @param <T> the type that extends {@code Node}
+     * @return the set of nodes that match this query
+     */
+    <T extends Node> Set<T> queryAllAs(Class<T> clazz);
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
@@ -25,7 +25,17 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
 import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 
 import org.hamcrest.Matcher;
 
@@ -123,6 +133,60 @@ public class NodeQueryImpl implements NodeQuery {
     }
 
     @Override
+    public Button queryButton() {
+        return (Button) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> ComboBox<T> queryComboBox() {
+        return (ComboBox<T>) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public Labeled queryLabeled() {
+        return (Labeled) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> ListView<T> queryListView() {
+        return (ListView<T>) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public Parent queryParent() {
+        return (Parent) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> TableView<T> queryTableView() {
+        return (TableView<T>) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public Text queryText() {
+        return (Text) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public TextFlow queryTextFlow() {
+        return (TextFlow) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public TextInputControl queryTextInputControl() {
+        return (TextInputControl) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Node> T queryAs(Class<T> clazz) {
+        return (T) parentNodes.stream().findFirst().orElse(null);
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <T extends Node> Optional<T> tryQuery() {
         return (Optional<T>) parentNodes.stream().findFirst();
@@ -130,7 +194,19 @@ public class NodeQueryImpl implements NodeQuery {
 
     @Override
     @SuppressWarnings("unchecked")
+    public <T extends Node> Optional<T> tryQueryAs(Class<T> clazz) {
+        return (Optional<T>) parentNodes.stream().findFirst();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public <T extends Node> Set<T> queryAll() {
+        return (Set<T>) new LinkedHashSet<>(parentNodes);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Node> Set<T> queryAllAs(Class<T> clazz) {
         return (Set<T>) new LinkedHashSet<>(parentNodes);
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/DebugUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/DebugUtils.java
@@ -40,32 +40,33 @@ import org.hamcrest.Matcher;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxService;
 import org.testfx.api.FxToolkit;
+import org.testfx.api.annotation.Unstable;
 import org.testfx.service.support.CaptureSupport;
 import org.testfx.service.support.FiredEvents;
 
 /**
- * Utility class for displaying additional info, running code, or capturing an image of the test when
+ * Utility class for displaying additional info, running code, or capturing an image of a test whenever
  * a test fails using {@link org.testfx.api.FxAssert#verifyThat(Node, Matcher)} or its related methods.
- *
  * <p>
- *     Quickly chain things together using {@link #compose(Function[])} or use standard handlers like
- *     {@link #informedErrorMessage(String, boolean, boolean, FxRobot, boolean, boolean)}.
- *     Any {@code indent} parameters in methods are there to specify what to insert to offset values.
- *     Default indent value is three spaces (e.g. {@code "   "}).
- * </p>
+ * It is possible to create completely customized error messages by chaining functions together using
+ * {@link #compose(Function[])} or one can use the standard provided handlers such as
+ * {@link #informedErrorMessage(FxRobot)}, {@link #informedErrorMessage(FxRobot, String)}, etc.
+ * All {@code indent} parameters in methods are used to specify the spacing to insert in order to
+ * offset values. The default indent value is three spaces (e.g. {@code "   "}).
  * <p>
- *     When a test fails, an image of the test can be captured and saved to a PNG file. Supports a number
- *     of image sizes: a screenshot, a window, an area of the screen (i.e. bounds), or an individual node.
- *     Use the convenience methods prefixed by "save" (e.g. {@link #saveScreenshot(String)}) to quickly capture
- *     and save images. The image path will be outputted using {@link #insertContent(String, Object)} and
- *     will appear in the error's message.
- *     For your own custom-built handler, use {@link #saveTestImage(Function, Supplier, String)}, one of the
- *     "capture"-prefixed methods, and your own {@code Supplier<Path>}.
- * </p>
+ * When a test fails, an image of the screen at the time of failure can be captured and saved to a PNG file.
+ * {@code DebugUtils} provides support for a number of image sizes: the full screen, a window, an area of the
+ * screen (i.e. bounds), or an individual node. Use the convenience methods prefixed by "save" (e.g.
+ * {@link #saveScreenshot(String)}) to capture and save images. The image path will be printed using
+ * {@link #insertContent(String, Object)} and will appear in the error message. For your own custom handler, use
+ * {@link #saveTestImage(Function, Supplier, String)}, one of the "capture"-prefixed methods, and a
+ * {@code Supplier<Path>} that determines where to save the image to.
  * <p>
- *     This class follows the given philosophy in how to add additional information to the {@link AssertionError}'s
- *     message:
- * <pre><code>
+ * This class uses the concept of combining functions together in order to add additional information
+ * to the error message of an {@link AssertionError} thrown by a failing test.
+ * <p>
+ * Example:
+ * <pre>{@code
  * // Template:
  * compose(
  *      // insert a header for the section of error information
@@ -80,8 +81,7 @@ import org.testfx.service.support.FiredEvents;
  *      insertHeader(headerText),
  *      // insert the specific content that falls under this header
  *      insertContent(contentHeading5, contentStream2),
- *      insertContent(contentHeading6, contentStream3),
- * );
+ *      insertContent(contentHeading6, contentStream3));
  *
  * // Example:
  * compose(
@@ -89,30 +89,30 @@ import org.testfx.service.support.FiredEvents;
  *      showKeysPressedAtTestFailure(this),
  *      showMouseButtonsPressedAtTestFailure(this),
  *      showFiredEvents(),
- *      saveScreenshot()
- * );
+ *      saveScreenshot());
  *
- * // The above example can be done using one method:
+ * // is equivalent to:
+ *
  * informedErrorMessage(this);
- * </code></pre>
- * </p>
+ *
+ * // as it uses all of the default arguments.
+ * }</pre>
  */
+@Unstable(reason = "class was recently added")
 public final class DebugUtils {
 
-    // 3 spaces easier to read the list of fired events
-    // on Travis CI's console when error message is thrown
+    /**
+     * The default indentation to use for spacing between items of the error messages, defaults to
+     * three spaces.
+     */
     private static final String DEFAULT_INDENT = "   ";
     private static final AtomicInteger DEFAULT_PHOTO_NUMBER = new AtomicInteger(0);
 
     private DebugUtils() {}
 
-    //---------------------------------------------------------------------------------------------
-    // COMPOSITION AND CREATION SUPPORT.
-    //---------------------------------------------------------------------------------------------
-
     /**
-     * Composes multiple functions together into one. The ones to run first should be the first in the array,
-     * and the ones to run last should be at the end of the array.
+     * Composes multiple functions together into one. The functions are called in the order that they appear
+     * in the array. That is, {@code functions[0]} is run first, {@code functions[1]} is run second, etc.
      */
     @SafeVarargs
     public static Function<StringBuilder, StringBuilder> compose(Function<StringBuilder, StringBuilder>... functions) {
@@ -131,7 +131,7 @@ public final class DebugUtils {
     }
 
     /**
-     * Ignores the StringBuilder and runs the given code block
+     * Ignores the given {@code StringBuilder} and just runs the given code block.
      */
     public static Function<StringBuilder, StringBuilder> runCode(Runnable runnable) {
         return sb -> {
@@ -141,88 +141,108 @@ public final class DebugUtils {
     }
 
     /**
-     * Inserts a header on a newline; useful for specifying a section in the message
+     * Inserts a header on a newline followed by the default indent; useful for specifying a section
+     * in the error message.
      */
     public static Function<StringBuilder, StringBuilder> insertHeader(String headerText) {
         return insertHeader(headerText, DEFAULT_INDENT);
     }
 
+    /**
+     * Inserts a header on a newline followed by the given {@code indent}; useful for specifying a
+     * section in the error message.
+     */
     public static Function<StringBuilder, StringBuilder> insertHeader(String headerText, String indent) {
         return sb -> sb.append("\n\n").append(indent).append(headerText);
     }
 
     /**
-     * Inserts the heading on a newline followed by two indents followed by the contentHeading.
-     * Then, inserts a newline followed by three indents followed by the content itself.
+     * Inserts the heading on a newline followed by two default indents followed by the given {@code contentHeading}.
+     * Then, inserts a newline followed by three default indents followed by the content itself.
      */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Object content) {
         return insertContent(contentHeading, content, DEFAULT_INDENT);
     }
 
+    /**
+     * Inserts the heading on a newline followed by two of the given {@code indents} followed by the given
+     * {@code contentHeading}. Then, inserts a newline followed by three of the given {@code indents} followed
+     * by the content itself.
+     */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Object content,
                                                                        String indent) {
-        return sb -> sb
-                .append("\n").append(indent).append(indent).append(contentHeading)
-                .append("\n").append(indent).append(indent).append(indent).append(content);
-
+        return sb -> sb.append("\n").append(indent).append(indent)
+                .append(contentHeading).append("\n")
+                .append(indent).append(indent).append(indent)
+                .append(content);
     }
 
     /**
-     * Inserts the heading on a newline followed by two indents followed by the contentHeading.
-     * Then, for each item in the list, inserts a newline followed by three indents followed by the list item itself.
+     * Inserts the heading on a newline followed by two default indents followed by the given {@code contentHeading}.
+     * Then, for each item in the given iterable, inserts a newline followed by three default indents followed by the
+     * list item itself.
      */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Iterable<?> contentIter) {
         return insertContent(contentHeading, contentIter, DEFAULT_INDENT);
     }
 
+    /**
+     * Inserts the heading on a newline followed by two of the given {@code indents} followed by the given
+     * {@code contentHeading}. Then, for each item in the given iterable, inserts a newline followed by three of
+     * the given indents followed by the list item itself.
+     */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Iterable<?> contentIter,
                                                                        String indent) {
         return sb -> {
-            sb
-                    .append("\n").append(indent).append(indent).append(contentHeading);
-            contentIter.forEach(content -> sb
-                    .append("\n").append(indent).append(indent).append(indent).append(content)
-            );
+            sb.append("\n").append(indent).append(indent).append(contentHeading);
+            contentIter.forEach(content ->
+                sb.append("\n").append(indent).append(indent).append(indent).append(content));
             return sb;
         };
     }
 
     /**
-     * Inserts the heading on a newline followed by two indents followed by the contentHeading.
-     * Then, for each item in the array, inserts a newline followed by three indents followed by the array item itself.
+     * Inserts the heading on a newline followed by two default indents followed by the given {@code contentHeading}.
+     * Then, for each item in the given array, inserts a newline followed by three default indents followed by the
+     * array item itself.
      */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Object[] contentArray) {
         return insertContent(contentHeading, contentArray, DEFAULT_INDENT);
     }
 
+    /**
+     * Inserts the heading on a newline followed by two of the given indents followed by the given
+     * {@code contentHeading}. Then, for each item in the given array, inserts a newline followed by three of the
+     * given indents followed by the array item itself.
+     */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Object[] contentArray,
                                                                        String indent) {
         return insertContent(contentHeading, Stream.of(contentArray), indent);
     }
 
     /**
-     * Inserts the heading on a newline followed by two indents followed by the contentHeading.
-     * Then, for each item in the stream, inserts a newline followed by three indents followed by the next item itself.
+     * Inserts the heading on a newline followed by two default indents followed by the given {@code contentHeading}.
+     * Then, for each item in the given stream, inserts a newline followed by three default indents followed by the
+     * item itself.
      */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Stream<?> contentStream) {
         return insertContent(contentHeading, contentStream, DEFAULT_INDENT);
     }
 
+    /**
+     * Inserts the heading on a newline followed by two of the given indents followed by the given
+     * {@code contentHeading}. Then, for each item in the given stream, inserts a newline followed by three of
+     * the given indents followed by the item itself.
+     */
     public static Function<StringBuilder, StringBuilder> insertContent(String contentHeading, Stream<?> contentStream,
                                                                        String indent) {
         return sb -> {
-            sb
-                .append("\n").append(indent).append(indent).append(contentHeading);
-            contentStream.forEach(content -> sb
-                .append("\n").append(indent).append(indent).append(indent).append(content)
-            );
+            sb.append("\n").append(indent).append(indent).append(contentHeading);
+            contentStream.forEach(content ->
+                sb.append("\n").append(indent).append(indent).append(indent).append(content));
             return sb;
         };
     }
-
-    //---------------------------------------------------------------------------------------------
-    // ERROR MESSAGE SUPPORT.
-    //---------------------------------------------------------------------------------------------
 
     /**
      * Via {@link #insertContent(String, Object)}: shows the keys that were pressed when the test failed.
@@ -258,7 +278,7 @@ public final class DebugUtils {
 
     /**
      * Via {@link #insertContent(String, Object)}: shows all events that were fired since the start of the test.
-     * Note: only events stored in {@link org.testfx.api.FxToolkitContext#getFiredEvents()} will be shown
+     * Note: only events stored in {@link org.testfx.api.FxToolkitContext#getFiredEvents()} will be shown.
      */
     public static Function<StringBuilder, StringBuilder> showFiredEvents() {
         return showFiredEvents(DEFAULT_INDENT);
@@ -290,10 +310,6 @@ public final class DebugUtils {
         return insertContent("Fired events since test began:", events, indent);
     }
 
-    //---------------------------------------------------------------------------------------------
-    // CAPTURE SUPPORT.
-    //---------------------------------------------------------------------------------------------
-
     public static Function<CaptureSupport, Image> captureScreenshot() {
         return captureScreenshot(Screen.getPrimary());
     }
@@ -307,7 +323,7 @@ public final class DebugUtils {
     }
 
     /**
-     * Captures the registered stage
+     * Captures the registered stage.
      */
     public static Function<CaptureSupport, Image> captureWindow() {
         return captureWindow(FxToolkit.toolkitContext().getRegisteredStage());
@@ -433,7 +449,7 @@ public final class DebugUtils {
     }
 
     /**
-     * Saves the captured registered stage to the supplied path
+     * Saves the captured registered stage to the supplied path.
      */
     public static Function<StringBuilder, StringBuilder> saveWindow(Supplier<Path> capturedImagePath, String indent) {
         return saveWindow(FxToolkit.toolkitContext().getRegisteredStage(), capturedImagePath, indent);
@@ -448,7 +464,7 @@ public final class DebugUtils {
     }
 
     /**
-     * Saves the captured window to the supplied path
+     * Saves the captured window to the supplied path.
      */
     public static Function<StringBuilder, StringBuilder> saveWindow(Window window, Supplier<Path> capturedImagePath,
                                                                     String indent) {
@@ -544,10 +560,6 @@ public final class DebugUtils {
         };
     }
 
-    //---------------------------------------------------------------------------------------------
-    // DEFAULT ERROR HANDLER METHODS.
-    //---------------------------------------------------------------------------------------------
-
     /**
      * Convenience method for {@link #informedErrorMessage(String, boolean, boolean, FxRobot, boolean, boolean)}
      * with all booleans set to {@code true} and the header text set to {@code "Context:"}.
@@ -594,10 +606,6 @@ public final class DebugUtils {
         }
         return function;
     }
-
-    //---------------------------------------------------------------------------------------------
-    // PRIVATE METHODS.
-    //---------------------------------------------------------------------------------------------
 
     private static Rectangle2D mapToRect2D(Bounds bounds) {
         return new Rectangle2D(bounds.getMinX(), bounds.getMinY(), bounds.getWidth(), bounds.getHeight());

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ButtonAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ButtonAssertTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class ButtonAssertTest extends FxRobot {
+
+    Button button;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupSceneRoot(() -> {
+            button = new Button();
+            return new StackPane(button);
+        });
+        FxToolkit.showStage();
+    }
+
+    @Test
+    public void isCancelButton() {
+        // given:
+        button.setCancelButton(true);
+
+        // expect:
+        assertThat(lookup(".button").queryAs(Button.class)).isCancelButton();
+        assertThat((Button) lookup(".button").query()).isCancelButton();
+        assertThat(button).isCancelButton();
+    }
+
+    @Test
+    public void isCancelButton_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(button).isCancelButton())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Button is cancel button");
+    }
+
+    @Test
+    public void isNotCancelButton() {
+        // expect:
+        assertThat(button).isNotCancelButton();
+    }
+
+    @Test
+    public void isNotCancelButton_fails() {
+        // given:
+        button.setCancelButton(true);
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(button).isNotCancelButton())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Button is cancel button to be false");
+    }
+
+    @Test
+    public void isDefaultButton() {
+        // given:
+        button.setDefaultButton(true);
+
+        // expect:
+        assertThat(button).isDefaultButton();
+    }
+
+    @Test
+    public void isDefaultButton_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(button).isDefaultButton())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Button is default button\n");
+    }
+
+    @Test
+    public void isNotDefaultButton() {
+        // expect:
+        assertThat(button).isNotDefaultButton();
+    }
+
+    @Test
+    public void isNotDefaultButton_fails() {
+        // given:
+        button.setDefaultButton(true);
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(button).isNotDefaultButton())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Button is default button to be false\n");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ColorAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ColorAssertTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.paint.Color;
+
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.service.support.impl.PixelMatcherRgb;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class ColorAssertTest extends FxRobot {
+
+    @Test
+    public void isColor() {
+        // expect:
+        assertThat(Color.color(1, 0, 0)).isColor(Color.RED);
+    }
+
+    @Test
+    public void isColor_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(1, 0, 0)).isColor(Color.BLACK))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Color has color \"BLACK\" (#000000)\n     " +
+                        "but: was \"RED\" (#ff0000)");
+    }
+
+    @Test
+    public void isNotColor() {
+        // expect:
+        assertThat(Color.color(1, 0, 0)).isNotColor(Color.BROWN);
+    }
+
+    @Test
+    public void isNotColor_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(1, 0, 0)).isNotColor(Color.RED))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Color has color \"RED\" (#ff0000) to be false\n     " +
+                        "but: was \"RED\" (#ff0000)");
+    }
+
+    @Test
+    public void isColor_colorMatcher() {
+        // expect:
+        assertThat(Color.color(0.9, 0, 0)).isColor(Color.RED, new PixelMatcherRgb());
+    }
+
+    @Test
+    public void isColor_colorMatcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(0.5, 0, 0)).isColor(Color.RED, new PixelMatcherRgb(0.01, 0)))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Color has color \"RED\" (#ff0000)\n     ");
+    }
+
+    @Test
+    public void isNotColor_colorMatcher() {
+        // expect:
+        assertThat(Color.color(0.9, 0, 0)).isNotColor(Color.GREEN, new PixelMatcherRgb());
+    }
+
+    @Test
+    public void isNotColor_colorMatcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(0.9, 0, 0)).isNotColor(Color.RED, new PixelMatcherRgb(0.6, 0)))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Color has color \"RED\" (#ff0000) to be false\n     ");
+    }
+
+    @Test
+    public void isNamedColor() {
+        // expect:
+        assertThat(Color.AQUAMARINE).isColor("AQUAMARINE");
+    }
+
+    @Test
+    public void isNamedColor_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.ANTIQUEWHITE).isColor("AQUAMARINE"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Color is \"AQUAMARINE\"\n     " +
+                        "but: was \"ANTIQUEWHITE\" (#faebd7)");
+    }
+
+    @Test
+    public void isNotNamedColor() {
+        // expect:
+        assertThat(Color.AQUAMARINE).isNotColor("BLUE");
+    }
+
+    @Test
+    public void isNotNamedColor_fails() {
+        // expect:
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.ANTIQUEWHITE).isNotColor("ANTIQUEWHITE"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Color is \"ANTIQUEWHITE\" to be false\n     " +
+                        "but: was \"ANTIQUEWHITE\" (#faebd7)");
+    }
+
+    @Test
+    public void isNamedColor_non_named_color_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.web("#f3b2aa")).isColor("BAGEL"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("given color name: \"BAGEL\" is not a named color\n" +
+                        "See: https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor");
+    }
+
+    @Test
+    public void isNotNamedColor_non_named_color_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.web("#f3b2aa")).isNotColor("BAGEL"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("given color name: \"BAGEL\" is not a named color\n" +
+                        "See: https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor");
+    }
+
+    @Test
+    public void hasClosestNamedColor_string() {
+        // expect:
+        assertThat(Color.color(0.8, 0.2, 0.1)).hasClosestNamedColor("FIREBRICK");
+    }
+
+    @Test
+    public void hasClosestNamedColor_string_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(0.6, 0.1, 0.1)).hasClosestNamedColor("GAINSBORO"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Color has closest named color \"GAINSBORO\" (#dcdcdc)\n     " +
+                        "but: was \"#991a1a\" which has closest named color: \"BROWN\"");
+    }
+
+    @Test
+    public void hasClosestNamedColor_non_named_color_string_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(0.6, 0.1, 0.1)).hasClosestNamedColor("BETELGEUSE"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("given color name: \"BETELGEUSE\" is not a named color\n" +
+                        "See: https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor");
+    }
+
+    @Test
+    public void hasClosestNamedColor_non_named_color_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.web("#dcdcdc")).hasClosestNamedColor(Color.web("#acb2f1")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("given color: \"#acb2f1\" is not a named color\n" +
+                        "See: https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor");
+    }
+
+    @Test
+    public void doesNotHaveClosestNamedColor() {
+        // expect:
+        assertThat(Color.color(0.8, 0.2, 0.1)).doesNotHaveClosestNamedColor("YELLOW");
+    }
+
+    @Test
+    public void doesNotHaveClosestNamedColor_string_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(0.6, 0.1, 0.1)).doesNotHaveClosestNamedColor("BROWN"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Color has closest named color \"BROWN\" (#a52a2a) to be false\n     " +
+                        "but: was \"#991a1a\" which has closest named color: \"BROWN\"");
+    }
+
+    @Test
+    public void doesNotHaveClosestNamedColor_color_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.color(0.6, 0.1, 0.1)).doesNotHaveClosestNamedColor(Color.BROWN))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Color has closest named color \"BROWN\" (#a52a2a) to be false\n     " +
+                        "but: was \"#991a1a\" which has closest named color: \"BROWN\"");
+    }
+
+    @Test
+    public void doesNotHaveClosestNamedColor_non_named_color_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(Color.web("#dcdcdc")).doesNotHaveClosestNamedColor(Color.web("#acb2f1")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("given color: \"#acb2f1\" is not a named color\n" +
+                        "See: https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor");
+    }
+
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ComboBoxAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ComboBoxAssertTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.ComboBox;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.StackPane;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static javafx.collections.FXCollections.observableArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class ComboBoxAssertTest extends FxRobot {
+
+    ComboBox<String> comboBox;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupSceneRoot(() -> {
+            comboBox = new ComboBox<>();
+            comboBox.setItems(observableArrayList("alice", "bob", "carol", "dave"));
+            comboBox.getSelectionModel().selectFirst();
+            return new StackPane(comboBox);
+        });
+        FxToolkit.showStage();
+    }
+
+    @Test
+    public void hasExactlyNumItems() {
+        // expect:
+        assertThat(comboBox).hasExactlyNumItems(4);
+    }
+
+    @Test
+    public void hasExactlyNumItems_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(comboBox).hasExactlyNumItems(3))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox has exactly 3 items\n     " +
+                        "but: was 4");
+    }
+
+    @Test
+    public void doesNotHaveExactlyNumItems() {
+        // expect:
+        assertThat(comboBox).doesNotHaveExactlyNumItems(5);
+    }
+
+    @Test
+    public void doesNotHaveExactlyNumItems_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(comboBox).doesNotHaveExactlyNumItems(4))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox has exactly 4 items to be false\n     " +
+                        "but: was 4");
+    }
+
+    @Test
+    public void hasSelectedItem() {
+        // given:
+        assertThat(comboBox).hasSelectedItem("alice");
+
+        // when:
+        clickOn(".combo-box-base");
+        type(KeyCode.DOWN);
+        type(KeyCode.ENTER);
+
+        // then:
+        assertThat(comboBox).hasSelectedItem("bob");
+    }
+
+    @Test
+    public void hasSelectedItem_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(comboBox).hasSelectedItem("bob"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox has selection \"bob\"\n     " +
+                        "but: was \"alice\"");
+    }
+
+    @Test
+    public void doesNotHaveSelectedItem() {
+        // expect:
+        assertThat(comboBox).doesNotHaveSelectedItem("dave");
+    }
+
+    @Test
+    public void doesNotHaveSelectedItem_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(comboBox).doesNotHaveSelectedItem("alice"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox has selection \"alice\" to be false\n     " +
+                        "but: was \"alice\"");
+    }
+
+    @Test
+    public void containsItems() {
+        // expect:
+        // in order
+        assertThat(comboBox).containsItems("alice", "bob", "carol", "dave");
+        // not in order
+        assertThat(comboBox).containsItems("bob", "alice", "dave", "carol");
+        // partial
+        assertThat(comboBox).containsItems("bob", "alice", "dave");
+    }
+
+    @Test
+    public void containsItems_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(comboBox).containsItems("alice", "bob", "eric"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox contains items [alice, bob, eric]\n" +
+                        "     but: was [alice, bob, carol, dave]");
+    }
+
+    @Test
+    public void containsExactlyItems() {
+        // expect:
+        // in order
+        assertThat(comboBox).containsExactlyItems("alice", "bob", "carol", "dave");
+        // not in order
+        assertThat(comboBox).containsExactlyItems("bob", "alice", "dave", "carol");
+    }
+
+    @Test
+    public void containsExactlyItems_fails() {
+        // expected (missing "dave", so should fail):
+        assertThatThrownBy(() -> assertThat(comboBox).containsExactlyItems("alice", "bob", "carol"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox contains exactly items [alice, bob, carol]\n" +
+                        "     but: was [alice, bob, carol, dave]");
+    }
+
+    @Test
+    public void containsItemsInOrder() {
+        // expect:
+        // in order
+        assertThat(comboBox).containsItemsInOrder("alice", "bob", "carol", "dave");
+        // partial (but in-order)
+        assertThat(comboBox).containsItemsInOrder("bob", "carol", "dave");
+    }
+
+    @Test
+    public void containsItemsInOrder_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(comboBox).containsItemsInOrder("alice", "carol", "bob"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox contains items in order [alice, carol, bob]\n" +
+                        "     but: was [alice, bob, carol, dave]");
+    }
+
+    @Test
+    public void containsExactlyItemsInOrder() {
+        // expect:
+        // in order
+        assertThat(comboBox).containsExactlyItemsInOrder("alice", "bob", "carol", "dave");
+    }
+
+    @Test
+    public void containsExactlyItemsInOrder_fails() {
+        // expect (not in correct order, should fail):
+        assertThatThrownBy(() -> assertThat(comboBox).containsExactlyItemsInOrder("bob", "alice", "dave", "carol"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ComboBox contains exactly items in order [bob, alice, dave, carol]\n" +
+                        "     but: was [alice, bob, carol, dave]");
+    }
+
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/Dimension2DAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/Dimension2DAssertTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.geometry.Dimension2D;
+
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class Dimension2DAssertTest extends FxRobot {
+
+    @Test
+    public void hasDimension() {
+        // expect:
+        assertThat(new Dimension2D(10, 20)).hasDimension(10, 20);
+    }
+
+    @Test
+    public void hasDimension_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(new Dimension2D(10, 20)).hasDimension(0, 0))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Dimension2D has dimension (0.0, 0.0)\n");
+    }
+
+    @Test
+    public void doesNotHaveDimension() {
+        // expect:
+        assertThat(new Dimension2D(10, 20)).doesNotHaveDimension(5, 10);
+    }
+
+    @Test
+    public void doesNotHaveDimension_same_width() {
+        // expect:
+        assertThat(new Dimension2D(10, 20)).doesNotHaveDimension(10, 21);
+    }
+
+    @Test
+    public void doesNotHaveDimension_same_height() {
+        // expect:
+        assertThat(new Dimension2D(10, 20)).doesNotHaveDimension(9, 20);
+    }
+
+    @Test
+    public void doesNotHaveDimension_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(new Dimension2D(10, 20)).doesNotHaveDimension(10, 20))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Dimension2D has dimension (10.0, 20.0) to be false\n");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/LabeledAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/LabeledAssertTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.Button;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class LabeledAssertTest extends FxRobot {
+
+    Button foobarButton;
+    Button quuxButton;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            foobarButton = new Button("foobar");
+            quuxButton = new Button("quux");
+        });
+    }
+
+    @Test
+    public void hasText() {
+        // expect:
+        assertThat(foobarButton).hasText("foobar");
+    }
+
+    @Test
+    public void hasText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(quuxButton).hasText("foobar"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Labeled has text \"foobar\"\n     " +
+                        "but: was \"quux\"");
+    }
+
+    @Test
+    public void doesNotHaveText() {
+        // expect:
+        assertThat(foobarButton).doesNotHaveText("lilly pad");
+    }
+
+    @Test
+    public void doesNotHaveText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(foobarButton).doesNotHaveText("foobar"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Labeled has text \"foobar\" to be false\n     " +
+                        "but: was \"foobar\"");
+    }
+
+    @Test
+    public void hasText_matcher() {
+        // expect:
+        assertThat(foobarButton).hasText(endsWith("bar"));
+    }
+
+    @Test
+    public void hasText_matcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(quuxButton).hasText(endsWith("bar")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Labeled has a string ending with \"bar\"\n     " +
+                        "but: was \"quux\"");
+    }
+
+    @Test
+    public void doesNotHaveText_matcher() {
+        // expect:
+        assertThat(foobarButton).doesNotHaveText(endsWith("baz"));
+    }
+
+    @Test
+    public void doesNotHaveText_matcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(foobarButton).doesNotHaveText(startsWith("foo")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Labeled has a string starting with \"foo\" to be false\n     " +
+                        "but: was \"foobar\"");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ListViewAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ListViewAssertTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.application.Platform;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.StackPane;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static javafx.collections.FXCollections.observableArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class ListViewAssertTest extends FxRobot {
+
+    ListView<String> listView;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupSceneRoot(() -> {
+            listView = new ListView<>();
+            listView.setItems(observableArrayList("alice", "bob", "carol", "dave"));
+            listView.setPlaceholder(new Label("Empty!"));
+            return new StackPane(listView);
+        });
+        FxToolkit.showStage();
+    }
+
+    @Test
+    public void hasListCell() {
+        // expect:
+        assertThat(listView).hasListCell("alice");
+    }
+
+    @Test
+    public void hasListCell_with_null_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).hasListCell(null))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has list cell \"null\"\n     " +
+                        "but: was [alice, bob, carol, dave]");
+    }
+
+    @Test
+    public void hasListCell_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).hasListCell("foobar"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has list cell \"foobar\"\n     " +
+                        "but: was [alice, bob, carol, dave]");
+    }
+
+    @Test
+    public void doesNotHaveListCell() {
+        // expect:
+        assertThat(listView).doesNotHaveListCell("ebert");
+    }
+
+    @Test
+    public void doesNotHaveListCell_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).doesNotHaveListCell("alice"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has list cell \"alice\" to be false\n     " +
+                        "but: was [alice, bob, carol, dave]");
+    }
+
+    @Test
+    public void hasExactlyNumItems() {
+        // expect:
+        assertThat(listView).hasExactlyNumItems(4);
+    }
+
+    @Test
+    public void hasExactlyNumItems_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).hasExactlyNumItems(1))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has exactly 1 item\n     " +
+                        "but: was 4");
+    }
+
+    @Test
+    public void doesNotHaveExactlyNumItems() {
+        // expect:
+        assertThat(listView).doesNotHaveExactlyNumItems(3);
+    }
+
+    @Test
+    public void doesNotHaveExactlyNumItems_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).doesNotHaveExactlyNumItems(4))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has exactly 4 items to be false\n     " +
+                        "but: was 4");
+    }
+
+    @Test
+    public void isEmpty() {
+        // when:
+        Platform.runLater(() -> listView.getItems().clear());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(listView).isEmpty();
+    }
+
+    @Test
+    public void isEmpty_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).isEmpty())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView is empty (contains no items)\n     " +
+                        "but: was contains 4 items");
+    }
+
+    @Test
+    public void isNotEmpty() {
+        // when:
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(listView).isNotEmpty();
+    }
+
+    @Test
+    public void isNotEmpty_fails() {
+        // when:
+        Platform.runLater(() -> listView.getItems().clear());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).isNotEmpty())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView is empty (contains no items) to be false\n     " +
+                        "but: was empty");
+    }
+
+    @Test
+    public void hasPlaceholder() {
+        // expect:
+        assertThat(listView).hasPlaceholder(new Label("Empty!"));
+    }
+
+    @Test
+    public void hasPlaceholder_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).hasPlaceholder(new Label("foobar")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has labeled placeholder containing text: \"foobar\"\n     " +
+                        "but: was labeled placeholder containing text: \"Empty!\"");
+    }
+
+    @Test
+    public void doesNotHavePlaceholder() {
+        // expect:
+        assertThat(listView).doesNotHavePlaceholder(new Label("cat"));
+    }
+
+    @Test
+    public void doesNotHavePlaceholder_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).doesNotHavePlaceholder(new Label("Empty!")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has labeled placeholder containing text: \"Empty!\" to be false\n" +
+                        "     but: was labeled placeholder containing text: \"Empty!\"");
+    }
+
+    @Test
+    public void hasVisiblePlaceholder() {
+        // expect:
+        assertThat(listView).hasVisiblePlaceholder(new Label("Empty!"));
+    }
+
+    @Test
+    public void hasVisiblePlaceholder_fails_whenPlaceHolderHasWrongText() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).hasVisiblePlaceholder(new Label("foobar")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has visible labeled placeholder containing text: \"foobar\"\n     " +
+                        "but: was visible labeled placeholder containing text: \"Empty!\"");
+    }
+
+    @Test
+    public void hasVisiblePlaceholder_fails_whenPlaceHolderIsInvisible() {
+        // when:
+        listView.getPlaceholder().setVisible(false);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).hasVisiblePlaceholder(new Label("Empty!")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has visible labeled placeholder containing text: \"Empty!\"\n     " +
+                        "but: was invisible labeled placeholder containing text: \"Empty!\"");
+    }
+
+    @Test
+    public void doesNotHaveVisiblePlaceholder_when_wrong_text() {
+        // when:
+        listView.getPlaceholder().setVisible(false);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(listView).doesNotHaveVisiblePlaceholder(new Label("foobar"));
+    }
+
+    @Test
+    public void doesNotHaveVisiblePlaceholder_when_invisible() {
+        // when:
+        listView.getPlaceholder().setVisible(false);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(listView).doesNotHaveVisiblePlaceholder(new Label("Empty!"));
+    }
+
+    @Test
+    public void doesNotHaveVisiblePlaceholder_fails_same_text() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(listView).doesNotHaveVisiblePlaceholder(new Label("Empty!")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: ListView has visible labeled placeholder containing text: \"Empty!\" to be" +
+                        " false\n     but: was visible labeled placeholder containing text: \"Empty!\"");
+    }
+
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/NodeAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/NodeAssertTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.matcher.control.LabeledMatchers;
+import org.testfx.matcher.control.TextInputControlMatchers;
+import org.testfx.service.query.NodeQuery;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class NodeAssertTest extends FxRobot {
+
+    TextField textField;
+    TextField textField2;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Test
+    public void hasText_with_button() throws Exception {
+        // given:
+        Button button = FxToolkit.setupFixture(() -> new Button("foo"));
+
+        // expect:
+        assertThat(button).hasText("foo");
+    }
+
+    @Test
+    public void doesNotHaveText_with_button() throws Exception {
+        // given:
+        Button button = FxToolkit.setupFixture(() -> new Button("foo"));
+
+        // expect:
+        assertThat(button).doesNotHaveText("bar");
+    }
+
+    @Test
+    public void doesNotHaveText_with_button_fails() throws Exception {
+        // given:
+        Button button = FxToolkit.setupFixture(() -> new Button("foo"));
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(button).doesNotHaveText("foo"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Labeled has text \"foo\" to be false\n     " +
+                        "but: was \"foo\"");
+    }
+
+    @Test
+    public void isFocused() throws Exception {
+        // given:
+        FxToolkit.setupSceneRoot(() -> {
+            textField = new TextField("foo");
+            return new StackPane(textField);
+        });
+
+        // when:
+        Platform.runLater(() -> textField.requestFocus());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // then:
+        assertThat(textField).isFocused();
+    }
+
+    @Test
+    public void isFocused_fails() throws Exception {
+        // given:
+        FxToolkit.setupSceneRoot(() -> {
+            textField = new TextField("foo");
+            textField2 = new TextField("bar");
+            return new StackPane(textField, textField2);
+        });
+
+        // when:
+        Platform.runLater(() -> textField2.requestFocus());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // then:
+        assertThatThrownBy(() -> assertThat(textField).isFocused())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Node has focus\n");
+    }
+
+    @Test
+    public void isNotFocused() throws Exception {
+        // given:
+        FxToolkit.setupSceneRoot(() -> {
+            textField = new TextField("foo");
+            textField2 = new TextField("bar");
+            return new StackPane(textField, textField2);
+        });
+
+        Platform.runLater(() -> textField2.requestFocus());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // then:
+        assertThat(textField).isNotFocused();
+    }
+
+    @Test
+    public void isNotFocused_fails() throws Exception {
+        // given:
+        FxToolkit.setupSceneRoot(() -> {
+            textField = new TextField("foo");
+            return new StackPane(textField);
+        });
+
+        // when:
+        Platform.runLater(() -> textField.requestFocus());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // then:
+        assertThatThrownBy(() -> assertThat(textField).isNotFocused())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Node does not have focus\n");
+    }
+
+    @Test
+    public void hasText_filters_nodes() throws Exception {
+        // given:
+        List<Node> nodes =  FxToolkit.setupFixture(() -> {
+            List<Node> temp = new ArrayList<>(3);
+            temp.add(new Region());
+            temp.add(new Button("foo"));
+            temp.add(new TextField("bar"));
+            return temp;
+        });
+
+        // expect:
+        NodeQuery query1 = from(nodes).match(LabeledMatchers.hasText("foo"));
+        assertThat(query1.queryAll()).containsExactly(nodes.get(1));
+
+        // and:
+        NodeQuery query2 = from(nodes).match(TextInputControlMatchers.hasText("bar"));
+        assertThat(query2.queryAll()).containsExactly(nodes.get(2));
+    }
+
+    @Test
+    public void hasChild() throws Exception {
+        // given:
+        Node parent = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar"), new Button("baz")));
+
+        // expect:
+        assertThat(parent).hasChild(".button");
+    }
+
+    @Test
+    public void hasChild_fails() throws Exception {
+        // given:
+        Node parent = FxToolkit.setupFixture(() -> new StackPane());
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(parent).hasChild(".button"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Node has child \".button\"\n");
+    }
+
+    @Test
+    public void doesNotHaveChild() throws Exception {
+        // given:
+        Node parent = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar"), new Button("baz")));
+
+        // expect:
+        assertThat(parent).doesNotHaveChild(".boot");
+    }
+
+    @Test
+    public void doesNotHaveChild_fails() throws Exception {
+        // given:
+        Node parent = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar"), new Button("baz")));
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(parent).doesNotHaveChild(".button"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Node has child \".button\" to be false\n");
+    }
+
+    @Test
+    public void hasChildren() throws Exception {
+        // given:
+        Node parent = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar"), new Button("baz")));
+
+        // expect:
+        assertThat(parent).hasExactlyChildren(2, ".button");
+    }
+
+    @Test
+    public void hasChildren_fails() throws Exception {
+        // given:
+        Node parent = FxToolkit.setupFixture(() -> new StackPane(new Label("foo"), new Button("bar")));
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(parent).hasExactlyChildren(2, ".button"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Node has 2 children \".button\"\n");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ParentAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ParentAssertTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class ParentAssertTest extends FxRobot {
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Test
+    public void hasAnyChild() throws Exception {
+        // given (a StackPane with children which is-a Parent):
+        StackPane stackPane = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar"), new Button("baz")));
+
+        // expect:
+        assertThat(stackPane).hasAnyChild();
+    }
+
+    @Test
+    public void hasAnyChild_fails() throws Exception {
+        // given (a StackPane with no children which is-a Parent):
+        StackPane parent = FxToolkit.setupFixture(() -> new StackPane());
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(parent).hasAnyChild())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Parent has at least one child\n     " +
+                        "but: was empty (contained no children)");
+    }
+
+    @Test
+    public void hasNoChildren() throws Exception {
+        // given (a StackPane with no children which is-a Parent):
+        StackPane stackPane = FxToolkit.setupFixture(() -> new StackPane());
+
+        // expect:
+        assertThat(stackPane).hasNoChildren();
+    }
+
+    @Test
+    public void hasNoChildren_fails() throws Exception {
+        // given (a StackPane with 1 child which is-a Parent):
+        StackPane stackPane = FxToolkit.setupFixture(() -> new StackPane(new Button("lol")));
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(stackPane).hasNoChildren())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Parent has at least one child to be false\n     " +
+                        "but: was [Button] (which has 1 child)");
+    }
+
+    @Test
+    public void hasNumChildren() throws Exception {
+        // given (a StackPane with 3 children which is-a Parent):
+        StackPane stackPane = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar"), new Button("baz")));
+
+        // expect:
+        assertThat(stackPane).hasExactlyNumChildren(3);
+    }
+
+    @Test
+    public void hasNumChildren_fails() throws Exception {
+        // given (a StackPane with 2 children which is-a Parent):
+        StackPane stackPane = FxToolkit.setupFixture(() -> new StackPane(new Label("foo"), new Button("bar")));
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(stackPane).hasExactlyNumChildren(3))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Parent has exactly 3 children\n     " +
+                        "but: was [Label, Button] (which has 2 children)");
+    }
+
+    @Test
+    public void doesNotHaveNumChildren() throws Exception {
+        // given (a StackPane with 2 children which is-a Parent):
+        StackPane stackPane = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar")));
+
+        // expect:
+        assertThat(stackPane).doesNotHaveExactlyNumChildren(3);
+    }
+
+    @Test
+    public void doesNotHaveNumChildren_fails() throws Exception {
+        // given (a StackPane with 2 children which is-a Parent):
+        StackPane stackPane = FxToolkit.setupFixture(() -> new StackPane(
+                new Label("foo"), new Button("bar")));
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(stackPane).doesNotHaveExactlyNumChildren(2))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Parent has exactly 2 children to be false\n     " +
+                        "but: was [Label, Button] (which has 2 children)");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TableViewAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TableViewAssertTest.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javafx.application.Platform;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.MapValueFactory;
+import javafx.scene.layout.StackPane;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static javafx.collections.FXCollections.observableArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class TableViewAssertTest extends FxRobot {
+
+    TableView<Map> tableView;
+    TableColumn<Map, String> tableColumn0;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupSceneRoot(() -> {
+            tableView = new TableView<>();
+            Map<String, Object> row1 = new HashMap<>(2);
+            row1.put("name", "alice");
+            row1.put("age", 30);
+
+            Map<String, Object> row2 = new HashMap<>(2);
+            row2.put("name", "bob");
+            row2.put("age", 31);
+
+            Map<String, Object> row3 = new HashMap<>(1);
+            row3.put("name", "carol");
+
+            Map<String, Object> row4 = new HashMap<>(1);
+            row4.put("name", "dave");
+
+            tableView.setItems(observableArrayList(row1, row2, row3, row4));
+            tableColumn0 = new TableColumn<>("name");
+            tableColumn0.setCellValueFactory(new MapValueFactory<>("name"));
+            TableColumn<Map, Integer> tableColumn1 = new TableColumn<>("age");
+            tableColumn1.setCellValueFactory(new MapValueFactory<>("age"));
+            tableView.getColumns().setAll(tableColumn0, tableColumn1);
+            return new StackPane(tableView);
+        });
+        FxToolkit.showStage();
+    }
+
+    @Test
+    public void hasTableCell() {
+        // expect:
+        assertThat(tableView).hasTableCell("alice");
+        assertThat(tableView).hasTableCell("bob");
+    }
+
+    @Test
+    public void hasTableCell_customCellValueFactory() {
+        // given:
+        Platform.runLater(() ->
+                tableColumn0.setCellFactory(column -> new TableCell<Map, String>() {
+                    @Override
+                    protected void updateItem(String item, boolean empty) {
+                        super.updateItem(item, empty);
+                        if (item == null || empty) {
+                            setText(null);
+                        } else {
+                            setText(item.toUpperCase(Locale.US).concat("!"));
+                        }
+                    }
+                }));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).hasTableCell("ALICE!");
+        assertThat(tableView).hasTableCell("BOB!");
+    }
+
+    @Test
+    public void hasTableCell_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).hasTableCell("foobar"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has table cell \"foobar\"\n     " +
+                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+    }
+
+    @Test
+    public void hasTableCell_fails_customCellValueFactory() {
+        // given:
+        Platform.runLater(() ->
+                tableColumn0.setCellFactory(column -> new TableCell<Map, String>() {
+                    @Override
+                    protected void updateItem(String item, boolean empty) {
+                        super.updateItem(item, empty);
+
+                        if (item == null || empty) {
+                            setText(null);
+                        } else {
+                            setText(item.toUpperCase(Locale.US).concat("!"));
+                        }
+                    }
+                }));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).hasTableCell("ALICE!!!"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: TableView has table cell \"ALICE!!!\"\n     ");
+        // FIXME(mike): Currently the table is printed without applying the cell value factory
+        // once that is fixed, add these lines:
+        // "but: was [[ALICE!, 30], [BOB!, 31], [CAROL!, null], [DAVE!, null]]");
+    }
+
+    @Test
+    public void doesNotHaveTableCell() {
+        // expect:
+        assertThat(tableView).doesNotHaveTableCell("june");
+        assertThat(tableView).doesNotHaveTableCell("july");
+    }
+
+    @Test
+    public void hasTableCell_with_toString() {
+        // expect:
+        assertThat(tableView).hasTableCell("30");
+        assertThat(tableView).hasTableCell(31);
+    }
+
+    @Test
+    public void hasTableCell_with_null_fails() {
+        // expect:
+        // FIXME: This works but it is nonsensical - why can't we accept null?
+        assertThatThrownBy(() -> assertThat(tableView).hasTableCell(null))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has table cell \"null\"\n     " +
+                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+    }
+
+    @Test
+    public void doesNotHaveTableCell_customCellValueFactory() {
+        // given:
+        Platform.runLater(() ->
+                tableColumn0.setCellFactory(column -> new TableCell<Map, String>() {
+                    @Override
+                    protected void updateItem(String item, boolean empty) {
+                        super.updateItem(item, empty);
+                        if (item == null || empty) {
+                            setText(null);
+                        } else {
+                            setText(item.toUpperCase(Locale.US).concat("!"));
+                        }
+                    }
+                }));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).doesNotHaveTableCell("alice");
+        assertThat(tableView).doesNotHaveTableCell("bob");
+    }
+
+    @Test
+    public void doesNotHaveTableCell_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).doesNotHaveTableCell("alice"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has table cell \"alice\" to be false\n     " +
+                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+    }
+
+    @Test
+    public void doesNotHaveTableCell_with_toString() {
+        assertThat(tableView).doesNotHaveTableCell("44");
+        assertThat(tableView).doesNotHaveTableCell(44);
+    }
+
+    @Test
+    public void hasExactlyNumRows() {
+        // expect:
+        assertThat(tableView).hasExactlyNumRows(4);
+    }
+
+    @Test
+    public void hasExactlyNumRows_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).hasExactlyNumRows(0))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has 0 rows\n     " +
+                        "but: was contained 4 rows");
+    }
+
+    @Test
+    public void doesNotHaveExactlyNumRows() {
+        // expect:
+        assertThat(tableView).doesNotHaveExactlyNumRows(5);
+    }
+
+    @Test
+    public void doesNotHaveExactlyNumRows_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).doesNotHaveExactlyNumRows(4))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has 4 rows to be false\n     " +
+                        "but: was contained 4 rows");
+    }
+
+    @Test
+    public void containsRowAtIndex() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(2);
+        row3.put("name", "carol");
+        row3.put("age", 42);
+
+        Map<String, Object> row4 = new HashMap<>(2);
+        row4.put("name", "dave");
+        row4.put("age", 55);
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).containsRowAtIndex(0, "alice", 30);
+        assertThat(tableView).containsRowAtIndex(1, "bob", 31);
+        assertThat(tableView).containsRowAtIndex(2, "carol", 42);
+        assertThat(tableView).containsRowAtIndex(3, "dave", 55);
+    }
+
+    @Test
+    public void containsRowAtIndex_with_empty_cells() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(1);
+        row3.put("name", "carol");
+
+        Map<String, Object> row4 = new HashMap<>(1);
+        row4.put("name", "dave");
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).containsRowAtIndex(0, "alice", 30);
+        assertThat(tableView).containsRowAtIndex(1, "bob", 31);
+        assertThat(tableView).containsRowAtIndex(2, "carol", null);
+        assertThat(tableView).containsRowAtIndex(3, "dave", null);
+    }
+
+    @Test
+    public void containsRowAtIndex_no_such_row_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).containsRowAtIndex(0, "jerry", 29))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has row: [jerry, 29] at index 0\n     " +
+                        "but: was [alice, 30] at index: 0");
+    }
+
+    @Test
+    public void containsRowAtIndex_out_of_bounds_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).containsRowAtIndex(4, "tom", 54))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has row: [tom, 54] at index 4\n     " +
+                        "but: was given out-of-bounds row index: 4 (table only has 4 rows)");
+    }
+
+    @Test
+    public void containsRowAtNegativeIndex_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).containsRowAtIndex(-1, "alice", 30))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has row: [alice, 30] at index -1\n     " +
+                        "but: was given negative row index: -1");
+    }
+
+    @Test
+    public void containsRowAtIndex_wrong_types_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).containsRowAtIndex(1, 63, "deedee"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has row: [63, deedee] at index 1\n     " +
+                        "but: was [bob, 31] at index: 1");
+    }
+
+    @Test
+    public void doesNotContainRowAtIndex() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(2);
+        row3.put("name", "carol");
+        row3.put("age", 42);
+
+        Map<String, Object> row4 = new HashMap<>(2);
+        row4.put("name", "dave");
+        row4.put("age", 55);
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).doesNotContainRowAtIndex(0, "ebert", 49);
+        assertThat(tableView).doesNotContainRowAtIndex(1, "alice", 30);
+        assertThat(tableView).doesNotContainRowAtIndex(4, "granger", 49);
+    }
+
+    @Test
+    public void doesNotContainRowAtIndex_with_empty_cells() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(1);
+        row3.put("name", "carol");
+
+        Map<String, Object> row4 = new HashMap<>(1);
+        row4.put("name", "dave");
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).doesNotContainRowAtIndex(1, "alice", 30);
+        assertThat(tableView).doesNotContainRowAtIndex(1, "bob", null);
+        assertThat(tableView).doesNotContainRowAtIndex(2, null, 31);
+        assertThat(tableView).doesNotContainRowAtIndex(2, "ebert", null);
+        assertThat(tableView).doesNotContainRowAtIndex(2, null, null);
+    }
+
+    @Test
+    public void doesNotContainRowAtIndex_fails() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(2);
+        row3.put("name", "carol");
+        row3.put("age", 42);
+
+        Map<String, Object> row4 = new HashMap<>(2);
+        row4.put("name", "dave");
+        row4.put("age", 55);
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThatThrownBy(() -> assertThat(tableView).doesNotContainRowAtIndex(0, "alice", 30))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has row: [alice, 30] at index 0 to be false\n     " +
+                        "but: was [alice, 30] at index: 0");
+    }
+
+    @Test
+    public void containsRow() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(2);
+        row3.put("name", "carol");
+        row3.put("age", 42);
+
+        Map<String, Object> row4 = new HashMap<>(2);
+        row4.put("name", "dave");
+        row4.put("age", 55);
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).containsRow("alice", 30);
+        assertThat(tableView).containsRow("bob", 31);
+        assertThat(tableView).containsRow("carol", 42);
+        assertThat(tableView).containsRow("dave", 55);
+    }
+
+    @Test
+    public void containsRow_with_empty_cells() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(1);
+        row3.put("name", "carol");
+
+        Map<String, Object> row4 = new HashMap<>(1);
+        row4.put("name", "dave");
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).containsRow("alice", 30);
+        assertThat(tableView).containsRow("bob", 31);
+        assertThat(tableView).containsRow("carol", null);
+        assertThat(tableView).containsRow("dave", null);
+    }
+
+    @Test
+    public void containsRow_no_such_row_fails() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(1);
+        row3.put("name", "carol");
+
+        Map<String, Object> row4 = new HashMap<>(1);
+        row4.put("name", "dave");
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).containsRow("jerry", 29))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has row: [jerry, 29]\n     " +
+                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+    }
+
+    @Test
+    public void containsRow_wrong_types_fails() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(1);
+        row3.put("name", "carol");
+
+        Map<String, Object> row4 = new HashMap<>(1);
+        row4.put("name", "dave");
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(tableView).containsRow(63, "deedee"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TableView has row: [63, deedee]\n     " +
+                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+    }
+
+    @Test
+    public void doesNotContainRow() {
+        Map<String, Object> row1 = new HashMap<>(2);
+        row1.put("name", "alice");
+        row1.put("age", 30);
+
+        Map<String, Object> row2 = new HashMap<>(2);
+        row2.put("name", "bob");
+        row2.put("age", 31);
+
+        Map<String, Object> row3 = new HashMap<>(2);
+        row3.put("name", "carol");
+        row3.put("age", 42);
+
+        Map<String, Object> row4 = new HashMap<>(2);
+        row4.put("name", "dave");
+        row4.put("age", 55);
+
+        Platform.runLater(() -> tableView.setItems(observableArrayList(row1, row2, row3, row4)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // expect:
+        assertThat(tableView).doesNotContainRow("alice", 33);
+        assertThat(tableView).doesNotContainRow("bobo", 31);
+        assertThat(tableView).doesNotContainRow(null, 42);
+        assertThat(tableView).doesNotContainRow("dave", null);
+        assertThat(tableView).doesNotContainRow(null, null);
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.text.Text;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class TextAssertTest extends FxRobot {
+
+    Text foobarText;
+    Text quuxText;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            foobarText = new Text("foobar");
+            quuxText = new Text("quux");
+        });
+    }
+
+    @Test
+    public void hasText() {
+        // expect:
+        assertThat(foobarText).hasText("foobar");
+    }
+
+    @Test
+    public void hasText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(quuxText).hasText("foobar"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Text has text \"foobar\"\n     " +
+                        "but: was Text with text: \"quux\"");
+    }
+
+    @Test
+    public void doesNotHaveText() {
+        // expect:
+        assertThat(foobarText).doesNotHaveText("veritas");
+    }
+
+    @Test
+    public void doesNotHaveText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(quuxText).doesNotHaveText("quux"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Text has text \"quux\" to be false\n     " +
+                        "but: was Text with text: \"quux\"");
+    }
+
+    @Test
+    public void hasText_matcher() {
+        // expect:
+        assertThat(foobarText).hasText(endsWith("bar"));
+    }
+
+    @Test
+    public void hasText_matcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(quuxText).hasText(endsWith("bar")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Text has a string ending with \"bar\"\n     " +
+                        "but: was Text with text: \"quux\"");
+    }
+
+    @Test
+    public void doesNotHaveText_matcher() {
+        // expect:
+        assertThat(foobarText).doesNotHaveText(startsWith("bar"));
+    }
+
+    @Test
+    public void doesNotHaveText_matcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(foobarText).doesNotHaveText(startsWith("foo")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: Text has a string starting with \"foo\" to be false\n     " +
+                        "but: was Text with text: \"foobar\"");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextFlowAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextFlowAssertTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.paint.Color;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class TextFlowAssertTest extends FxRobot {
+
+    TextFlow textFlow;
+    TextFlow exactTextFlow;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            Text foobarText = new Text("foobar ");
+            Text quuxText = new Text("quux");
+            quuxText.setFill(Color.RED);
+            textFlow = new TextFlow(foobarText, quuxText);
+
+            Text exactText = new Text("exact");
+            // set the fill to the closest color to, but not exactly, LimeGreen (50, 205, 50)
+            exactText.setFill(Color.rgb(51, 205, 50));
+            exactTextFlow = new TextFlow(exactText);
+        });
+    }
+
+    @Test
+    public void hasText() {
+        // expect:
+        assertThat(textFlow).hasText("foobar quux");
+    }
+
+    @Test
+    public void hasText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(textFlow).hasText("foobar baaz"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextFlow has text \"foobar baaz\"\n     " +
+                        "but: was TextFlow containing text: \"foobar quux\"");
+    }
+
+    @Test
+    public void doesNotHaveText() {
+        // expect:
+        assertThat(textFlow).doesNotHaveText("chess master");
+    }
+
+    @Test
+    public void doesNotHaveText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(textFlow).doesNotHaveText("foobar quux"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextFlow has text \"foobar quux\" to be false\n     " +
+                        "but: was TextFlow containing text: \"foobar quux\"");
+    }
+
+    @Test
+    public void hasColoredText() {
+        assertThat(textFlow).hasColoredText("foobar <RED>quux</RED>");
+    }
+
+    @Test
+    public void hasColoredText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(textFlow).hasColoredText("foobar <BLUE>quux</BLUE>"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextFlow has colored text \"foobar <BLUE>quux</BLUE>\"\n     " +
+                        "but: was TextFlow with colored text: \"foobar <RED>quux</RED>\"");
+    }
+
+    @Test
+    public void hasColoredText_withBogusColor_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(textFlow).hasColoredText("foobar <LALALA>quux</LALALA>"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextFlow has colored text \"foobar <LALALA>quux</LALALA>\"\n     " +
+                        "but: was TextFlow with colored text: \"foobar <RED>quux</RED>\"");
+    }
+
+    @Test
+    public void doesNotHaveColoredText() {
+        assertThat(textFlow).doesNotHaveColoredText("foobar <GREEN>quux</GREEN>");
+    }
+
+    @Test
+    public void doesNotHaveColoredText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(textFlow).doesNotHaveColoredText("foobar <RED>quux</RED>"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextFlow has colored text \"foobar <RED>quux</RED>\" to be false\n     " +
+                        "but: was TextFlow with colored text: \"foobar <RED>quux</RED>\"");
+    }
+
+    @Test
+    public void hasExactlyColoredText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(exactTextFlow).hasExactlyColoredText("<LIMEGREEN>exact</LIMEGREEN>"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextFlow has exactly colored text \"<LIMEGREEN>exact</LIMEGREEN>\"\n     " +
+                        "but: was impossible to exactly match TextFlow containing " +
+                        "colored text: \"exact\" which has color: \"#33cd32\".\n" +
+                        "This is not a named color. The closest named color is: \"LIMEGREEN\".\n" +
+                        "See: https://docs.oracle.com/javase/9/docs/api/javafx/scene/doc-files/cssref.html#typecolor");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextInputControlAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextInputControlAssertTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.TextField;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class TextInputControlAssertTest extends FxRobot {
+
+    TextField foobarTextField;
+    TextField quuxTextField;
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            foobarTextField = new TextField("foobar");
+            quuxTextField = new TextField("quux");
+        });
+    }
+
+    @Test
+    public void hasText() {
+        // expect:
+        assertThat(foobarTextField).hasText("foobar");
+    }
+
+    @Test
+    public void hasText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(quuxTextField).hasText("foobar"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextInputControl has text \"foobar\"\n     " +
+                        "but: was TextField with text: \"quux\"");
+    }
+
+    @Test
+    public void doesNotHaveText() {
+        // expect:
+        assertThat(foobarTextField).doesNotHaveText("minnesota");
+    }
+
+    @Test
+    public void doesNotHaveText_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(foobarTextField).doesNotHaveText("foobar"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextInputControl has text \"foobar\" to be false\n     " +
+                        "but: was TextField with text: \"foobar\"");
+    }
+
+    @Test
+    public void hasText_matcher() {
+        // expect:
+        assertThat(foobarTextField).hasText(endsWith("bar"));
+    }
+
+    @Test
+    public void hasText_matcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(quuxTextField).hasText(endsWith("bar")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextInputControl has a string ending with \"bar\"\n     " +
+                        "but: was TextField with text: \"quux\"");
+    }
+
+    @Test
+    public void doesNotHaveText_matcher() {
+        // expect:
+        assertThat(foobarTextField).doesNotHaveText(startsWith("fuu"));
+    }
+
+    @Test
+    public void doesNotHaveText_matcher_fails() {
+        // expect:
+        assertThatThrownBy(() -> assertThat(foobarTextField).doesNotHaveText(endsWith("bar")))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("Expected: TextInputControl has a string ending with \"bar\" to be false\n     " +
+                        "but: was TextField with text: \"foobar\"");
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/WindowAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/WindowAssertTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+
+import javafx.stage.Stage;
+import javafx.stage.Window;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class WindowAssertTest extends FxRobot {
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @After
+    public void cleanup() throws TimeoutException {
+        FxToolkit.cleanupStages();
+    }
+
+    @Test
+    public void isShowing() throws Exception {
+        // given:
+        Window window = FxToolkit.setupFixture(() -> {
+            Stage stage = new Stage();
+            stage.show();
+            return stage;
+        });
+
+        // expect:
+        assertThat(window).isShowing();
+    }
+
+    @Test
+    public void isShowing_fails() throws Exception {
+        // given:
+        Window window = FxToolkit.setupFixture((Callable<Stage>) Stage::new);
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(window).isShowing())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Window is showing");
+    }
+
+    @Test
+    public void isNotShowing() throws Exception {
+        // given:
+        Window window = FxToolkit.setupFixture((Callable<Stage>) Stage::new);
+
+        // then:
+        assertThat(window).isNotShowing();
+    }
+
+    @Test
+    public void isNotShowing_fails() throws Exception {
+        // given:
+        Window window = FxToolkit.setupFixture(() -> {
+            Stage stage = new Stage();
+            stage.show();
+            return stage;
+        });
+
+        // expect:
+        assertThatThrownBy(() -> assertThat(window).isNotShowing())
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessageStartingWith("Expected: Window is not showing");
+    }
+
+    @Test
+    public void isNotFocused() throws Exception {
+        Window window = FxToolkit.setupFixture((Callable<Stage>) Stage::new);
+
+        // expect:
+        assertThat(window).isNotFocused();
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -30,13 +30,13 @@ import org.testfx.framework.junit.TestFXRule;
 import static org.hamcrest.CoreMatchers.not;
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.api.FxToolkit.setupApplication;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
 import static org.testfx.matcher.base.NodeMatchers.isDisabled;
 import static org.testfx.matcher.base.NodeMatchers.isEnabled;
 import static org.testfx.matcher.base.NodeMatchers.isInvisible;
 import static org.testfx.matcher.base.NodeMatchers.isNotNull;
 import static org.testfx.matcher.base.NodeMatchers.isNull;
 import static org.testfx.matcher.base.NodeMatchers.isVisible;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 public class FxAssertBasicTest extends TestCaseBase {

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
@@ -56,7 +56,10 @@ public class ColorMatchersTest extends FxRobot {
     @Test
     public void isColor_colorMatcher_fails() {
         // expect:
-        assertThat(Color.color(0.5, 0, 0), ColorMatchers.isColor(Color.RED, new PixelMatcherRgb(0.5, 0)));
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: Color has color \"RED\" (#ff0000)\n     ");
+
+        assertThat(Color.color(0.5, 0, 0), ColorMatchers.isColor(Color.RED, new PixelMatcherRgb(0.01, 0)));
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
@@ -26,7 +26,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
-import javafx.scene.text.Text;
 
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -37,12 +36,14 @@ import org.junit.rules.TestRule;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
+import org.testfx.matcher.control.LabeledMatchers;
+import org.testfx.matcher.control.TextInputControlMatchers;
 import org.testfx.service.query.NodeQuery;
 import org.testfx.util.WaitForAsyncUtils;
 
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 public class NodeMatchersTest extends FxRobot {
 
@@ -69,51 +70,11 @@ public class NodeMatchersTest extends FxRobot {
         });
 
         // expect:
-        assertThat(from(nodes).match(NodeMatchers.anything()).queryAll(),
-            hasItem(NodeMatchers.hasText("bar")));
+        assertThat(from(nodes).match(NodeMatchers.anything()).queryAll(), hasItem(nodes.get(1)));
     }
 
     @Test
-    public void hasText_with_button() throws Exception {
-        // given:
-        Button button = FxToolkit.setupFixture(() -> new Button("foo"));
-
-        // expect:
-        assertThat(button, NodeMatchers.hasText("foo"));
-    }
-
-    @Test
-    public void hasText_with_text_field() throws Exception {
-        // given:
-        TextField textField = FxToolkit.setupFixture(() -> new TextField("foo"));
-
-        // expect:
-        assertThat(textField, NodeMatchers.hasText("foo"));
-    }
-
-    @Test
-    public void hasText_with_text() throws Exception {
-        // given:
-        Text textShape = FxToolkit.setupFixture(() -> new Text("foo"));
-
-        // expect:
-        assertThat(textShape, NodeMatchers.hasText("foo"));
-    }
-
-    @Test
-    public void hasText_with_region_fails() throws Exception {
-        // given:
-        Region region = FxToolkit.setupFixture(Region::new);
-
-        // expect:
-        exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: Node has text \"foo\"\n");
-
-        assertThat(region, NodeMatchers.hasText("foo"));
-    }
-
-    @Test
-    public void isFocus() throws Exception {
+    public void isFocused() throws Exception {
         // given:
         FxToolkit.setupSceneRoot(() -> {
             textField = new TextField("foo");
@@ -194,11 +155,11 @@ public class NodeMatchersTest extends FxRobot {
         });
 
         // expect:
-        NodeQuery query1 = from(nodes).match(NodeMatchers.hasText("foo"));
+        NodeQuery query1 = from(nodes).match(LabeledMatchers.hasText("foo"));
         assertThat(query1.queryAll(), hasItems(nodes.get(1)));
 
         // and:
-        NodeQuery query2 = from(nodes).match(NodeMatchers.hasText("bar"));
+        NodeQuery query2 = from(nodes).match(TextInputControlMatchers.hasText("bar"));
         assertThat(query2.queryAll(), hasItems(nodes.get(2)));
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ParentMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ParentMatchersTest.java
@@ -54,6 +54,19 @@ public class ParentMatchersTest {
     }
 
     @Test
+    public void hasChild_fails() throws Exception {
+        // given:
+        Parent parent = FxToolkit.setupFixture(() -> new StackPane());
+
+        // expect:
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Expected: Parent has at least one child\n     " +
+                "but: was empty (contained no children)");
+
+        assertThat(parent, ParentMatchers.hasChild());
+    }
+
+    @Test
     public void hasChildren() throws Exception {
         // given:
         Parent parent = FxToolkit.setupFixture(() -> new StackPane(
@@ -64,25 +77,14 @@ public class ParentMatchersTest {
     }
 
     @Test
-    public void hasChild_fails() throws Exception {
-        // given:
-        Parent parent = FxToolkit.setupFixture(() -> new StackPane());
-
-        // expect:
-        exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: Parent has child\n");
-
-        assertThat(parent, ParentMatchers.hasChild());
-    }
-
-    @Test
     public void hasChildren_fails() throws Exception {
         // given:
         Parent parent = FxToolkit.setupFixture(() -> new StackPane(new Label("foo"), new Button("bar")));
 
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: Parent has 3 children\n");
+        exception.expectMessage("Expected: Parent has exactly 3 children\n     " +
+                "but: was [Label, Button] (which has 2 children)");
 
         assertThat(parent, ParentMatchers.hasChildren(3));
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/WindowMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/WindowMatchersTest.java
@@ -46,7 +46,7 @@ public class WindowMatchersTest extends FxRobot {
     }
 
     @Test
-    public void windowIsNotShowing() throws Exception {
+    public void isNotShowing() throws Exception {
         Window window = FxToolkit.setupFixture((Callable<Stage>) Stage::new);
 
         // expect:
@@ -54,7 +54,7 @@ public class WindowMatchersTest extends FxRobot {
     }
 
     @Test
-    public void windowIsNotFocused() throws Exception {
+    public void isNotFocused() throws Exception {
         Window window = FxToolkit.setupFixture((Callable<Stage>) Stage::new);
 
         // expect:
@@ -62,7 +62,7 @@ public class WindowMatchersTest extends FxRobot {
     }
 
     @Test
-    public void windowIsShowing() throws Exception {
+    public void isShowing() throws Exception {
         Window window = FxToolkit.setupFixture(() -> {
             Stage stage = new Stage();
             stage.show();
@@ -83,7 +83,7 @@ public class WindowMatchersTest extends FxRobot {
 
     @Test
     @Ignore("See https://github.com/TestFX/TestFX/pull/284 for details")
-    public void windowIsFocused() throws Exception {
+    public void isFocused() throws Exception {
         Window window = FxToolkit.setupFixture(() -> {
             Stage stage = new Stage();
             stage.show();

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
@@ -68,29 +68,32 @@ public class ComboBoxMatchersTest extends FxRobot {
     public void hasItems_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: ComboBox has 3 items\n     " +
+        exception.expectMessage("Expected: ComboBox has exactly 3 items\n     " +
                 "but: was 4");
 
         assertThat(comboBox, ComboBoxMatchers.hasItems(3));
     }
 
     @Test
-    public void hasSelection() {
+    public void hasSelectedItem() {
+        // given:
         assertThat(comboBox, ComboBoxMatchers.hasSelectedItem("alice"));
 
+        // when:
         clickOn(".combo-box-base");
         type(KeyCode.DOWN);
         type(KeyCode.ENTER);
 
+        // then:
         assertThat(comboBox, ComboBoxMatchers.hasSelectedItem("bob"));
     }
 
     @Test
-    public void hasSelection_fails() {
+    public void hasSelectedItem_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: ComboBox has selection bob\n     " +
-                "but: was alice");
+        exception.expectMessage("Expected: ComboBox has selection \"bob\"\n     " +
+                "but: was \"alice\"");
 
         assertThat(comboBox, ComboBoxMatchers.hasSelectedItem("bob"));
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
@@ -60,7 +60,8 @@ public class LabeledMatchersTest extends FxRobot {
     public void hasText_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: Labeled has text \"foobar\"\n     but: was \"quux\"");
+        exception.expectMessage("Expected: Labeled has text \"foobar\"\n     " +
+                "but: was \"quux\"");
 
         assertThat(quuxButton, LabeledMatchers.hasText("foobar"));
     }
@@ -75,7 +76,8 @@ public class LabeledMatchersTest extends FxRobot {
     public void hasText_matcher_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: Labeled has a string ending with \"bar\"\n     but: was \"quux\"");
+        exception.expectMessage("Expected: Labeled has a string ending with \"bar\"\n     " +
+                "but: was \"quux\"");
 
         assertThat(quuxButton, LabeledMatchers.hasText(endsWith("bar")));
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
@@ -70,8 +70,8 @@ public class ListViewMatchersTest extends FxRobot {
     public void hasListCell_with_null_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: ListView has list cell \"null\"\n" +
-                "     but: was [alice, bob, carol, dave]");
+        exception.expectMessage("Expected: ListView has list cell \"null\"\n     " +
+                "but: was [alice, bob, carol, dave]");
 
         assertThat(listView, ListViewMatchers.hasListCell(null));
     }
@@ -80,8 +80,8 @@ public class ListViewMatchersTest extends FxRobot {
     public void hasListCell_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: ListView has list cell \"foobar\"\n" +
-                "     but: was [alice, bob, carol, dave]");
+        exception.expectMessage("Expected: ListView has list cell \"foobar\"\n     " +
+                "but: was [alice, bob, carol, dave]");
 
         assertThat(listView, ListViewMatchers.hasListCell("foobar"));
     }
@@ -96,7 +96,7 @@ public class ListViewMatchersTest extends FxRobot {
     public void hasItems_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: ListView has 0 items\n     " +
+        exception.expectMessage("Expected: ListView has exactly 0 items\n     " +
                 "but: was 4");
 
         assertThat(listView, ListViewMatchers.hasItems(0));
@@ -116,7 +116,7 @@ public class ListViewMatchersTest extends FxRobot {
     public void isEmpty_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: ListView is empty (contains 0 (zero) items)\n     " +
+        exception.expectMessage("Expected: ListView is empty (contains no items)\n     " +
                 "but: was contains 4 items");
         assertThat(listView, ListViewMatchers.isEmpty());
     }
@@ -131,10 +131,16 @@ public class ListViewMatchersTest extends FxRobot {
     public void hasPlaceholder_fails() {
         // expect:
         exception.expect(AssertionError.class);
-        exception.expectMessage("Expected: ListView has labeled placeholder containing text: \"foobar\"\n" +
-                "     but: was labeled placeholder containing text: \"Empty!\"");
+        exception.expectMessage("Expected: ListView has labeled placeholder containing text: \"foobar\"\n     " +
+                "but: was labeled placeholder containing text: \"Empty!\"");
 
         assertThat(listView, ListViewMatchers.hasPlaceholder(new Label("foobar")));
+    }
+
+    @Test
+    public void hasVisiblePlaceholder() {
+        // expect:
+        assertThat(listView, ListViewMatchers.hasVisiblePlaceholder(new Label("Empty!")));
     }
 
     @Test
@@ -151,6 +157,7 @@ public class ListViewMatchersTest extends FxRobot {
     public void hasVisiblePlaceholder_fails_whenPlaceHolderIsInvisible() {
         // when:
         listView.getPlaceholder().setVisible(false);
+        WaitForAsyncUtils.waitForFxEvents();
 
         // expect:
         exception.expect(AssertionError.class);

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -90,8 +90,7 @@ public class TableViewMatchersTest extends FxRobot {
             TableColumn<Map, Integer> tableColumn1 = new TableColumn<>("age");
             tableColumn1.setCellValueFactory(new MapValueFactory<>("age"));
             tableView.getColumns().setAll(tableColumn0, tableColumn1);
-            StackPane stackPane = new StackPane(tableView);
-            return stackPane;
+            return new StackPane(tableView);
         });
         FxToolkit.showStage();
     }
@@ -130,8 +129,7 @@ public class TableViewMatchersTest extends FxRobot {
         // expect:
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: TableView has table cell \"foobar\"\n     " +
-                "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]\n" +
-                "which does not contain a cell with the given value");
+                "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
 
         assertThat(tableView, TableViewMatchers.hasTableCell("foobar"));
     }
@@ -159,8 +157,7 @@ public class TableViewMatchersTest extends FxRobot {
         exception.expectMessage("Expected: TableView has table cell \"ALICE!!!\"\n     ");
         // FIXME(mike): Currently the table is printed without applying the cell value factory
         // once that is fixed, add these lines:
-        // "but: was [[ALICE!, 30], [BOB!, 31], [CAROL!, null], [DAVE!, null]]\n" +
-        // "which does not contain a cell with the given value");
+        // "but: was [[ALICE!, 30], [BOB!, 31], [CAROL!, null], [DAVE!, null]]");
         assertThat(tableView, TableViewMatchers.hasTableCell("ALICE!!!"));
     }
 
@@ -179,8 +176,7 @@ public class TableViewMatchersTest extends FxRobot {
         exception.expect(AssertionError.class);
         // FIXME: This works but it is nonsensical - why can't we accept null?
         exception.expectMessage("Expected: TableView has table cell \"null\"\n     " +
-                "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]\n" +
-                "which does not contain a cell with the given value");
+                "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
 
         assertThat(tableView, TableViewMatchers.hasTableCell(null));
     }
@@ -196,7 +192,7 @@ public class TableViewMatchersTest extends FxRobot {
         // expect:
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: TableView has 0 rows\n     " +
-                "but: was 4");
+                "but: was contained 4 rows");
 
         assertThat(tableView, TableViewMatchers.hasNumRows(0));
     }
@@ -265,7 +261,7 @@ public class TableViewMatchersTest extends FxRobot {
         // expect:
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: TableView has row: [jerry, 29] at index 0\n     " +
-                "but: was [alice, 30]");
+                "but: was [alice, 30] at index: 0");
 
         assertThat(tableView, TableViewMatchers.containsRowAtIndex(0, "jerry", 29));
     }
@@ -285,7 +281,7 @@ public class TableViewMatchersTest extends FxRobot {
         // expect:
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: TableView has row: [alice, 30] at index -1\n     " +
-                "but: was given negative row index");
+                "but: was given negative row index: -1");
 
         assertThat(tableView, TableViewMatchers.containsRowAtIndex(-1, "alice", 30));
     }
@@ -295,7 +291,7 @@ public class TableViewMatchersTest extends FxRobot {
         // expect:
         exception.expect(AssertionError.class);
         exception.expectMessage("Expected: TableView has row: [63, deedee] at index 1\n     " +
-                "but: was [bob, 31]");
+                "but: was [bob, 31] at index: 1");
 
         assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, 63, "deedee"));
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
@@ -49,6 +49,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
+import org.testfx.matcher.control.TextInputControlMatchers;
 import org.testfx.util.WaitForAsyncUtils;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -58,7 +59,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
 
 public class JavafxRobotAdapterTest {
 
@@ -130,7 +130,7 @@ public class JavafxRobotAdapterTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(textField, hasText(String.valueOf(glyphs)));
+        verifyThat(textField, TextInputControlMatchers.hasText(String.valueOf(glyphs)));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class JavafxRobotAdapterTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(textField, hasText(String.valueOf(glyphs)));
+        verifyThat(textField, TextInputControlMatchers.hasText(String.valueOf(glyphs)));
     }
 
     @Test
@@ -166,7 +166,7 @@ public class JavafxRobotAdapterTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(textField, hasText(String.valueOf(glyphs)));
+        verifyThat(textField, TextInputControlMatchers.hasText(String.valueOf(glyphs)));
     }
 
     @Test
@@ -184,7 +184,7 @@ public class JavafxRobotAdapterTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(textField, hasText(String.valueOf(glyphs)));
+        verifyThat(textField, TextInputControlMatchers.hasText(String.valueOf(glyphs)));
     }
 
     @Test
@@ -206,7 +206,7 @@ public class JavafxRobotAdapterTest {
         typeText(text);
 
         // then:
-        verifyThat(textArea, hasText(text));
+        verifyThat(textArea, TextInputControlMatchers.hasText(text));
     }
 
     @Test
@@ -227,7 +227,7 @@ public class JavafxRobotAdapterTest {
         typeText(text);
 
         // then:
-        verifyThat(textArea, hasText(text));
+        verifyThat(textArea, TextInputControlMatchers.hasText(text));
     }
 
     @Test
@@ -247,7 +247,7 @@ public class JavafxRobotAdapterTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        verifyThat(textField, hasText(String.valueOf(LATIN_EXTENDED_A_GLYPHS) +
+        verifyThat(textField, TextInputControlMatchers.hasText(String.valueOf(LATIN_EXTENDED_A_GLYPHS) +
                 String.valueOf(LATIN_EXTENDED_A_GLYPHS)));
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
@@ -24,7 +24,6 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
 import javafx.scene.layout.Pane;
 
 import org.junit.Before;
@@ -53,17 +52,12 @@ public class NodeQueryImplTest {
     Scene scene;
 
     @FXML Pane labels;
-    @FXML Pane buttons;
-    @FXML Pane textfields;
     @FXML Label label0;
     @FXML Label label1;
     @FXML Label label2;
     @FXML Button button0;
     @FXML Button button1;
     @FXML Button button2;
-    @FXML TextField textfield0;
-    @FXML TextField textfield1;
-    @FXML TextField textfield2;
 
     @BeforeClass
     public static void setupSpec() throws Exception {
@@ -88,7 +82,7 @@ public class NodeQueryImplTest {
     }
 
     @Test
-    public void queryFirst() {
+    public void query() {
         // when:
         Node result = nodeQuery
             .from(label0, label1, label2)
@@ -99,7 +93,7 @@ public class NodeQueryImplTest {
     }
 
     @Test
-    public void queryFirst_is_null() {
+    public void query_null() {
         // when:
         Node result = nodeQuery
             .query();
@@ -109,7 +103,7 @@ public class NodeQueryImplTest {
     }
 
     @Test
-    public void tryQueryFirst() {
+    public void tryQuery() {
         // when:
         Optional<Node> result = nodeQuery
             .from(label0, label1, label2)
@@ -120,7 +114,7 @@ public class NodeQueryImplTest {
     }
 
     @Test
-    public void tryQueryFirst_is_absent() {
+    public void tryQueryFirst_absent() {
         // when:
         Optional<Node> result = nodeQuery
             .tryQuery();
@@ -148,6 +142,17 @@ public class NodeQueryImplTest {
 
         // then:
         assertThat(result.isEmpty(), is(true));
+    }
+
+    @Test
+    public void queryAllAs() {
+        // when:
+        Set<Label> result = nodeQuery
+                .from(label0, label1, label2)
+                .queryAllAs(Label.class);
+
+        // then:
+        assertThat(result, hasItems(label0, label1, label2));
     }
 
     @Test
@@ -284,7 +289,7 @@ public class NodeQueryImplTest {
     }
 
     @Test
-    public void lookup_selectAt_lookup_selectAt_with_indizes_out_of_bounds() {
+    public void lookup_selectAt_lookup_selectAt_with_indices_out_of_bounds() {
         // when:
         Set<Node> result = nodeQuery
             .from(rootOfScene(scene))

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -30,6 +30,7 @@ dependencies {
     }
 
     compile "org.hamcrest:hamcrest-core:1.3"
+    compile "org.assertj:assertj-core:3.8.0"
     compileOnly 'org.osgi:org.osgi.core:6.0.0'
 
     testCompile "junit:junit:4.12"

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -32,7 +32,7 @@ import org.testfx.framework.junit.ApplicationTest;
 import org.testfx.framework.junit.TestFXRule;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 public class ApplicationLaunchTest extends FxRobot {

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -26,7 +26,7 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.ApplicationTest;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 public class ApplicationStartTest extends ApplicationTest {

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 
 public class ApplicationRuleTest {
 

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -30,7 +30,7 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit5.ApplicationTest;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 public class ApplicationLaunchTest extends FxRobot {

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -26,7 +26,7 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit5.ApplicationTest;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 class ApplicationStartTest extends ApplicationTest {

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/NonPublicAnnotationsTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/NonPublicAnnotationsTest.java
@@ -28,7 +28,7 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 
 /**
  * This test class makes sure that the JUnit 5 annotations can be on

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/ApplicationRuleTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.matcher.base.NodeMatchers.hasText;
+import static org.testfx.matcher.control.LabeledMatchers.hasText;
 
 @ExtendWith(ApplicationExtension.class)
 class ApplicationRuleTest {

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
@@ -17,7 +17,7 @@
 package org.testfx.cases.acceptance
 
 import static org.testfx.api.FxAssert.verifyThat
-import static org.testfx.matcher.base.NodeMatchers.hasText
+import static org.testfx.matcher.control.LabeledMatchers.hasText
 
 import javafx.application.Application
 import javafx.scene.Scene

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
@@ -17,7 +17,7 @@
 package org.testfx.cases.acceptance
 
 import static org.testfx.api.FxAssert.verifyThat
-import static org.testfx.matcher.base.NodeMatchers.hasText
+import static org.testfx.matcher.control.LabeledMatchers.hasText
 
 import javafx.scene.Scene
 import javafx.scene.control.Button


### PR DESCRIPTION
This PR adds AssertJ assertions to TestFX, for each existing hamcrest matcher that we currently have (and their inverses, where they make sense). Currently this is added to `testfx-core`, but having a `testfx-assertj` subproject is another way to go.

What's going to be awesome about this is, following the lead from the AssertJ folks - it is possible to emulate "self types" using generics. This allows for using `assertThat(..)` with say, a Button argument, and automatically get access to all Node assertions, because Button is a sub-class of Node. As we start to fill out TestFX with more matchers/assertion classes, we will create a hierarchy that closely matches the JavaFX hierarchy. In other words, a Button will have the following assertions open to it:

Button -> Labeled -> Control -> Region -> Parent -> Node

So, when typing in `assertThat(someButton).` in an IDE, it will auto-complete the possible assertions from all the above (ButtonAssert, LabeledAssert, ControlAssert, RegionAssert, ParentAssert, and NodeAssert). Currently we only have Button, Labeled, Parent, and Node but that's why I mentioned above "as we start to fill out TestFX with more matchers/assertion classes".

We will still support Hamcrest matchers as first-class citizens. In fact, the current implementation in this PR piggy-backs on the hamcrest matcher for each AssertJ assertion. It's a bit hacky, but the most important thing for this proof-of-concept is that it works (all new AssertJ assertions and their inverses pass the existing tests from the hamcrest matchers).

Currently I am trying to figure out how we can use the AssertJ assertions with node query based arguments. If anyone has any advice/guidance, it would be much appreciated :) (details below).
The basic problem is that the type of the instance we are asserting on is not fully known at compile-time. One way to perhaps force the type to be known at compile-time is to support some type of addon to `assertThat` such as `assertThat("#someButton").expecting(Button.class)` which will then return a ButtonAssert (which extends LabeledAssert, ControlAssert, etc. etc.). Not sure if that actually gets around the problem, though, because then the argument will be a `Class<?>` argument and then we have the same problem.

```
// TODO: Implement analogous methods to FxAssert.verifyThat(..) that accept node query arguments.
// The question is, how can we, starting from Node, traverse down the class hierarchy and select
// the most application node class? For example, assertThat("#someButton").isCancelButton() -
// how can we make it so that a String argument returns a ButtonAssert instead of a LabeledAssert,
// or NodeAssert, etc.
```

Update: I can't think of a solution where the type of the result of executing a node query could be possibly known at compile-time. However, I remembered that by using node queries inside the `assertThat`s we can get pretty good, readable code:

```java
assertThat((Button) lookup(".button").query()).isCancelButton();`
assertThat(lookup(".button").queryAs(Button.class)).isCancelButton();
```

I added the second `queryAs` method to `NodeQuery` as part of this PR as it gets rid of a cast operation which is a bit cleaner IMO.

Being able to write: `assertThat(".button").isCancelButton()` would be the most ideal, but I just don't think it's possible. We could add a bunch of individual `query` methods to `NodeQuery`, such as `queryButton`, `queryComboBox`, `queryListView`, etc. which would result in more readable assertion code but may be too heavy-handed of a solution. That would look like:

```java
assertThat(lookup(".button").queryButton()).isCancelButton();
```

In a future PR we can support the `DebugUtils` work done by @JordanMartinez by adding a `withErrorMessage` mapper method, similar to `overridingErrorMessage` method in assertj-core. The details of the `Adapter` from this PR may need to be tweaked to allow for that, though.

We should be able to implement this by having all our abstract assertion classes extend from `AbstractTestFXAssert` which has a private errorMessageMapper field. Then we could change `Adapter.fromMatcher` and `fromInverseMatcher` to accept an error message mapper and if it's not-null during execution of the assertj condition, apply the error message to it and throw a new assertion error with the new message as we do in verifyThatImpl.