### PR TITLE
(fix) typing of characters in the background

### DIFF
--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
@@ -16,15 +16,42 @@
  */
 package org.testfx.cases;
 
+import java.util.List; //checkstyle needs one line between javafx and any group before it
+
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+
 import org.junit.BeforeClass;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 
 public abstract class TestCaseBase extends FxRobot {
 
+    // Provide some background component for the basic test, that can fetch
+    // some key and mouse events...
     @BeforeClass
     public static void baseSetupSpec() throws Exception {
         FxToolkit.registerPrimaryStage();
+        FxToolkit.setupStage(stage -> {
+            Region region = new Region();
+            List.class.getName(); //and we need to use that package (check style)
+            String bg = "-fx-background-color: magenta;";
+            region.setStyle(bg);
+    
+            VBox box = new VBox(region);
+            box.setPadding(new Insets(10));
+            box.setSpacing(10);
+            VBox.setVgrow(region, Priority.ALWAYS);
+    
+            StackPane sceneRoot = new StackPane(box);
+            Scene scene = new Scene(sceneRoot, 300, 100);
+            stage.setScene(scene);
+            stage.show();
+        });
     }
 
 }


### PR DESCRIPTION
## Issue

Text is typed in my editor when running the testFX testsuite (see #593).

## Solution

Added a component in the background for the basic tests.

## Open issue

I needed to add (and use) a java package, as checkstyle wants to have a line between javafx imports and the (not existing) group before it.

fixes #593 