### PR TITLE
(fix) Test FxRobot.push(..) with shortcut combo.

### DIFF
--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
@@ -51,6 +51,7 @@ public class MenuBarTest {
     FxRobot fxRobot = new FxRobot();
     Menu editMenu;
     CountDownLatch newMenuShownLatch = new CountDownLatch(1);
+    CountDownLatch saveAsActionLatch = new CountDownLatch(1);
     CountDownLatch editMenuShownLatch = new CountDownLatch(1);
 
     @BeforeClass
@@ -73,6 +74,7 @@ public class MenuBarTest {
             saveAsItem.setId("saveAsItem");
             saveAsItem.setAccelerator(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN,
                     KeyCombination.CONTROL_DOWN));
+            saveAsItem.setOnAction(event -> saveAsActionLatch.countDown());
             fileMenu.getItems().add(saveAsItem);
 
             editMenu = new Menu("Edit");
@@ -99,7 +101,7 @@ public class MenuBarTest {
      * @see <a href="https://github.com/TestFX/TestFX/issues/309">Issue #309</a>
      */
     @Test
-    public void should_move_vertically_first() throws Exception {
+    public void should_move_vertically_first() throws InterruptedException {
         // First we show that it is indeed the case that {@code editMenu} is triggered when moving directly:
         editMenu.setOnShown(event -> editMenuShownLatch.countDown());
         fxRobot.clickOn("#fileMenu").clickOn("#newItem", Motion.DIRECT);
@@ -110,5 +112,11 @@ public class MenuBarTest {
         // uses Motion.VERTICAL_FIRST because "#newItem" is a MenuItem.
         fxRobot.clickOn("#fileMenu").clickOn("#newItem");
         verifyThat(newMenuShownLatch.await(3, TimeUnit.SECONDS), is(true), informedErrorMessage(fxRobot));
+    }
+
+    @Test
+    public void shortcut_accelerator() throws InterruptedException {
+        fxRobot.push(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN));
+        verifyThat(saveAsActionLatch.await(3, TimeUnit.SECONDS), is(true), informedErrorMessage(fxRobot));
     }
 }


### PR DESCRIPTION
From gitter:

```
Danny Gonzalez
@dannyagonzalez_twitter
Trying to execute file open on an application I’m testing with FxRobot. The menu item has an accelerator set to KeyCodeCombination(KeyCode.O, KeyCombination.SHORTCUT_DOWN). When I use FxRobot.push(new KeyCodeCombination(KeyCode.O, KeyCombination.SHORTCUT_DOWN)) this seems to work fine on Windows but not on the Mac, any reason why?
```