### PR TITLE
Refactoring HDPI

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/internal/JavaVersionAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/internal/JavaVersionAdapter.java
@@ -181,7 +181,7 @@ public final class JavaVersionAdapter {
      * See the License for the specific language governing permissions and
      * limitations under the License.
      */
-    private static JavaVersion currentVersion() {
+    public static JavaVersion currentVersion() {
         if (currentJavaVersion == null) {
             currentJavaVersion = toVersion(System.getProperty("java.version"));
         }
@@ -228,7 +228,7 @@ public final class JavaVersionAdapter {
      * Before 9: http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
      * 9+: http://openjdk.java.net/jeps/223
      */
-    private enum JavaVersion {
+    public enum JavaVersion {
         VERSION_1_1, VERSION_1_2, VERSION_1_3, VERSION_1_4,
         VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8,
         VERSION_1_9, VERSION_1_10, VERSION_11, VERSION_HIGHER;

--- a/subprojects/testfx-core/src/main/java/org/testfx/internal/PlatformAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/internal/PlatformAdapter.java
@@ -1,0 +1,39 @@
+package org.testfx.internal;
+
+import java.util.Locale;
+
+/**
+ * Provides an API for platform specific features
+ * 
+ */
+public class PlatformAdapter {
+
+    /**
+     * Stores the operating system we are running on. Shouldn't change during
+     * execution, so singleton.
+     */
+    private static OS os;
+
+    /**
+     * Gets the operting system
+     * 
+     * @return the operating system
+     */
+    public static OS getOs() {
+        if (os == null) {
+            if (System.getProperty("os.name").toLowerCase(Locale.US).contains("nux")) {
+                os = OS.unix;
+            } else if (System.getProperty("os.name").toLowerCase(Locale.US).startsWith("win")) {
+                os = OS.windows;
+            } else {
+                os = OS.mac;
+            }
+        }
+        return os;
+    }
+
+    public static enum OS {
+        windows, unix, mac
+    }
+
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/RobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/RobotAdapter.java
@@ -23,20 +23,105 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.paint.Color;
 
+/**
+ * The common interface for all RobotAdapters.<br>
+ * These are the minimum set of functions required from a robot to provide the
+ * full functionality use in the higher level api.
+ * 
+ * <h2>Threading</h2>
+ * The caller of the Adapter usually doesn't run on the FX-Application Thread.
+ * If required, the implementation of this class will schedule the actions on the 
+ * FX-Application Thread.
+ *
+ * @param <T> the type of the implementing robot class
+ */
 public interface RobotAdapter<T> {
+    /**
+     * Creates a robot.
+     */
     void robotCreate();
+
+    /**
+     * Destroys the robot
+     */
     void robotDestroy();
+
+    /**
+     * Gets a instance of this Robot
+     * 
+     * @return a instance of this robot
+     */
     T getRobotInstance();
 
+    /**
+     * Function used to make the robot press a key. The key must be a physical
+     * existing key on the keyboard.
+     * 
+     * @param key the key to press (must exist on a keyboard)
+     */
     void keyPress(KeyCode key);
+
+    /**
+     * Function used to make the robot release a key. The key must be a physical
+     * existing key on the keyboard.
+     * 
+     * @param key the key to press (must exist on a keyboard)
+     */
     void keyRelease(KeyCode key);
 
+    /**
+     * Returns the current position of the cursor in JavaFx coordinates
+     * 
+     * @return the current position of the mouse cursor
+     */
     Point2D getMouseLocation();
+
+    /**
+     * Moves the mouse cursor to the given position in JavaFx coordinates
+     * 
+     * @param location the location in JavaFx coordinates to move the cursor to
+     */
     void mouseMove(Point2D location);
+
+    /**
+     * Makes the robot press a mouse button.
+     * 
+     * @param button the button to press
+     */
     void mousePress(MouseButton button);
+
+    /**
+     * Makes the robot release a mouse button.
+     * 
+     * @param button the button to release
+     */
     void mouseRelease(MouseButton button);
+
+    /**
+     * Makes the robot to simulate a action of the mouse wheel.<br>
+     * Negative values indicate movement up/away from the user, positive values
+     * indicate movement down/towards the user.
+     * 
+     * @param wheelAmount the amount to scroll
+     */
     void mouseWheel(int wheelAmount);
 
+    /**
+     * Gets the color of a pixel at the given JavaFx coordinates. The returned Color
+     * is in the JavaFx color space. //TODO Due to technical reasons, there might be
+     * a deviation in color.
+     * 
+     * @param location of the pixel in JavaFx coordinates, to retrieve the color for
+     * @return the Color of the given Pixel in the JavaFx color space
+     */
     Color getCapturePixelColor(Point2D location);
+
+    /**
+     * Captures a region of the screen. The returned Image is in the JavaFx color
+     * space. //TODO Due to technical reasons, there might be a deviation.
+     * 
+     * @param region the region to capture in JavaFx coordinates
+     * @return a image of the region
+     */
     Image getCaptureRegion(Rectangle2D region);
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
@@ -38,6 +38,7 @@ import javafx.scene.paint.Color;
 
 import org.testfx.internal.JavaVersionAdapter;
 import org.testfx.internal.PlatformAdapter;
+import org.testfx.internal.PlatformAdapter.OS;
 import org.testfx.service.adapter.RobotAdapter;
 
 import static org.testfx.internal.JavaVersionAdapter.convertToKeyCodeId;
@@ -110,8 +111,8 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
 
     @Override
     public Color getCapturePixelColor(Point2D location) {
-        final Rectangle2D scaled = scaleRect(new Rectangle2D(location.getX(), location.getY(), 0, 0));
-        Rectangle2D region = new Rectangle2D(scaled.getMinX(), scaled.getMinY(), 1, 1);
+        //captureRegion does scaling already
+        final Rectangle2D region = new Rectangle2D(location.getX(), location.getY(), 2, 2);
         Image image = getCaptureRegion(region);
         return image.getPixelReader().getColor(0, 0);
     }
@@ -200,10 +201,11 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
     }
     
     protected boolean scaleRequired() {
-        return !(PlatformAdapter.getOs() == PlatformAdapter.OS.mac ||
-                PlatformAdapter.getOs() == PlatformAdapter.OS.unix) &&
-                // just prevent unnecessary transforms...
-                (JavaVersionAdapter.getScreenScaleX() != 1.0 && JavaVersionAdapter.getScreenScaleY() != 1.0);
+        // MacOS Awt is not covered by the build server.
+        // Do not remove, if not testing on a headed mac with java 10 or above.
+        return PlatformAdapter.getOs() != OS.mac &&
+            // just prevent unnecessary transforms...
+            JavaVersionAdapter.getScreenScaleX() != 1.0 && JavaVersionAdapter.getScreenScaleY() != 1.0;
     }
     
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -204,7 +204,8 @@ public class GlassRobotAdapter implements RobotAdapter<Robot> {
     
     // scale
     protected Rectangle2D scaleRect(Rectangle2D rect) {
-        if (PlatformAdapter.getOs() == PlatformAdapter.OS.mac) {
+        if (PlatformAdapter.getOs() == PlatformAdapter.OS.mac ||
+                PlatformAdapter.getOs() == PlatformAdapter.OS.windows) {
             return rect;
         }
         double factorX = JavaVersionAdapter.getScreenScaleX();
@@ -214,7 +215,8 @@ public class GlassRobotAdapter implements RobotAdapter<Robot> {
     }
 
     protected Point2D scaleInverseRect(Point2D pt) {
-        if (PlatformAdapter.getOs() == PlatformAdapter.OS.mac) {
+        if (PlatformAdapter.getOs() == PlatformAdapter.OS.mac ||
+                PlatformAdapter.getOs() == PlatformAdapter.OS.windows) {
             return pt;
         }
         double factorX = JavaVersionAdapter.getScreenScaleX();

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -30,6 +30,10 @@ import javafx.scene.paint.Color;
 import com.sun.glass.ui.Application;
 import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.Robot;
+
+import org.testfx.internal.JavaVersionAdapter;
+import org.testfx.internal.PlatformAdapter;
+import org.testfx.internal.PlatformAdapter.OS;
 import org.testfx.service.adapter.RobotAdapter;
 
 import static org.testfx.internal.JavaVersionAdapter.convertToKeyCodeId;
@@ -77,6 +81,16 @@ public class GlassRobotAdapter implements RobotAdapter<Robot> {
 
     @Override
     public Point2D getMouseLocation() {
+        // note the current (10.0.2) behavior below is quite inconsistent (no scaling on
+        // set, but scaling on read) this might change in the future
+        // please keep backwards compatibility to the last version with this behavior in
+        // this case
+        if (PlatformAdapter.getOs() == OS.unix &&
+                Integer.parseInt(JavaVersionAdapter.currentVersion().getMajorVersion()) > 8) {
+            return waitForAsyncFx(RETRIEVAL_TIMEOUT_IN_MILLIS,
+                () -> new Point2D(useRobot().getMouseX() / JavaVersionAdapter.getScreenScaleX(),
+                useRobot().getMouseY() / JavaVersionAdapter.getScreenScaleY()));
+        }
         return waitForAsyncFx(RETRIEVAL_TIMEOUT_IN_MILLIS,
             () -> scaleInverseRect(new Point2D(useRobot().getMouseX(), useRobot().getMouseY())));
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -118,7 +118,8 @@ public class GlassRobotAdapter implements RobotAdapter<Robot> {
 
     @Override
     public Image getCaptureRegion(Rectangle2D region) {
-        final Rectangle2D scaled = scaleRect(new Rectangle2D(region.getMinX(), region.getMinY(), region.getWidth(), region.getHeight()));
+        final Rectangle2D scaled = scaleRect(
+                new Rectangle2D(region.getMinX(), region.getMinY(), region.getWidth(), region.getHeight()));
         return waitForAsyncFx(RETRIEVAL_TIMEOUT_IN_MILLIS, () -> {
             Pixels glassPixels = useRobot().getScreenCapture(
                     (int) scaled.getMinX(), (int) scaled.getMinY(),
@@ -129,7 +130,8 @@ public class GlassRobotAdapter implements RobotAdapter<Robot> {
     }
     
     public Image getCaptureRegionRaw(Rectangle2D region) {
-        final Rectangle2D scaled = scaleRect(new Rectangle2D(region.getMinX(), region.getMinY(), region.getWidth(), region.getHeight()));
+        final Rectangle2D scaled = scaleRect(
+                new Rectangle2D(region.getMinX(), region.getMinY(), region.getWidth(), region.getHeight()));
         return waitForAsyncFx(RETRIEVAL_TIMEOUT_IN_MILLIS, () -> {
             Pixels glassPixels = useRobot().getScreenCapture(
                     (int) scaled.getMinX(), (int) scaled.getMinY(),

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -30,8 +30,6 @@ import javafx.scene.paint.Color;
 import com.sun.glass.ui.Application;
 import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.Robot;
-import org.testfx.internal.JavaVersionAdapter;
-import org.testfx.internal.PlatformAdapter;
 import org.testfx.service.adapter.RobotAdapter;
 
 import static org.testfx.internal.JavaVersionAdapter.convertToKeyCodeId;
@@ -203,25 +201,14 @@ public class GlassRobotAdapter implements RobotAdapter<Robot> {
     }
     
     // scale
-    protected Rectangle2D scaleRect(Rectangle2D rect) {
-        if (PlatformAdapter.getOs() == PlatformAdapter.OS.mac ||
-                PlatformAdapter.getOs() == PlatformAdapter.OS.windows) {
-            return rect;
-        }
-        double factorX = JavaVersionAdapter.getScreenScaleX();
-        double factorY = JavaVersionAdapter.getScreenScaleY();
-        return new Rectangle2D(rect.getMinX() * factorX, rect.getMinY() * factorY, rect.getWidth() * factorX,
-                rect.getHeight() * factorY);
+    protected Rectangle2D scaleRect(Rectangle2D rect) { 
+        //no scaling at all for currently tested environments
+        return rect;
     }
 
-    protected Point2D scaleInverseRect(Point2D pt) {
-        if (PlatformAdapter.getOs() == PlatformAdapter.OS.mac ||
-                PlatformAdapter.getOs() == PlatformAdapter.OS.windows) {
-            return pt;
-        }
-        double factorX = JavaVersionAdapter.getScreenScaleX();
-        double factorY = JavaVersionAdapter.getScreenScaleY();
-        return new Point2D(pt.getX() / factorX, pt.getY() / factorY);
+    protected Point2D scaleInverseRect(Point2D pt) { 
+        //no scaling at all for currently tested environments
+        return pt;
     }
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
@@ -81,11 +81,13 @@ public class JavafxRobotAdapter implements RobotAdapter<JavafxRobotAdapter> {
         return null;
     }
 
+    @Override
     public void keyPress(KeyCode key) {
         asyncFx(() -> Event.fireEvent(getEventTarget(scene), createKeyEvent(
                 KeyEvent.KEY_PRESSED, key, "")));
     }
 
+    @Override
     public void keyRelease(KeyCode key) {
         asyncFx(() -> Event.fireEvent(getEventTarget(scene), createKeyEvent(
                 KeyEvent.KEY_RELEASED, key, "")));
@@ -97,10 +99,12 @@ public class JavafxRobotAdapter implements RobotAdapter<JavafxRobotAdapter> {
                 KeyEvent.KEY_TYPED, key, character)));
     }
 
+    @Override
     public Point2D getMouseLocation() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public void mouseMove(Point2D location) {
         asyncFx(() -> Event.fireEvent(getEventTarget(scene), createMouseEvent(MouseEvent.MOUSE_MOVED,
                 (int) location.getX(), (int) location.getY(), lastButtonPressed, 0)));
@@ -124,10 +128,12 @@ public class JavafxRobotAdapter implements RobotAdapter<JavafxRobotAdapter> {
                 sceneMouseX, sceneMouseY, button, clickCount)));
     }
 
+    @Override
     public void mousePress(MouseButton button) {
         mousePress(button, 1);
     }
 
+    @Override
     public void mouseRelease(MouseButton button) {
         mouseRelease(button, 1);
     }
@@ -141,10 +147,12 @@ public class JavafxRobotAdapter implements RobotAdapter<JavafxRobotAdapter> {
                 sceneMouseX, sceneMouseY, button, 0)));
     }
 
+    @Override
     public void mouseWheel(int wheelAmount) {
         asyncFx(() -> Event.fireEvent(getEventTarget(scene), createScrollEvent(wheelAmount)));
     }
 
+    @Override
     public Color getCapturePixelColor(Point2D location) {
         if (!Platform.isFxApplicationThread()) {
             throw new RuntimeException("JavafxRobotAdapter#getCapturePixelColor(..) must be called on JavaFX " +
@@ -154,6 +162,7 @@ public class JavafxRobotAdapter implements RobotAdapter<JavafxRobotAdapter> {
         return snapshot.getPixelReader().getColor((int) location.getX(), (int) location.getY());
     }
 
+    @Override
     public Image getCaptureRegion(Rectangle2D region) {
         if (!Platform.isFxApplicationThread()) {
             throw new RuntimeException("JavafxRobotAdapter#getCaptureRegion(..) must be called on JavaFX " +

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/BoundsLocatorImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/BoundsLocatorImpl.java
@@ -16,19 +16,14 @@
  */
 package org.testfx.service.locator.impl;
 
-import java.util.Locale;
-
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.Window;
 
-import org.testfx.internal.JavaVersionAdapter;
 import org.testfx.service.locator.BoundsLocator;
 import org.testfx.service.locator.BoundsLocatorException;
-
-import static org.testfx.util.BoundsQueryUtils.scale;
 
 public class BoundsLocatorImpl implements BoundsLocator {
 
@@ -75,17 +70,7 @@ public class BoundsLocatorImpl implements BoundsLocator {
     public Bounds boundsOnScreenFor(Bounds boundsInScene, Scene scene) {
         Bounds windowBounds = boundsInWindowFor(boundsInScene, scene);
         Window window = scene.getWindow();
-        if (System.getProperty("testfx.robot", "awt").equalsIgnoreCase("glass")) {
-            return scale(translateBounds(windowBounds, window.getX(), window.getY()));
-        } else {
-            if (JavaVersionAdapter.getScreenScaleX() != 1 || JavaVersionAdapter.getScreenScaleY() != 1) {
-                if (System.getProperty("os.name").toLowerCase(Locale.US).contains("nux") ||
-                        System.getProperty("os.name").toLowerCase(Locale.US).startsWith("win")) {
-                    return scale(translateBounds(windowBounds, window.getX(), window.getY()));
-                }
-            }
-            return translateBounds(windowBounds, window.getX(), window.getY());
-        }
+        return translateBounds(windowBounds, window.getX(), window.getY());
     }
 
     private Bounds limitToVisibleBounds(Bounds boundsInScene, Scene scene) {

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
@@ -18,19 +18,26 @@ package org.testfx.cases;
 
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
 
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
+import org.testfx.util.WaitForAsyncUtils;
 
 public abstract class TestCaseBase extends FxRobot {
 
-    @BeforeClass
-    public static void baseSetupSpec() throws Exception {
+    protected Stage blockStage;
+    
+    @Before
+    public void baseSetupSpec() throws Exception {
         FxToolkit.registerPrimaryStage();
 
         // Provide some background component for the basic test, that can fetch
@@ -52,5 +59,20 @@ public abstract class TestCaseBase extends FxRobot {
             stage.show();
         });
     }
+    
+    @After
+    public final void tearDown() throws Throwable {
+        if (blockStage != null) {
+            interact(() -> blockStage.close());
+        }
+        // release all keys
+        release(new KeyCode[0]);
+        // release all mouse buttons
+        release(new MouseButton[0]);
+        FxToolkit.cleanupStages();
+        WaitForAsyncUtils.checkException();
+    }
 
+    
+    
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
@@ -1,0 +1,611 @@
+package org.testfx.cases.integration;
+
+import java.util.List;
+import javafx.event.EventHandler;
+import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelReader;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+import org.junit.After;
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.internal.JavaVersionAdapter;
+import org.testfx.internal.PlatformAdapter;
+import org.testfx.internal.PlatformAdapter.OS;
+import org.testfx.service.adapter.RobotAdapter;
+import org.testfx.service.adapter.impl.AwtRobotAdapter;
+import org.testfx.service.adapter.impl.GlassRobotAdapter;
+import org.testfx.service.locator.impl.BoundsLocatorImpl;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the contract for HDPI (and normal resolution).<br>
+ * The contract is:
+ * <ul>
+ * <li>The higher level components work with JavaFx coordinates</li>
+ * <li>The RobotAdapter translates to screen coordinates if required</li>
+ * </ul>
+ * 
+ */
+public class HDPIContractTest extends FxRobot {
+
+    List<RobotAdapter<?>> adapters;
+    Stage stage;
+    Scene scene;
+    Pane root;
+    Rectangle topLeft;
+    Rectangle topRight;
+    Rectangle bottomLeft;
+    Rectangle bottomRight;
+
+    AwtRobotAdapter awtAdapter;
+    GlassRobotAdapter glassAdapter;
+    
+    private long waitBetween = 200;
+
+    @Before
+    public void setupHDPI() throws Exception {
+        FxToolkit.registerPrimaryStage();
+
+        // Provide some background component for the basic test, that can fetch
+        // some key and mouse events.
+        // See issue #593 (https://github.com/TestFX/TestFX/issues/593).
+        FxToolkit.setupStage(stage -> {
+            this.stage = new Stage(); //don't mess up the primary stage!
+            this.stage.initStyle(StageStyle.UNDECORATED);
+            root = new Pane();
+            String bg = "-fx-background-color: magenta;";
+            root.setStyle(bg);
+
+            bg = "-fx-background-color: black;";
+            topLeft = new Rectangle(0, 0, 5, 5);
+            topLeft.setStyle(bg);
+            root.getChildren().add(topLeft);
+
+            topRight = new Rectangle(95, 0, 5, 5);
+            topRight.setStyle(bg);
+            root.getChildren().add(topRight);
+
+            bottomLeft = new Rectangle(0, 95, 5, 5);
+            bottomLeft.setStyle(bg);
+            root.getChildren().add(bottomLeft);
+
+            bottomRight = new Rectangle(95, 95, 5, 5);
+            bottomRight.setStyle(bg);
+            root.getChildren().add(bottomRight);
+
+            scene = new Scene(root);
+            this.stage.setScene(scene);
+            this.stage.show();
+        });
+        initRobots();
+        System.out.println("JavaVersion: " + System.getProperty("java.version"));
+        System.out.println("Java scaling x=" + JavaVersionAdapter.getScreenScaleX() + 
+                "Java scaling y=" + JavaVersionAdapter.getScreenScaleY());
+    }
+    
+    @After
+    public void tearDownHDPI() throws Throwable {
+        interact(() -> stage.close());
+        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.checkException();
+    }
+
+    public void initRobots() {
+        try {
+            awtAdapter = new AwtRobotAdapter();
+        } 
+        catch (Exception e) {
+            System.out.println("AwtRobotAdapter seems to be not supported on this Platform");
+        }
+        try {
+            glassAdapter = new GlassRobotAdapter();
+        } 
+        catch (Exception e) {
+            System.out.println("GlassRobotAdapter seems to be not supported on this Platform");
+        }
+    }
+
+    /**
+     * Checks that same location is returned, so if set location works in JavaFx
+     * Coordinates, the robot is consistent.
+     */
+    public void mouseLocationAdapterTest(RobotAdapter<?> adapter) {
+        Point2D testPt = new Point2D(100, 100);
+        adapter.mouseMove(testPt);
+        sleep(waitBetween); //ensure there are no timing issues
+        Point2D readPt = adapter.getMouseLocation();
+        System.out.println("TestMouse for " + adapter.getClass().getSimpleName() + " is " + readPt);
+        assertThat("Move and read back failed for " + adapter.getClass().getSimpleName(), readPt, equalTo(testPt));
+    }
+
+    @Test
+    public void mouseLocationAwtAdapterTest() {
+        try {
+            mouseLocationAdapterTest(awtAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    @Test
+    public void mouseLocationGlassAdapterTest() {
+        try {
+            mouseLocationAdapterTest(glassAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    /**
+     * Checks that returned bounds are in JavaFx coordinates, as a offset of (0,0)
+     * is used, the coordinates of the window do not affect the result.<br>
+     * If the Robot hits those Points, the Robot is definitely working correct in
+     * JavaFx coordinates.
+     */
+    public void nullOffsetAdapterTest(RobotAdapter<?> adapter) {
+        interact(() -> {
+            stage.setX(0);
+            stage.setY(0);
+        });
+        sleep(1000); // TODO#608 just for debugging sleep really long...
+
+        // Checking that bounds are in JavaFx-Coordinates
+        BoundsLocatorImpl locator = new BoundsLocatorImpl();
+        Bounds bounds = locator.boundsOnScreenFor(root);
+        System.out.println("Top left window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+
+        // checking correct bounds
+        // interesting feature on mac: 
+        // Running in eclipse on mac, the window is placed below the MenuBar
+        // running within gradle the window is positioned behind the menubar (at real (0,0) offset)
+        assertThat("Min x doesn't match", bounds.getMinX(), equalTo(0.0));
+        if (PlatformAdapter.getOs() != OS.mac) { // Respect control bar on mac (top)
+            assertThat("MinY doesn't match", bounds.getMinY(), equalTo(0.0));
+        }
+        assertThat("Width doesn't match", bounds.getWidth(), equalTo(100.0));
+        assertThat("Height doesn't match", bounds.getHeight(), equalTo(100.0));
+
+        // checking Robot clicks on the JavaFx coordinates (if coordinates above are
+        // correct)
+        EventHandler<MouseEvent> topLeftEvent = mock(EventHandler.class);
+        interact(() -> topLeft.addEventHandler(MouseEvent.MOUSE_PRESSED, topLeftEvent));
+        EventHandler<MouseEvent> topRightEvent = mock(EventHandler.class);
+        interact(() -> topRight.addEventHandler(MouseEvent.MOUSE_PRESSED, topRightEvent));
+        EventHandler<MouseEvent> bottomLeftEvent = mock(EventHandler.class);
+        interact(() -> bottomLeft.addEventHandler(MouseEvent.MOUSE_PRESSED, bottomLeftEvent));
+        EventHandler<MouseEvent> bottomRightEvent = mock(EventHandler.class);
+        interact(() -> bottomRight.addEventHandler(MouseEvent.MOUSE_PRESSED, bottomRightEvent));
+
+        // using bounds because of mac menu bar... 
+        if (PlatformAdapter.getOs() != OS.mac) { // clicking menus on mac is not cool...
+            adapter.mouseMove(new Point2D(bounds.getMinX() + 2.5, bounds.getMinY() + 2.5));
+            WaitForAsyncUtils.waitForFxEvents();
+            sleep(waitBetween); //ensure there are no timing issues
+            adapter.mousePress(MouseButton.PRIMARY);
+            WaitForAsyncUtils.waitForFxEvents();
+            sleep(waitBetween); //ensure there are no timing issues
+            adapter.mouseRelease(MouseButton.PRIMARY);
+            WaitForAsyncUtils.waitForFxEvents();
+            sleep(waitBetween); //ensure there are no timing issues
+            System.out.println("TopLeft Click " + adapter.getClass().getSimpleName() + ": " +
+                    Mockito.mockingDetails(topLeftEvent).getInvocations().size());
+    
+            adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMinY() + 2.5));
+            WaitForAsyncUtils.waitForFxEvents();
+            sleep(waitBetween); //ensure there are no timing issues
+            adapter.mousePress(MouseButton.PRIMARY);
+            WaitForAsyncUtils.waitForFxEvents();
+            sleep(waitBetween); //ensure there are no timing issues
+            adapter.mouseRelease(MouseButton.PRIMARY);
+            WaitForAsyncUtils.waitForFxEvents();
+            sleep(waitBetween); //ensure there are no timing issues
+            System.out.println("TopRight Click " + adapter.getClass().getSimpleName() + ": " +
+                    Mockito.mockingDetails(topRightEvent).getInvocations().size());
+        }
+
+        adapter.mouseMove(new Point2D(bounds.getMinX() + 2.5, bounds.getMaxY() - 2.5));
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mousePress(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mouseRelease(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        System.out.println("BottomLeft Click " + adapter.getClass().getSimpleName() + ": " +
+                Mockito.mockingDetails(bottomLeftEvent).getInvocations().size());
+
+        adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMaxY() - 2.5));
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mousePress(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mouseRelease(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        System.out.println("BottomRight Click " + adapter.getClass().getSimpleName() + ": " +
+                Mockito.mockingDetails(bottomRightEvent).getInvocations().size());
+
+        // checking mouse has hit
+        if (PlatformAdapter.getOs() != OS.mac) { // Respect control bar on mac (top)
+            verify(topLeftEvent, times(1)).handle(any());
+            verify(topRightEvent, times(1)).handle(any());
+        }
+        verify(bottomLeftEvent, times(1)).handle(any());
+        verify(bottomRightEvent, times(1)).handle(any());
+    }
+
+    @Test
+    public void nullOffsetAwtAdapterTest() {
+        try {
+            nullOffsetAdapterTest(awtAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    @Test
+    public void nullOffsetGlassAdapterTest() {
+        try {
+            nullOffsetAdapterTest(glassAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    /**
+     * The nullOffsetTest has already verified that the Robot uses Screen
+     * coordinates and that the BoundsLocator returns JavaFx Coordinates within a
+     * JavaFx component. Last thing that might not work, is that the translation of
+     * the window is calculated in screen coordinates.<br>
+     * So if this test fails (and nullOffset works), the scaling has to be accounted
+     * to the translation of the window.
+     */
+    public void defaultOffsetAdapterTest(RobotAdapter<?> adapter) {
+        sleep(1000); // TODO#608 just for debugging sleep really long...
+
+        // Checking that bounds are in JavaFx-Coordinates
+        BoundsLocatorImpl locator = new BoundsLocatorImpl();
+        Bounds bounds = locator.boundsOnScreenFor(root);
+        System.out.println("Default window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+
+        // checking correct bounds (x,y) is unknown...
+        assertThat("Width doesn't match", bounds.getWidth(), equalTo(100.0));
+        assertThat("Height doesn't match", bounds.getHeight(), equalTo(100.0));
+
+        // using robot to verify the coordinates
+        EventHandler<MouseEvent> topLeftEvent = mock(EventHandler.class);
+        interact(() -> topLeft.addEventHandler(MouseEvent.MOUSE_PRESSED, topLeftEvent));
+        EventHandler<MouseEvent> topRightEvent = mock(EventHandler.class);
+        interact(() -> topRight.addEventHandler(MouseEvent.MOUSE_PRESSED, topRightEvent));
+        EventHandler<MouseEvent> bottomLeftEvent = mock(EventHandler.class);
+        interact(() -> bottomLeft.addEventHandler(MouseEvent.MOUSE_PRESSED, bottomLeftEvent));
+        EventHandler<MouseEvent> bottomRightEvent = mock(EventHandler.class);
+        interact(() -> bottomRight.addEventHandler(MouseEvent.MOUSE_PRESSED, bottomRightEvent));
+
+        adapter.mouseMove(new Point2D(bounds.getMinX() + 2.5, bounds.getMinY() + 2.5));
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mousePress(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mouseRelease(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        System.out.println("TopLeft Click " + adapter.getClass().getSimpleName() + ": " +
+                Mockito.mockingDetails(topLeftEvent).getInvocations().size());
+
+        adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMinY() + 2.5));
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mousePress(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mouseRelease(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        System.out.println("TopRight Click " + adapter.getClass().getSimpleName() + ": " +
+                Mockito.mockingDetails(topRightEvent).getInvocations().size());
+
+        adapter.mouseMove(new Point2D(bounds.getMinX() + 2.5, bounds.getMaxY() - 2.5));
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mousePress(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mouseRelease(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        System.out.println("BottomLeft Click " + adapter.getClass().getSimpleName() + ": " +
+                Mockito.mockingDetails(bottomLeftEvent).getInvocations().size());
+
+        adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMaxY() - 2.5));
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mousePress(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mouseRelease(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        System.out.println("BottomRight Click " + adapter.getClass().getSimpleName() + ": " +
+                Mockito.mockingDetails(bottomRightEvent).getInvocations().size());
+
+        // checking mouse has hit
+        verify(topLeftEvent, times(1)).handle(any());
+        verify(topRightEvent, times(1)).handle(any());
+        verify(bottomLeftEvent, times(1)).handle(any());
+        verify(bottomRightEvent, times(1)).handle(any());
+    }
+
+    @Test
+    public void defaultOffsetAwtAdapterTest() {
+        try {
+            defaultOffsetAdapterTest(awtAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    @Test
+    public void defaultOffsetGlassAdapterTest() {
+        try {
+            defaultOffsetAdapterTest(glassAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    /**
+     * Just verifies, that grabPixelColor also uses the right coordinates.
+     * defaultOffsetTest must work. Does only a approximate test. Uses Black, to
+     * minimize error in case of color profiles. And uses a high threshold.
+     */
+    public void capturePixelColorAdapterTest(RobotAdapter<?> adapter) {
+        sleep(1000); // TODO#608 just for debugging sleep really long...
+
+        // Checking that bounds are in JavaFx-Coordinates
+        BoundsLocatorImpl locator = new BoundsLocatorImpl();
+        Bounds bounds = locator.boundsOnScreenFor(root);
+        System.out.println("CapturePixel window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+
+        // checking correct bounds (x,y) is unknown...
+        assertThat("Width doesn't match", bounds.getWidth(), equalTo(100.0));
+        assertThat("Height doesn't match", bounds.getHeight(), equalTo(100.0));
+
+
+        Color c = adapter.getCapturePixelColor(new Point2D(bounds.getMinX() + 2.5, bounds.getMinY() + 2.5));
+        assertTrue(c.getRed() < 16.0 / 255.0);
+        assertTrue(c.getGreen() < 16.0 / 255.0);
+        assertTrue(c.getBlue() < 16.0 / 255.0);
+
+        c = adapter.getCapturePixelColor(new Point2D(bounds.getMaxX() - 2.5, bounds.getMinY() + 2.5));
+        assertTrue(c.getRed() < 16.0 / 255.0);
+        assertTrue(c.getGreen() < 16.0 / 255.0);
+        assertTrue(c.getBlue() < 16.0 / 255.0);
+
+        c = adapter.getCapturePixelColor(new Point2D(bounds.getMinX() + 2.5, bounds.getMaxY() - 2.5));
+        assertTrue(c.getRed() < 16.0 / 255.0);
+        assertTrue(c.getGreen() < 16.0 / 255.0);
+        assertTrue(c.getBlue() < 16.0 / 255.0);
+
+        c = adapter.getCapturePixelColor(new Point2D(bounds.getMaxX() - 2.5, bounds.getMaxY() - 2.5));
+        assertTrue(c.getRed() < 16.0 / 255.0);
+        assertTrue(c.getGreen() < 16.0 / 255.0);
+        assertTrue(c.getBlue() < 16.0 / 255.0);
+
+    }
+
+    @Test
+    public void capturePixelColorAwtAdapterTest() {
+        try {
+            capturePixelColorAdapterTest(awtAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    @Test
+    public void capturePixelColorGlassAdapterTest() {
+        try {
+            capturePixelColorAdapterTest(glassAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    // open issue:
+
+    // TODO#608 check sizes of screen shots (done in CaptureSupportImpl)?
+
+    /**
+     * Just verifies, that grabPixelColor also uses the right coordinates.
+     * defaultOffsetTest must work. Does only a approximate test. Uses Black, to
+     * minimize error in case of color profiles. And uses a high threshold.
+     */
+    public void captureRegionAdapterTest(RobotAdapter<?> adapter) {
+        sleep(1000); // TODO#608 just for debugging sleep really long...
+
+        // Checking that bounds are in JavaFx-Coordinates
+        BoundsLocatorImpl locator = new BoundsLocatorImpl();
+        Bounds bounds = locator.boundsOnScreenFor(root);
+        System.out.println("CaptureRegion window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+
+        // checking correct bounds (x,y) is unknown...
+        assertThat("Width doesn't match", bounds.getWidth(), equalTo(100.0));
+        assertThat("Height doesn't match", bounds.getHeight(), equalTo(100.0));
+
+        // not really required, as Robot coordinates are verified in nullOffsetTest, but
+        // for completeness...
+        // checking Robot clicks on the JavaFx coordinates (if coordinates above are
+        // correct)
+        Image image = adapter.getCaptureRegion(
+                new Rectangle2D(bounds.getMinX(), bounds.getMinY(), bounds.getWidth(), bounds.getHeight()));
+        PixelReader img = image.getPixelReader();
+        // verify correctness of dimensions
+        assertTrue("Width of image incorrect. Is=" + image.getWidth() + " expected " + bounds.getWidth(),
+                Math.abs(image.getWidth() - bounds.getWidth()) < 1.0);
+        assertTrue("Height of image incorrect. Is=" + image.getHeight() + " expected " + bounds.getHeight(),
+                Math.abs(image.getHeight() - bounds.getHeight()) < 1.0);
+
+        // verify correctness of content
+        Color c = img.getColor(2, 2);
+        assertTrue("TopLeft color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("TopLeft color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("TopLeft color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
+
+        c = img.getColor((int) bounds.getWidth() - 2, 2);
+        assertTrue("TopRight color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("TopRight color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("TopRight color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
+
+        c = img.getColor(2, (int) bounds.getHeight() - 2);
+        assertTrue("BottomLeft color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("BottomLeft color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("BottomLeft color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
+
+        c = img.getColor((int) bounds.getWidth() - 2, (int) bounds.getHeight() - 2);
+        assertTrue("BottomRight color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("BottomRight color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("BottomRight color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
+
+    }
+
+    @Test
+    public void captureRegionAwtAdapterTest() {
+        try {
+            captureRegionAdapterTest(awtAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    @Test
+    public void captureRegionGlassAdapterTest() {
+        try {
+            captureRegionAdapterTest(glassAdapter);
+        } 
+        catch (Exception e) {
+            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+    
+    
+    //// Just debugging: ////
+
+    /**
+     * Just another test, that double verifies the Robot handler coordinates...
+     */
+    public void clickOffsetAdapterTest(RobotAdapter<?> adapter) {
+        interact(() -> {
+            stage.setX(0);
+            stage.setY(0);
+            stage.setWidth(400);
+            stage.setHeight(400);
+        });
+        interact(() -> root.getChildren().clear());
+        sleep(1000); // TODO#608 just for debugging sleep really long...
+
+        // Checking that bounds are in JavaFx-Coordinates
+        BoundsLocatorImpl locator = new BoundsLocatorImpl();
+        Bounds bounds = locator.boundsOnScreenFor(root);
+        System.out.println(awtAdapter.getClass().getSimpleName() + ": Click offset window bounds for " +
+                adapter.getClass().getSimpleName() + " is " + bounds);
+        
+        assumeThat("If the bounds have an offset at the top left edge, this test provides no additional information",
+                bounds.getMinY(), equalTo(0.0));
+
+
+        // checking Robot clicks on the JavaFx coordinates (if coordinates above are
+        // correct)
+        EventHandler<MouseEvent> rootEvent = mock(EventHandler.class);
+        interact(() -> root.addEventHandler(MouseEvent.MOUSE_PRESSED, rootEvent));
+
+        // using bounds because of mac menu bar... 
+        adapter.mouseMove(new Point2D(50, 50)); //will work up to a scaling factor of 8x
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mousePress(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        adapter.mouseRelease(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+        sleep(waitBetween); //ensure there are no timing issues
+        
+
+        // checking mouse has hit
+        ArgumentCaptor<MouseEvent> ev = ArgumentCaptor.forClass(MouseEvent.class);
+        verify(rootEvent, times(1)).handle(ev.capture()); //can't output coordinates
+        // if hit check 
+        MouseEvent mEv = ev.getAllValues().get(0);
+        System.out.println(awtAdapter.getClass().getSimpleName() + ": ClickOffset landed on " +
+                adapter.getClass().getSimpleName() + ": " + Mockito.mockingDetails(rootEvent).printInvocations());
+        assertTrue(awtAdapter.getClass().getSimpleName() + ": Expected click to be at x 50.0, but was at " + mEv.getX(),
+                Math.abs(mEv.getX() - 50.0) < 1.0);
+        assertTrue(awtAdapter.getClass().getSimpleName() + ": Expected click to be at y 50.0, but was at " + mEv.getY(),
+                Math.abs(mEv.getY() - 50.0) < 1.0);
+    }
+
+    @Test
+    public void clickOffsetAwtAdapterTest() {
+        try {
+            clickOffsetAdapterTest(awtAdapter);
+        }
+        catch (AssumptionViolatedException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+
+    @Test
+    public void clickOffsetGlassAdapterTest() {
+        try {
+            clickOffsetAdapterTest(glassAdapter);
+        } 
+        catch (AssumptionViolatedException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+        }
+    }
+    
+
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
@@ -66,6 +66,8 @@ public class HDPIContractTest extends FxRobot {
     GlassRobotAdapter glassAdapter;
     
     private long waitBetween = 200;
+    
+    private final boolean verbose = true;
 
     @Before
     public void setupHDPI() throws Exception {
@@ -103,8 +105,8 @@ public class HDPIContractTest extends FxRobot {
             this.stage.show();
         });
         initRobots();
-        System.out.println("JavaVersion: " + System.getProperty("java.version"));
-        System.out.println("Java scaling x=" + JavaVersionAdapter.getScreenScaleX() + 
+        log("JavaVersion: " + System.getProperty("java.version"));
+        log("Java scaling x=" + JavaVersionAdapter.getScreenScaleX() + 
                 "Java scaling y=" + JavaVersionAdapter.getScreenScaleY());
     }
     
@@ -120,13 +122,13 @@ public class HDPIContractTest extends FxRobot {
             awtAdapter = new AwtRobotAdapter();
         } 
         catch (Exception e) {
-            System.out.println("AwtRobotAdapter seems to be not supported on this Platform");
+            log("AwtRobotAdapter seems to be not supported on this Platform");
         }
         try {
             glassAdapter = new GlassRobotAdapter();
         } 
         catch (Exception e) {
-            System.out.println("GlassRobotAdapter seems to be not supported on this Platform");
+            log("GlassRobotAdapter seems to be not supported on this Platform");
         }
     }
 
@@ -137,9 +139,11 @@ public class HDPIContractTest extends FxRobot {
     public void mouseLocationAdapterTest(RobotAdapter<?> adapter) {
         Point2D testPt = new Point2D(100, 100);
         adapter.mouseMove(testPt);
-        sleep(waitBetween); //ensure there are no timing issues
+        sleep(waitBetween); // ensure there are no timing issues
+        // note: if this test fails in the future on HDPI Unix with Java > 10 see
+        // comment in GlassRobotAdapter.getMouseLocation()
         Point2D readPt = adapter.getMouseLocation();
-        System.out.println("TestMouse for " + adapter.getClass().getSimpleName() + " is " + readPt);
+        log("TestMouse for " + adapter.getClass().getSimpleName() + " is " + readPt);
         assertThat("Move and read back failed for " + adapter.getClass().getSimpleName(), readPt, equalTo(testPt));
     }
 
@@ -149,7 +153,7 @@ public class HDPIContractTest extends FxRobot {
             mouseLocationAdapterTest(awtAdapter);
         } 
         catch (Exception e) {
-            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -159,7 +163,7 @@ public class HDPIContractTest extends FxRobot {
             mouseLocationAdapterTest(glassAdapter);
         } 
         catch (Exception e) {
-            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -174,12 +178,12 @@ public class HDPIContractTest extends FxRobot {
             stage.setX(0);
             stage.setY(0);
         });
-        sleep(1000); // TODO#608 just for debugging sleep really long...
+        sleep(1000);
 
         // Checking that bounds are in JavaFx-Coordinates
         BoundsLocatorImpl locator = new BoundsLocatorImpl();
         Bounds bounds = locator.boundsOnScreenFor(root);
-        System.out.println("Top left window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+        log("Top left window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
 
         // checking correct bounds
         // interesting feature on mac: 
@@ -214,7 +218,7 @@ public class HDPIContractTest extends FxRobot {
             adapter.mouseRelease(MouseButton.PRIMARY);
             WaitForAsyncUtils.waitForFxEvents();
             sleep(waitBetween); //ensure there are no timing issues
-            System.out.println("TopLeft Click " + adapter.getClass().getSimpleName() + ": " +
+            log("TopLeft Click " + adapter.getClass().getSimpleName() + ": " +
                     Mockito.mockingDetails(topLeftEvent).getInvocations().size());
     
             adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMinY() + 2.5));
@@ -226,7 +230,7 @@ public class HDPIContractTest extends FxRobot {
             adapter.mouseRelease(MouseButton.PRIMARY);
             WaitForAsyncUtils.waitForFxEvents();
             sleep(waitBetween); //ensure there are no timing issues
-            System.out.println("TopRight Click " + adapter.getClass().getSimpleName() + ": " +
+            log("TopRight Click " + adapter.getClass().getSimpleName() + ": " +
                     Mockito.mockingDetails(topRightEvent).getInvocations().size());
         }
 
@@ -239,7 +243,7 @@ public class HDPIContractTest extends FxRobot {
         adapter.mouseRelease(MouseButton.PRIMARY);
         WaitForAsyncUtils.waitForFxEvents();
         sleep(waitBetween); //ensure there are no timing issues
-        System.out.println("BottomLeft Click " + adapter.getClass().getSimpleName() + ": " +
+        log("BottomLeft Click " + adapter.getClass().getSimpleName() + ": " +
                 Mockito.mockingDetails(bottomLeftEvent).getInvocations().size());
 
         adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMaxY() - 2.5));
@@ -251,7 +255,7 @@ public class HDPIContractTest extends FxRobot {
         adapter.mouseRelease(MouseButton.PRIMARY);
         WaitForAsyncUtils.waitForFxEvents();
         sleep(waitBetween); //ensure there are no timing issues
-        System.out.println("BottomRight Click " + adapter.getClass().getSimpleName() + ": " +
+        log("BottomRight Click " + adapter.getClass().getSimpleName() + ": " +
                 Mockito.mockingDetails(bottomRightEvent).getInvocations().size());
 
         // checking mouse has hit
@@ -269,7 +273,7 @@ public class HDPIContractTest extends FxRobot {
             nullOffsetAdapterTest(awtAdapter);
         } 
         catch (Exception e) {
-            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -279,7 +283,7 @@ public class HDPIContractTest extends FxRobot {
             nullOffsetAdapterTest(glassAdapter);
         } 
         catch (Exception e) {
-            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -292,12 +296,12 @@ public class HDPIContractTest extends FxRobot {
      * to the translation of the window.
      */
     public void defaultOffsetAdapterTest(RobotAdapter<?> adapter) {
-        sleep(1000); // TODO#608 just for debugging sleep really long...
+        sleep(1000);
 
         // Checking that bounds are in JavaFx-Coordinates
         BoundsLocatorImpl locator = new BoundsLocatorImpl();
         Bounds bounds = locator.boundsOnScreenFor(root);
-        System.out.println("Default window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+        log("Default window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
 
         // checking correct bounds (x,y) is unknown...
         assertThat("Width doesn't match", bounds.getWidth(), equalTo(100.0));
@@ -322,7 +326,7 @@ public class HDPIContractTest extends FxRobot {
         adapter.mouseRelease(MouseButton.PRIMARY);
         WaitForAsyncUtils.waitForFxEvents();
         sleep(waitBetween); //ensure there are no timing issues
-        System.out.println("TopLeft Click " + adapter.getClass().getSimpleName() + ": " +
+        log("TopLeft Click " + adapter.getClass().getSimpleName() + ": " +
                 Mockito.mockingDetails(topLeftEvent).getInvocations().size());
 
         adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMinY() + 2.5));
@@ -334,7 +338,7 @@ public class HDPIContractTest extends FxRobot {
         adapter.mouseRelease(MouseButton.PRIMARY);
         WaitForAsyncUtils.waitForFxEvents();
         sleep(waitBetween); //ensure there are no timing issues
-        System.out.println("TopRight Click " + adapter.getClass().getSimpleName() + ": " +
+        log("TopRight Click " + adapter.getClass().getSimpleName() + ": " +
                 Mockito.mockingDetails(topRightEvent).getInvocations().size());
 
         adapter.mouseMove(new Point2D(bounds.getMinX() + 2.5, bounds.getMaxY() - 2.5));
@@ -346,7 +350,7 @@ public class HDPIContractTest extends FxRobot {
         adapter.mouseRelease(MouseButton.PRIMARY);
         WaitForAsyncUtils.waitForFxEvents();
         sleep(waitBetween); //ensure there are no timing issues
-        System.out.println("BottomLeft Click " + adapter.getClass().getSimpleName() + ": " +
+        log("BottomLeft Click " + adapter.getClass().getSimpleName() + ": " +
                 Mockito.mockingDetails(bottomLeftEvent).getInvocations().size());
 
         adapter.mouseMove(new Point2D(bounds.getMaxX() - 2.5, bounds.getMaxY() - 2.5));
@@ -358,7 +362,7 @@ public class HDPIContractTest extends FxRobot {
         adapter.mouseRelease(MouseButton.PRIMARY);
         WaitForAsyncUtils.waitForFxEvents();
         sleep(waitBetween); //ensure there are no timing issues
-        System.out.println("BottomRight Click " + adapter.getClass().getSimpleName() + ": " +
+        log("BottomRight Click " + adapter.getClass().getSimpleName() + ": " +
                 Mockito.mockingDetails(bottomRightEvent).getInvocations().size());
 
         // checking mouse has hit
@@ -374,7 +378,7 @@ public class HDPIContractTest extends FxRobot {
             defaultOffsetAdapterTest(awtAdapter);
         } 
         catch (Exception e) {
-            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -384,7 +388,7 @@ public class HDPIContractTest extends FxRobot {
             defaultOffsetAdapterTest(glassAdapter);
         } 
         catch (Exception e) {
-            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -394,12 +398,12 @@ public class HDPIContractTest extends FxRobot {
      * minimize error in case of color profiles. And uses a high threshold.
      */
     public void capturePixelColorAdapterTest(RobotAdapter<?> adapter) {
-        sleep(1000); // TODO#608 just for debugging sleep really long...
+        sleep(1000);
 
         // Checking that bounds are in JavaFx-Coordinates
         BoundsLocatorImpl locator = new BoundsLocatorImpl();
         Bounds bounds = locator.boundsOnScreenFor(root);
-        System.out.println("CapturePixel window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+        log("CapturePixel window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
 
         // checking correct bounds (x,y) is unknown...
         assertThat("Width doesn't match", bounds.getWidth(), equalTo(100.0));
@@ -434,7 +438,7 @@ public class HDPIContractTest extends FxRobot {
             capturePixelColorAdapterTest(awtAdapter);
         } 
         catch (Exception e) {
-            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -444,13 +448,9 @@ public class HDPIContractTest extends FxRobot {
             capturePixelColorAdapterTest(glassAdapter);
         } 
         catch (Exception e) {
-            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
-
-    // open issue:
-
-    // TODO#608 check sizes of screen shots (done in CaptureSupportImpl)?
 
     /**
      * Just verifies, that grabPixelColor also uses the right coordinates.
@@ -458,12 +458,12 @@ public class HDPIContractTest extends FxRobot {
      * minimize error in case of color profiles. And uses a high threshold.
      */
     public void captureRegionAdapterTest(RobotAdapter<?> adapter) {
-        sleep(1000); // TODO#608 just for debugging sleep really long...
+        sleep(1000);
 
         // Checking that bounds are in JavaFx-Coordinates
         BoundsLocatorImpl locator = new BoundsLocatorImpl();
         Bounds bounds = locator.boundsOnScreenFor(root);
-        System.out.println("CaptureRegion window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
+        log("CaptureRegion window bounds for " + adapter.getClass().getSimpleName() + " is " + bounds);
 
         // checking correct bounds (x,y) is unknown...
         assertThat("Width doesn't match", bounds.getWidth(), equalTo(100.0));
@@ -511,7 +511,7 @@ public class HDPIContractTest extends FxRobot {
             captureRegionAdapterTest(awtAdapter);
         } 
         catch (Exception e) {
-            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -521,7 +521,7 @@ public class HDPIContractTest extends FxRobot {
             captureRegionAdapterTest(glassAdapter);
         } 
         catch (Exception e) {
-            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
     
@@ -539,12 +539,12 @@ public class HDPIContractTest extends FxRobot {
             stage.setHeight(400);
         });
         interact(() -> root.getChildren().clear());
-        sleep(1000); // TODO#608 just for debugging sleep really long...
+        sleep(1000);
 
         // Checking that bounds are in JavaFx-Coordinates
         BoundsLocatorImpl locator = new BoundsLocatorImpl();
         Bounds bounds = locator.boundsOnScreenFor(root);
-        System.out.println(awtAdapter.getClass().getSimpleName() + ": Click offset window bounds for " +
+        log(awtAdapter.getClass().getSimpleName() + ": Click offset window bounds for " +
                 adapter.getClass().getSimpleName() + " is " + bounds);
         
         assumeThat("If the bounds have an offset at the top left edge, this test provides no additional information",
@@ -573,7 +573,7 @@ public class HDPIContractTest extends FxRobot {
         verify(rootEvent, times(1)).handle(ev.capture()); //can't output coordinates
         // if hit check 
         MouseEvent mEv = ev.getAllValues().get(0);
-        System.out.println(awtAdapter.getClass().getSimpleName() + ": ClickOffset landed on " +
+        log(awtAdapter.getClass().getSimpleName() + ": ClickOffset landed on " +
                 adapter.getClass().getSimpleName() + ": " + Mockito.mockingDetails(rootEvent).printInvocations());
         assertTrue(awtAdapter.getClass().getSimpleName() + ": Expected click to be at x 50.0, but was at " + mEv.getX(),
                 Math.abs(mEv.getX() - 50.0) < 1.0);
@@ -590,7 +590,7 @@ public class HDPIContractTest extends FxRobot {
             throw e;
         }
         catch (Exception e) {
-            System.out.println(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(awtAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
 
@@ -603,9 +603,15 @@ public class HDPIContractTest extends FxRobot {
             throw e;
         }
         catch (Exception e) {
-            System.out.println(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
+            log(glassAdapter.getClass().getSimpleName() + " seems to be not supported on this Platform");
         }
     }
     
+    
+    protected void log(String message) {
+        if (verbose) {
+            System.out.println(message);
+        }
+    }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
@@ -67,7 +67,7 @@ public class HDPIContractTest extends FxRobot {
     
     private long waitBetween = 200;
     
-    private final boolean verbose = true;
+    private final boolean verbose = false;
 
     @Before
     public void setupHDPI() throws Exception {

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
@@ -407,24 +407,24 @@ public class HDPIContractTest extends FxRobot {
 
 
         Color c = adapter.getCapturePixelColor(new Point2D(bounds.getMinX() + 2.5, bounds.getMinY() + 2.5));
-        assertTrue(c.getRed() < 16.0 / 255.0);
-        assertTrue(c.getGreen() < 16.0 / 255.0);
-        assertTrue(c.getBlue() < 16.0 / 255.0);
+        assertTrue("TopLeft color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("TopLeft color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("TopLeft color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
 
         c = adapter.getCapturePixelColor(new Point2D(bounds.getMaxX() - 2.5, bounds.getMinY() + 2.5));
-        assertTrue(c.getRed() < 16.0 / 255.0);
-        assertTrue(c.getGreen() < 16.0 / 255.0);
-        assertTrue(c.getBlue() < 16.0 / 255.0);
+        assertTrue("TopRight color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("TopRight color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("TopRight color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
 
         c = adapter.getCapturePixelColor(new Point2D(bounds.getMinX() + 2.5, bounds.getMaxY() - 2.5));
-        assertTrue(c.getRed() < 16.0 / 255.0);
-        assertTrue(c.getGreen() < 16.0 / 255.0);
-        assertTrue(c.getBlue() < 16.0 / 255.0);
+        assertTrue("BottomLeft color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("BottomLeft color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("BottomLeft color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
 
         c = adapter.getCapturePixelColor(new Point2D(bounds.getMaxX() - 2.5, bounds.getMaxY() - 2.5));
-        assertTrue(c.getRed() < 16.0 / 255.0);
-        assertTrue(c.getGreen() < 16.0 / 255.0);
-        assertTrue(c.getBlue() < 16.0 / 255.0);
+        assertTrue("BottomRight color doesn't match " + c, c.getRed() < 16.0 / 255.0);
+        assertTrue("BottomRight color doesn't match " + c, c.getGreen() < 16.0 / 255.0);
+        assertTrue("BottomRight color doesn't match " + c, c.getBlue() < 16.0 / 255.0);
 
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
@@ -27,12 +27,11 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
+import org.testfx.cases.TestCaseBase;
 import org.testfx.framework.junit.TestFXRule;
 import org.testfx.matcher.control.LabeledMatchers;
 import org.testfx.matcher.control.TextInputControlMatchers;
@@ -44,7 +43,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
-public class NodeMatchersTest extends FxRobot {
+public class NodeMatchersTest extends TestCaseBase {
 
     @Rule
     public TestRule rule = new TestFXRule();
@@ -52,10 +51,6 @@ public class NodeMatchersTest extends FxRobot {
     TextField textField;
     TextField textField2;
 
-    @BeforeClass
-    public static void setupSpec() throws Exception {
-        FxToolkit.registerPrimaryStage();
-    }
 
     @Test
     public void anything() throws Exception {
@@ -84,6 +79,7 @@ public class NodeMatchersTest extends FxRobot {
 
 
         // then:
+        textField.isFocused();
         assertThat(textField, NodeMatchers.isFocused());
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
@@ -196,6 +196,8 @@ public class GlassRobotAdapterTest {
 
         // when:
         WaitForAsyncUtils.waitForFxEvents();
+        // note: if this test fails in the future on HDPI Unix with Java > 10 see
+        // comment in GlassRobotAdapter.getMouseLocation()
         Point2D mouseLocation = robotAdapter.getMouseLocation();
 
         // then:

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
@@ -47,7 +47,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
-import static org.testfx.util.BoundsQueryUtils.scale;
 
 /**
  * Tests that {@link BoundsLocator} correctly computes the scene, window,
@@ -252,10 +251,10 @@ public class BoundsLocatorImplTest {
         Bounds actual = boundsLocator.boundsOnScreenFor(nodeInsideOfScene.getLayoutBounds(), primaryScene);
 
         // then:
-        assertThat(actual, equalTo(scaleIfNecessary(new BoundingBox(
+        assertThat(actual, equalTo(new BoundingBox(
                 WINDOW_TRANSLATE_X + INSIDE_SCENE_X + windowInsets.getLeft(),
                 WINDOW_TRANSLATE_Y + INSIDE_SCENE_Y + windowInsets.getTop(),
-                INSIDE_SCENE_WIDTH, INSIDE_SCENE_HEIGHT))));
+                INSIDE_SCENE_WIDTH, INSIDE_SCENE_HEIGHT)));
     }
 
     @Test
@@ -264,11 +263,11 @@ public class BoundsLocatorImplTest {
         Bounds actual = boundsLocator.boundsOnScreenFor(nodePartiallyOutsideOfScene.getLayoutBounds(), primaryScene);
 
         // then:
-        assertThat(actual, equalTo(scaleIfNecessary(new BoundingBox(
+        assertThat(actual, equalTo(new BoundingBox(
                 WINDOW_TRANSLATE_X + partialOutsideSceneX + windowInsets.getLeft(),
                 WINDOW_TRANSLATE_Y + partialOutsideSceneY + windowInsets.getTop(),
                 (partialOutsideSceneX + PARTIAL_OUTSIDE_SCENE_WIDTH) - sceneWidth,
-                (partialOutsideSceneY + PARTIAL_OUTSIDE_SCENE_HEIGHT) - sceneHeight))));
+                (partialOutsideSceneY + PARTIAL_OUTSIDE_SCENE_HEIGHT) - sceneHeight)));
     }
 
     @Test
@@ -285,16 +284,5 @@ public class BoundsLocatorImplTest {
         return new Insets(top, right, bottom, left);
     }
 
-    private static Bounds scaleIfNecessary(Bounds bounds) {
-        if (System.getProperty("testfx.robot", "awt").equalsIgnoreCase("glass")) {
-            return scale(bounds);
-        } else {
-            if ((JavaVersionAdapter.getScreenScaleX() != 1 || JavaVersionAdapter.getScreenScaleY() != 1) ||
-                    System.getProperty("os.name").toLowerCase(Locale.US).contains("nux")) {
-                return scale(bounds);
-            }
-        }
-        return bounds;
-    }
 
 }


### PR DESCRIPTION
This is the proposed solution to #607 

It should actually have the same functionality as before, but it's tested only using a Mac.

It seems, that the glass Robot on Windows uses Real (HDPI) coordinates. That would actually be in conflict with the definition of ` com.sun.glass.ui.Robot.getScreenCapture(int x, int y, int width, int height, boolean isHiDPI)`. Let's see what Travis says.