### PR TITLE
(fix) KeyCombination on Mac with Java10 and AwtRobotAdapter

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -47,8 +47,10 @@ public class KeyboardRobotImpl implements KeyboardRobot {
  
     @Override
     public void press(KeyCode... keys) {
-        pressNoWait(keys);
-        WaitForAsyncUtils.waitForFxEvents();
+        Arrays.asList(keys).forEach(k -> {
+            pressKey(k);
+            WaitForAsyncUtils.waitForFxEvents();
+        });
     }
 
     @Override
@@ -58,8 +60,17 @@ public class KeyboardRobotImpl implements KeyboardRobot {
 
     @Override
     public void release(KeyCode... keys) {
-        releaseNoWait(keys);
-        WaitForAsyncUtils.waitForFxEvents();
+        if (keys.length == 0) {
+            pressedKeys.forEach(k -> {
+                releaseKey(k);
+                WaitForAsyncUtils.waitForFxEvents();
+            });
+        } else {
+            Arrays.asList(keys).forEach(k -> {
+                releaseKey(k);
+                WaitForAsyncUtils.waitForFxEvents();
+            });
+        }
     }
 
     @Override

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/TypeRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/TypeRobotImpl.java
@@ -79,7 +79,7 @@ public class TypeRobotImpl implements TypeRobot {
         List<KeyCode> keyCodesForwards = Arrays.asList(keyCodeCombination);
         List<KeyCode> keyCodesBackwards = new ArrayList<>(keyCodesForwards);
         Collections.reverse(keyCodesBackwards);
-        keyboardRobot.pressNoWait(keyCodesForwards.toArray(new KeyCode[0]));
+        keyboardRobot.press(keyCodesForwards.toArray(new KeyCode[0]));
         keyboardRobot.release(keyCodesBackwards.toArray(new KeyCode[0]));
     }
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -36,7 +36,6 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 import org.testfx.util.WaitForAsyncUtils;
 
-import static javafx.scene.input.KeyCode.SHORTCUT;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.util.DebugUtils.informedErrorMessage;
@@ -105,11 +104,11 @@ public class ShortcutKeyTest extends FxRobot {
     @After
     public void cleanup() {
         // prevent hanging if test fails
-        release(SHORTCUT, KeyCode.A, KeyCode.C, KeyCode.V);
+        release(new KeyCode[0]);
     }
 
     /**
-     * Verifies that that the correct key is received and that the method KeyEvent.isShortcutDown works.
+     * Verifies that the correct key is received and that the method KeyEvent.isShortcutDown works.
      */
     @Test
     public void shortcut_keyCode_converts_to_OS_specific_keyCode_when_pressed() {
@@ -121,7 +120,7 @@ public class ShortcutKeyTest extends FxRobot {
     }
 
     /**
-     * Verifies that that the correct key is received and that the method KeyEvent.isShortcutDown works.
+     * Verifies that the correct key is received and that the method KeyEvent.isShortcutDown works.
      */
     @Test
     public void shortcut_keyCode_converts_to_OS_specific_keyCode_when_released() { //fix 589, 590

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/TypeRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/TypeRobotImplTest.java
@@ -65,7 +65,7 @@ public class TypeRobotImplTest {
         typeRobot.push(A);
 
         // then:
-        verify(keyboardRobot, times(1)).pressNoWait(eq(A));
+        verify(keyboardRobot, times(1)).press(eq(A));
         verify(keyboardRobot, times(1)).release(eq(A));
         verifyNoMoreInteractions(keyboardRobot);
     }
@@ -76,7 +76,7 @@ public class TypeRobotImplTest {
         typeRobot.push(ALT, A);
 
         // then:
-        verify(keyboardRobot, times(1)).pressNoWait(eq(ALT), eq(A));
+        verify(keyboardRobot, times(1)).press(eq(ALT), eq(A));
         verify(keyboardRobot, times(1)).release(eq(A), eq(ALT));
         verifyNoMoreInteractions(keyboardRobot);
     }
@@ -87,7 +87,7 @@ public class TypeRobotImplTest {
         typeRobot.push(COMMAND, B);
 
         // then:
-        verify(keyboardRobot, times(1)).pressNoWait(eq(COMMAND), eq(B));
+        verify(keyboardRobot, times(1)).press(eq(COMMAND), eq(B));
         verify(keyboardRobot, times(1)).release(eq(B), eq(COMMAND));
         verifyNoMoreInteractions(keyboardRobot);
     }
@@ -98,7 +98,7 @@ public class TypeRobotImplTest {
         typeRobot.push(new KeyCodeCombination(A, ALT_DOWN));
 
         // then:
-        verify(keyboardRobot, times(1)).pressNoWait(eq(ALT), eq(A));
+        verify(keyboardRobot, times(1)).press(eq(ALT), eq(A));
         verify(keyboardRobot, times(1)).release(eq(A), eq(ALT));
         verifyNoMoreInteractions(keyboardRobot);
     }
@@ -109,7 +109,7 @@ public class TypeRobotImplTest {
         typeRobot.push(new KeyCodeCombination(A, SHIFT_DOWN, CONTROL_DOWN));
 
         // then:
-        verify(keyboardRobot, times(1)).pressNoWait(eq(SHIFT), eq(CONTROL), eq(A));
+        verify(keyboardRobot, times(1)).press(eq(SHIFT), eq(CONTROL), eq(A));
         verify(keyboardRobot, times(1)).release(eq(A), eq(CONTROL), eq(SHIFT));
         verifyNoMoreInteractions(keyboardRobot);
     }


### PR DESCRIPTION
KeyCombinations for CopyPaste were not correctly recognized in the given
setup