### PR TITLE
(fix) Maintain order of nodes as returned by Node.lookupAll(..).

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
@@ -117,6 +117,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@code Node} found that matches
      * this query or {@literal null} if no nodes match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @param <T> the type that extends {@code Node}
      * @return the first node found or {@literal null}
@@ -126,6 +133,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link Button} found that matches
      * this query or {@literal null} if no buttons match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code Button} found or {@literal null}
      */
@@ -134,6 +148,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link ComboBox} found that matches
      * this query or {@literal null} if no combo-boxes match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code ComboBox} found or {@literal null}
      */
@@ -142,6 +163,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link Labeled} found that matches
      * this query or {@literal null} if no labeleds match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code Labeled} found or {@literal null}
      */
@@ -150,6 +178,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link ListView} found that matches
      * this query or {@literal null} if no list views match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code ListView} found or {@literal null}
      */
@@ -158,6 +193,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link Parent} found that matches
      * this query or {@literal null} if no parents match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code Parent} found or {@literal null}
      */
@@ -166,6 +208,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link TableView} found that matches
      * this query or {@literal null} if no table views match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code TableView} found or {@literal null}
      */
@@ -174,6 +223,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link Text} found that matches
      * this query or {@literal null} if no texts match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code Text} found or {@literal null}
      */
@@ -182,6 +238,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link TextFlow} found that matches
      * this query or {@literal null} if no text flows match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code TextFlow} found or {@literal null}
      */
