### PR TITLE
589 shortcut

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -515,7 +515,7 @@ public class FxRobot implements FxRobotInterface {
         context.getSleepRobot().sleep(duration, timeUnit);
         return this;
     }
-
+ 
     @Override
     @Deprecated
     public FxRobot scroll(int amount) {

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -31,7 +31,15 @@ import org.testfx.util.WaitForAsyncUtils;
 
 public class KeyboardRobotImpl implements KeyboardRobot {
 
-    protected static final KeyCode OS_SPECIFIC_SHORTCUT = System.getProperty("os.name").toLowerCase(Locale.US)
+    /**
+    * This key is sent depending on the platform via the Robot to Java.
+    */
+    private static final KeyCode OS_SPECIFIC_SHORTCUT = System.getProperty("os.name").toLowerCase(Locale.US)
+            .startsWith("mac") ? KeyCode.META : KeyCode.CONTROL;
+    /**
+    * This key is received by key listeners as os specific shortcut key.
+    */
+    protected static final KeyCode OS_SHORTCUT = System.getProperty("os.name").toLowerCase(Locale.US)
             .startsWith("mac") ? KeyCode.COMMAND : KeyCode.CONTROL;
 
     private final BaseRobot baseRobot;

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -36,11 +36,6 @@ public class KeyboardRobotImpl implements KeyboardRobot {
     */
     private static final KeyCode OS_SPECIFIC_SHORTCUT = System.getProperty("os.name").toLowerCase(Locale.US)
             .startsWith("mac") ? KeyCode.META : KeyCode.CONTROL;
-    /**
-    * This key is received by key listeners as os specific shortcut key.
-    */
-    protected static final KeyCode OS_SHORTCUT = System.getProperty("os.name").toLowerCase(Locale.US)
-            .startsWith("mac") ? KeyCode.COMMAND : KeyCode.CONTROL;
 
     private final BaseRobot baseRobot;
     private final Set<KeyCode> pressedKeys = ConcurrentHashMap.newKeySet();

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -35,7 +35,7 @@ public class KeyboardRobotImpl implements KeyboardRobot {
     * This key is sent depending on the platform via the Robot to Java.
     */
     private static final KeyCode OS_SPECIFIC_SHORTCUT = System.getProperty("os.name").toLowerCase(Locale.US)
-            .startsWith("mac") ? KeyCode.META : KeyCode.CONTROL;
+            .startsWith("mac") ? KeyCode.COMMAND : KeyCode.CONTROL;
 
     private final BaseRobot baseRobot;
     private final Set<KeyCode> pressedKeys = ConcurrentHashMap.newKeySet();

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -41,7 +41,7 @@ public class KeyboardRobotImpl implements KeyboardRobot {
         Objects.requireNonNull(baseRobot, "baseRobot must not be null");
         this.baseRobot = baseRobot;
     }
-
+ 
     @Override
     public void press(KeyCode... keys) {
         pressNoWait(keys);

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
@@ -38,7 +38,7 @@ public class MouseRobotImpl implements MouseRobot {
         Objects.requireNonNull(baseRobot, "baseRobot must not be null");
         this.baseRobot = baseRobot;
     }
-
+ 
     @Override
     public void press(MouseButton... buttons) {
         pressNoWait(buttons);

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
@@ -63,11 +63,17 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
 
     @Override
     public void keyPress(KeyCode key) {
+        if (key == KeyCode.COMMAND) {
+            key = KeyCode.META;
+        }
         useRobot().keyPress(convertToKeyCodeId(key));
     }
 
     @Override
     public void keyRelease(KeyCode key) {
+        if (key == KeyCode.COMMAND) {
+            key = KeyCode.META;
+        }
         useRobot().keyRelease(convertToKeyCodeId(key));
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -43,7 +43,6 @@ import static javafx.scene.input.KeyCode.SHORTCUT;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.robot.impl.KeyboardRobotImpl.OS_SHORTCUT;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 /**
@@ -71,8 +70,12 @@ public class ShortcutKeyTest extends FxRobot {
             box = new VBox();
             field = new TextField(initialText);
             field.setOnKeyPressed(e -> {
-                System.out.println(e.getCode().getName() + " " + e.isShortcutDown());
-                if (e.getCode() == OS_SHORTCUT && e.isShortcutDown()) { // e.isShortcutDown()
+                // System.out.println(e.getCode().getName() + " " + e.isShortcutDown());
+                // On macOS, depending on the system either KeyCode.META or KeyCode.COMMAND is reported see #589
+                if (((e.getCode() == KeyCode.CONTROL)  || 
+                        (e.getCode() == KeyCode.META) || 
+                        (e.getCode() == KeyCode.COMMAND)
+                        ) && e.isShortcutDown()) {
                     field.setText(pressedText);
                 } else {
                     field.setText(e.getCode().toString());
@@ -80,7 +83,10 @@ public class ShortcutKeyTest extends FxRobot {
                 e.consume();
             });
             field.setOnKeyReleased(e -> {
-                if (e.getCode() == OS_SHORTCUT && !e.isShortcutDown()) {
+                if (((e.getCode() == KeyCode.CONTROL)  || 
+                        (e.getCode() == KeyCode.META) || 
+                        (e.getCode() == KeyCode.COMMAND)
+                        ) && !e.isShortcutDown()) {
                     field.setText(releasedText);
                 } else {
                     field.setText(e.getCode().toString());

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -83,6 +83,8 @@ public class ShortcutKeyTest extends FxRobot {
                 e.consume();
             });
             field.setOnKeyReleased(e -> {
+                // System.out.println(e.getCode().getName() + " " + e.isShortcutDown());
+                // On macOS, depending on the system either KeyCode.META or KeyCode.COMMAND is reported see #589
                 if (((e.getCode() == KeyCode.CONTROL)  || 
                         (e.getCode() == KeyCode.META) || 
                         (e.getCode() == KeyCode.COMMAND)

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -20,6 +20,11 @@ import java.util.concurrent.TimeoutException;
 
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.VBox;
 
 import org.junit.After;
 import org.junit.Before;
@@ -38,7 +43,7 @@ import static javafx.scene.input.KeyCode.SHORTCUT;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 import static org.testfx.api.FxAssert.verifyThat;
-import static org.testfx.robot.impl.KeyboardRobotImpl.OS_SPECIFIC_SHORTCUT;
+import static org.testfx.robot.impl.KeyboardRobotImpl.OS_SHORTCUT;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
 
 /**
@@ -50,34 +55,42 @@ public class ShortcutKeyTest extends FxRobot {
     @Rule
     public TestRule rule = RuleChain.outerRule(new TestFXRule()).around(Timeout.millis(3000));
 
+    private VBox box;
     private TextField field;
+    private TextField field1;
+    private TextField field2;
+    private final String initialText = "no action";
     private final String pressedText = "pressed";
     private final String releasedText = "released";
+    private final String emptyText = "";
 
     @Before
     public void setup() throws TimeoutException {
         FxToolkit.registerPrimaryStage();
         FxToolkit.setupStage(stage -> {
-            field = new TextField("not pressed");
+            box = new VBox();
+            field = new TextField(initialText);
             field.setOnKeyPressed(e -> {
-                if (e.getCode().equals(OS_SPECIFIC_SHORTCUT)) {
+                System.out.println(e.getCode().getName() + " " + e.isShortcutDown());
+                if (e.getCode() == OS_SHORTCUT && e.isShortcutDown()) { // e.isShortcutDown()
                     field.setText(pressedText);
-                }
-                else {
+                } else {
                     field.setText(e.getCode().toString());
                 }
                 e.consume();
             });
             field.setOnKeyReleased(e -> {
-                if (e.getCode().equals(OS_SPECIFIC_SHORTCUT)) {
+                if (e.getCode() == OS_SHORTCUT && !e.isShortcutDown()) {
                     field.setText(releasedText);
-                }
-                else {
+                } else {
                     field.setText(e.getCode().toString());
                 }
                 e.consume();
             });
-            stage.setScene(new Scene(field));
+            field1 = new TextField(initialText);
+            field2 = new TextField(emptyText);
+            box.getChildren().addAll(field, field1, field2);
+            stage.setScene(new Scene(box));
             stage.show();
             field.requestFocus();
         });
@@ -88,30 +101,61 @@ public class ShortcutKeyTest extends FxRobot {
     @After
     public void cleanup() {
         // prevent hanging if test fails
-        release(SHORTCUT, OS_SPECIFIC_SHORTCUT);
+        release(SHORTCUT, KeyCode.A, KeyCode.C, KeyCode.V);
     }
 
+    /**
+     * Verifies that that the correct key is received and that the method KeyEvent.isShortcutDown works.
+     */
     @Test
     public void shortcut_keyCode_converts_to_OS_specific_keyCode_when_pressed() {
         // when:
-        press(SHORTCUT);
+        press(KeyCode.SHORTCUT);
 
         // then:
         verifyThat(field.getText(), equalTo(pressedText), informedErrorMessage(this));
     }
 
+    /**
+     * Verifies that that the correct key is received and that the method KeyEvent.isShortcutDown works.
+     */
     @Test
-    public void shortcut_keyCode_converts_to_OS_specific_keyCode_when_released() {
+    public void shortcut_keyCode_converts_to_OS_specific_keyCode_when_released() { //fix 589, 590
         // given:
-        press(OS_SPECIFIC_SHORTCUT);
+        press(KeyCode.SHORTCUT);
 
         // and:
         verifyThat(field.getText(), equalTo(pressedText), informedErrorMessage(this));
 
         // when:
-        release(SHORTCUT);
+        release(KeyCode.SHORTCUT);
 
         // then:
         verifyThat(field.getText(), equalTo(releasedText), informedErrorMessage(this));
     }
+    
+    /**
+     * Test that the KeyCombinations do work (copy paste)
+     */
+    @Test
+    public void shortcut_keyCode_copy_paste() {
+        //given:
+        verifyThat(field1.getText(), equalTo(initialText), informedErrorMessage(this));
+        verifyThat(field2.getText(), equalTo(emptyText), informedErrorMessage(this));
+
+
+        //when:
+        clickOn(field1, MouseButton.PRIMARY);
+        clickOn(field1, MouseButton.PRIMARY);
+        robotContext().getTypeRobot().push(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN));
+        robotContext().getTypeRobot().push(new KeyCodeCombination(KeyCode.C, KeyCombination.SHORTCUT_DOWN));
+        clickOn(field2, MouseButton.PRIMARY);
+        field2.requestFocus();
+        robotContext().getTypeRobot().push(new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN));
+        
+        //then:
+        verifyThat(field2.getText(), equalTo(initialText), informedErrorMessage(this));
+        
+    }
+    
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
@@ -152,7 +152,7 @@ public class PointLocatorImplTest {
         // then:
         assertThat(point, CoreMatchers.equalTo(topLeftPointFrom(windowBounds)));
     }
-
+ 
     @Test
     public void pointFor_Window_atOffset_afterChange() {
         // given:


### PR DESCRIPTION
## Issue
Command-Key handling on mac. On my platform the tests in `ShortcutKeyTest.java` on master fail. I guess they are running on Travis somehow. There are pretty much issues relating to the mac `SHORTCUT` key (#589, #436, #590).

Per specification, the `COMMAND`-Key on Mac does map to the `META` KeyCode in Java. The CONTROL key on Windows, well to the `CONTROL` KeyCode. Both Map to the `SHORTCUT` KeyCode in Java. The `SHORTCUT` is a generated Property by the JVM (a virtual, non existing key), it may not be used as real input. 

## Behaviour of KeyCodes on macOS

- `press(KeyCode.META)` - Received by KeyEvent: `KeyCode.COMMAND`, `e.isShortShortcutDown()`: true
- `press(KeyCode.SHORTCUT)` - Received by KeyEvent: `KeyCode.A`, `e.isShortShortcutDown()`: false (That's where all those 'a's in my text editor come from after running TestFX-Tests)
- `press(KeyCode.CONTROL)` - Received by KeyEvent: `KeyCode.Ctrl`, `e.isShortShortcutDown()`: false
- `press(KeyCode.COMMAND)` - Received by KeyEvent: nothing at all

## Expected Behavior

- `SHORTCUT+A`, `SHORTCUT+C`, `SHORTCUT+V` (...) should work
- the method KeyEvent.isShortcutDown() should actually return true while pressed (currently it returns false)
- KeyCode Combinations should work (e.g. robotContext().getTypeRobot().push(new KeyCodeCombination(KeyCode.O, KeyCombination.SHORTCUT_DOWN));) (#590, #589)

## Solution
Sending `KeyCode.META` (macOS) and receiving `KeyCode.COMMAND`. Added test for the other points too.

## Related issues
fixes #589 #590  (forgot to close in commit message)
partially #436 