### PR TITLE
(test) Remove t2k font engine usage from Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,13 @@ jobs:
       dist: trusty
       jdk: oraclejdk8
       env:
-        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dprism.verbose=true"
+        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.verbose=true"
     # Ubuntu Linux (trusty) / Oracle JDK 8 / Headless / HiDPI
     - os: linux
       dist: trusty
       jdk: oraclejdk8
       env:
-        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dprism.verbose=true -Dglass.gtk.uiScale=2.0"
+        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.verbose=true -Dglass.gtk.uiScale=2.0"
     # Ubuntu Linux (trusty) / Oracle JDK 10 / Headed (AWT Robot)
     - os: linux
       dist: trusty
@@ -103,7 +103,7 @@ jobs:
       osx_image: xcode9.4
       env:
         - TRAVIS_JAVA_VERSION="8"
-        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dprism.verbose=true"
+        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.verbose=true"
      # macOS / Oracle JDK 10 / Headless
     - os: osx
       osx_image: xcode9.4


### PR DESCRIPTION
This is mostly just a test to see if using the native font engines (freetype on Linux, coretext on macOS) in headless mode causes any crash, like it does on Windows. The `-Dprism.text=t2k` argument has been suggested to be used when testing in headless mode since forever, but that may just have been to have all platforms work, when it was really only needed on Windows. I am working on an [upstream fix](https://github.com/javafxports/openjdk-jfx/issues/66) to the crash that happens on Windows in headless mode (using Monocle) without `t2k` (which was removed from JavaFX in version 10, and was never open sourced, and so only ever worked with Oracle JDK and not OpenJDK).