@@ -190,6 +253,13 @@ public interface NodeQuery {
     /**
      * Executes this {@code NodeQuery} and returns the first {@link TextInputControl} found that matches
      * this query or {@literal null} if no text input controls match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @return the first {@code TextInputControl} found or {@literal null}
      */
@@ -199,6 +269,13 @@ public interface NodeQuery {
      * Type-safe version of {@link #query()} that executes this {@code NodeQuery} and returns
      * the first {@code Node} found that matches this query or {@literal null} if no nodes
      * match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @param clazz the concrete sub-type of {@code Node} that should be returned by this query
      * so as to avoid extraneous casting when used inside an "assertThat" assertion
@@ -211,6 +288,13 @@ public interface NodeQuery {
      * Executes this {@code NodeQuery} and returns an {@code Optional} that either contains
      * the first {@code Node} found that matches this query or nothing (e.g. {@link Optional#empty()}
      * returns {@literal true}) if no nodes match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @param <T> the type that extends {@code Node}
      * @return the first node found or {@literal null}
@@ -221,6 +305,13 @@ public interface NodeQuery {
      * Type-safe version of {@link #tryQuery()} that executes this {@code NodeQuery} and returns an
      * {@code Optional} that either contains the first {@code Node} found that matches this query or
      * nothing (e.g. {@link Optional#empty()} returns {@literal true}) if no nodes match this query.
+     * <p>
+     * The determinism of this method relies on the determinism of {@link Node#lookupAll(String)},
+     * for which the JavaDocs specifically state that the result is unordered. The current (9.0.4)
+     * version of JavaFX happens to return the nodes in the order in which they are encountered whilst
+     * traversing the scene graph but this could change in future versions of JavaFX. Thus if there are
+     * multiple nodes matched by this query and you want a specific one it is advised not to use this
+     * method and instead narrow the query so that only one node is matched.
      *
      * @param clazz the concrete sub-type of {@code Node} that should be contained in the
      * {@code Optional} returned by this query so as to avoid extraneous casting when used inside

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
@@ -38,7 +38,6 @@ import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 
 import org.hamcrest.Matcher;
-
 import org.testfx.api.annotation.Unstable;
 import org.testfx.service.query.NodeQuery;
 import org.testfx.util.NodeQueryUtils;
@@ -104,7 +103,7 @@ public class NodeQueryImpl implements NodeQuery {
     public <T> NodeQuery match(Matcher<T> matcher) {
         parentNodes = parentNodes.stream()
             .filter(NodeQueryUtils.matchesMatcher((Matcher<Node>) matcher))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
         return this;
     }
 
@@ -113,7 +112,7 @@ public class NodeQueryImpl implements NodeQuery {
     public <T extends Node> NodeQuery match(Predicate<T> predicate) {
         parentNodes = parentNodes.stream()
             .filter((Predicate<Node>) predicate)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
         return this;
     }
 
@@ -122,80 +121,132 @@ public class NodeQueryImpl implements NodeQuery {
         parentNodes = parentNodes.stream()
             .skip(index)
             .limit(1)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
         return this;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Node> T query() {
-        return (T) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.isEmpty()) {
+            return null;
+        } else {
+            return (T) parentNodes.iterator().next();
+        }
     }
 
     @Override
     public Button queryButton() {
-        return (Button) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> Button.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (Button) parentNodes.iterator().next();
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> ComboBox<T> queryComboBox() {
-        return (ComboBox<T>) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> ComboBox.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (ComboBox<T>) parentNodes.iterator().next();
+        }
     }
 
     @Override
     public Labeled queryLabeled() {
-        return (Labeled) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> Labeled.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (Labeled) parentNodes.iterator().next();
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> ListView<T> queryListView() {
-        return (ListView<T>) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> ListView.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (ListView<T>) parentNodes.iterator().next();
+        }
     }
 
     @Override
     public Parent queryParent() {
-        return (Parent) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> Parent.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (Parent) parentNodes.iterator().next();
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> TableView<T> queryTableView() {
-        return (TableView<T>) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> TableView.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (TableView<T>) parentNodes.iterator().next();
+        }
     }
 
     @Override
     public Text queryText() {
-        return (Text) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> Text.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (Text) parentNodes.iterator().next();
+        }
     }
 
     @Override
     public TextFlow queryTextFlow() {
-        return (TextFlow) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> TextFlow.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (TextFlow) parentNodes.iterator().next();
+        }
     }
 
     @Override
     public TextInputControl queryTextInputControl() {
-        return (TextInputControl) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> TextInputControl.class.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (TextInputControl) parentNodes.iterator().next();
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Node> T queryAs(Class<T> clazz) {
-        return (T) parentNodes.stream().findFirst().orElse(null);
+        if (parentNodes.stream().noneMatch(node -> clazz.isAssignableFrom(node.getClass()))) {
+            return null;
+        } else {
+            return (T) parentNodes.iterator().next();
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Node> Optional<T> tryQuery() {
-        return (Optional<T>) parentNodes.stream().findFirst();
+        if (parentNodes.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of((T) parentNodes.iterator().next());
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Node> Optional<T> tryQueryAs(Class<T> clazz) {
-        return (Optional<T>) parentNodes.stream().findFirst();
+        if (parentNodes.stream().noneMatch(node -> clazz.isAssignableFrom(node.getClass()))) {
+            return Optional.empty();
+        } else {
+            return Optional.of((T) parentNodes.iterator().next());
+        }
     }
 
     @Override

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -49,6 +49,7 @@ import org.testfx.framework.junit.TestFXRule;
 import org.testfx.util.WaitForAsyncUtils;
 
 import static javafx.collections.FXCollections.observableArrayList;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -86,6 +87,7 @@ public class TableViewMatchersTest extends FxRobot {
 
             tableView.setItems(observableArrayList(row1, row2, row3, row4));
             tableColumn0 = new TableColumn<>("name");
+            tableColumn0.setId("tableColumn0");
             tableColumn0.setCellValueFactory(new MapValueFactory<>("name"));
             TableColumn<Map, Integer> tableColumn1 = new TableColumn<>("age");
             tableColumn1.setCellValueFactory(new MapValueFactory<>("age"));
@@ -398,6 +400,15 @@ public class TableViewMatchersTest extends FxRobot {
                 "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
 
         assertThat(tableView, TableViewMatchers.containsRow(63, "deedee"));
+    }
+
+    /**
+     * @see <a href="https://github.com/TestFX/TestFX/issues/541">Issue #541</a>
+     */
+    @Test
+    public void shouldQueryTableHeader() {
+        assertThat(lookup("#tableColumn0").query().getStyleClass(), hasItem("column-header"));
+        assertThat(lookup("#tableColumn0").tryQuery().get().getStyleClass(), hasItem("column-header"));
     }
 
     @Test


### PR DESCRIPTION
Add a note to the Javadocs of each method in NodeQuery that returns the
"first" node that the order relies on the order of Node.lookupAll(..)
which could possibly change in the future.

Fixes #541