### PR TITLE
(test) Fix Locale in text matchers

### DIFF
--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
@@ -126,9 +126,9 @@ public class TextAssertTest extends FxRobot {
         assertThatThrownBy(() -> assertThat(quuxText).hasFont(Font.font(fontFamily, 14)))
                 .isExactlyInstanceOf(AssertionError.class)
                 .hasMessage(String.format("Expected: Text has font " +
-                        "\"%1$s\" with family (\"%1$s\") and size (14.0)\n     " +
+                        "\"%1$s\" with family (\"%1$s\") and size (%2$.1f)\n     " +
                         "but: was Text with font: " +
-                        "\"%1$s\" with family (\"%1$s\") and size (16.0)", fontFamily));
+                        "\"%1$s\" with family (\"%1$s\") and size (%3$.1f)", fontFamily, 14.0, 16.0));
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
@@ -105,9 +105,9 @@ public class TextMatchersTest extends FxRobot {
         assertThatThrownBy(() -> assertThat(quuxText, TextMatchers.hasFont(Font.font(fontFamily, 14))))
                 .isExactlyInstanceOf(AssertionError.class)
                 .hasMessage(String.format("\nExpected: Text has font " +
-                        "\"%1$s\" with family (\"%1$s\") and size (14.0)\n     " +
+                        "\"%1$s\" with family (\"%1$s\") and size (%2$.1f)\n     " +
                         "but: was Text with font: " +
-                        "\"%1$s\" with family (\"%1$s\") and size (16.0)", fontFamily));
+                        "\"%1$s\" with family (\"%1$s\") and size (%3$.1f)", fontFamily, 14.0, 16.0));
     }
 
     @Test


### PR DESCRIPTION
Locale of Numbers was not used in two tests.