### PR TITLE
Make glass robot default on all platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ you are using JUnit 4 in your project you would add a dependency on `testfx-juni
 </dependency>
 ```
 
-## Example: JUnit 4 with Hamcrest Matchers
+## Examples
+### JUnit 4 with Hamcrest Matchers
 
 ```java
 import org.testfx.framework.junit.ApplicationTest;
@@ -105,7 +106,7 @@ public class DesktopPaneTest extends ApplicationTest {
 }
 ```
 
-## Example: JUnit 4 with AssertJ Assertions
+### JUnit 4 with AssertJ Assertions
 
 ```java
 import org.testfx.framework.junit.ApplicationTest;
@@ -144,7 +145,7 @@ public class DesktopPaneTest extends ApplicationTest {
 }
 ```
 
-## Example: JUnit 5 with Hamcrest Matchers
+### JUnit 5 with Hamcrest Matchers
 
 ```java
 import org.testfx.framework.junit5.ApplicationTest;
@@ -177,7 +178,7 @@ class ClickableButtonTest {
 }
 ```
 
-## Example: JUnit 5 with AssertJ Assertions
+### JUnit 5 with AssertJ Assertions
 
 ```java
 import org.testfx.framework.junit5.ApplicationTest;
@@ -227,7 +228,7 @@ class ClickableButtonTest {
 }
 ```
 
-## Example: Spock with Hamcrest Matchers
+### Spock with Hamcrest Matchers
 
 ```java
 import org.testfx.framework.spock.ApplicationSpec;
@@ -264,6 +265,189 @@ class ClickableButtonSpec extends ApplicationSpec {
         verifyThat('.button', hasText('clicked!'))
     }
 }
+```
+
+## Continuous Integration (CI)
+
+### Travis CI
+
+To run TestFX tests as part of your Travis CI build on Ubuntu and/or macOS
+take the following steps:
+
+1. Ensure that your unit tests are triggered as part of your build script. This
+   is usually the default case when using Maven or Gradle.
+2. If you wish to test in a headless environment your must add [Monocle](https://github.com/TestFX/Monocle)
+    as a test dependency:
+
+`build.gradle`
+```gradle
+dependencies {
+    testCompile "org.testfx:openjfx-monocle:8u76-b04" // jdk-9+181 for Java 9
+}
+```
+
+`pom.xml`
+```xml
+<dependency>
+    <groupId>org.testfx</groupId>
+    <artifactId>openjfx-monocle</artifactId>
+    <version>8u76-b04</version> <!-- jdk-9+181 for Java 9 -->
+    <scope>test</scope>
+</dependency>
+```
+3. Base your Travis configuration on the following. Some different build variations are shown (Glass/AWT robot,
+    Headed/Headless, (Hi)DPI, etc.) adjust the build matrix to your requirements.
+
+`.travis.yml`
+``` yaml
+language: java
+
+sudo: false   # Linux OS: run in container
+
+matrix:
+  include:
+    # Ubuntu Linux (trusty) / Oracle JDK 8 / Headed (AWT Robot)
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+      env:
+        - _JAVA_OPTIONS="-Dtestfx.robot=awt"
+    # Ubuntu Linux (trusty) / Oracle JDK 8 / Headed (Glass Robot) / HiDPI
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+      env:
+        - _JAVA_OPTIONS="-Dtestfx.robot=glass -Dglass.gtk.uiScale=2.0"
+    # Ubuntu Linux (trusty) / Oracle JDK 8 / Headless
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+      env:
+        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw"
+    # macOS / Oracle JDK 8 / Headless
+    - os: osx
+      osx_image: xcode9.4
+      jdk: oraclejdk8
+      env:
+        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.verbose=true"
+    # Headed macOS is not currently possible on Travis.
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
+before_install:
+  - if [[ "${TRAVIS_OS_NAME}" == linux ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+
+install: true
+
+before_script:
+  - if [[ "${TRAVIS_OS_NAME}" == osx ]]; then brew update; brew cask reinstall caskroom/versions/java8; fi
+
+script:
+  - ./gradlew check
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -f  $HOME/.gradle/caches/*/fileHashes/fileHashes.bin
+  - rm -f  $HOME/.gradle/caches/*/fileHashes/fileHashes.lock
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+```
+
+Your TestFX tests should now run as part of your Travis CI build.
+
+### Appveyor (Windows)
+
+To run TestFX tests as part of your Appveyor build on Windows take the following
+steps:
+
+1. Ensure that your unit tests are triggered as part of your build script. This
+   is usually the default case when using Maven or Gradle.
+2. If you wish to test in a headless environment your must add [Monocle](https://github.com/TestFX/Monocle)
+    as a test dependency:
+
+`build.gradle`
+```gradle
+dependencies {
+    testCompile "org.testfx:openjfx-monocle:8u76-b04" // jdk-9+181 for Java 9
+}
+```
+
+`pom.xml`
+```xml
+<dependency>
+    <groupId>org.testfx</groupId>
+    <artifactId>openjfx-monocle</artifactId>
+    <version>8u76-b04</version> <!-- jdk-9+181 for Java 9 -->
+    <scope>test</scope>
+</dependency>
+```
+3. Base your Appveyor configuration on the following. Some different build variations are shown (Glass/AWT robot,
+    Headed/Headless, (Hi)DPI, etc.) adjust the build matrix to your requirements.
+
+`appveyor.yml`
+```yaml
+version: "{branch} {build}"
+environment:
+  matrix:
+    # Java 8 / AWT Robot
+    - JAVA_VERSION: "8"
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dtestfx.awt.scale=true"
+    # Java 8 / AWT Robot / HiDPI
+    - JAVA_VERSION: "8"
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dtestfx.awt.scale=true -Dglass.win.uiScale=200%"
+    # Java 8 / Headless
+    - JAVA_VERSION: "8"
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      _JAVA_OPTIONS: "-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k"
+    # Java 10 / AWT Robot / HiDPI
+    - JAVA_VERSION: "10"
+      JAVA_HOME: C:\jdk10
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dtestfx.awt.scale=true -Dglass.win.uiScale=200%"
+    # Java 11 / AWT Robot / HiDPI
+    - JAVA_VERSION: "11"
+      JAVA_HOME: C:\jdk11
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dtestfx.awt.scale=true -Dglass.win.uiScale=200%"
+
+build_script:
+  - ps: |
+      if ($env:JAVA_VERSION -eq "11") {
+        $client = New-Object net.webclient
+        $client.DownloadFile('http://jdk.java.net/11/', 'C:\Users\appveyor\openjdk11.html')
+        $openJdk11 = cat C:\Users\appveyor\openjdk11.html | where { $_ -match "href.*https://download.java.net.*jdk11.*windows-x64.*zip\`"" } | %{ $_ -replace "^.*https:", "https:" } | %{ $_ -replace ".zip\`".*$", ".zip" }
+        echo "Download boot JDK from: $openJdk11"
+        $client.DownloadFile($openJdk11, 'C:\Users\appveyor\openjdk11.zip')
+        Expand-Archive -Path 'C:\Users\appveyor\openjdk11.zip' -DestinationPath 'C:\Users\appveyor\openjdk11'
+        Copy-Item -Path 'C:\Users\appveyor\openjdk11\*\' -Destination 'C:\jdk11' -Recurse -Force
+      }
+      elseif ($env:JAVA_VERSION -eq "10") {
+        choco install jdk10 --version 10.0.2 --force --cache 'C:\ProgramData\chocolatey\cache' -params 'installdir=c:\\jdk10'
+      }
+
+      // Note: Currently Java 8 is the default JDK, if that changes the above will have to change accordingly.
+
+shallow_clone: true
+
+build:
+  verbosity: detailed
+
+test_script:
+  - gradlew build --no-daemon
+
+cache:
+  - C:\Users\appveyor\.gradle\caches
+  - C:\Users\appveyor\.gradle\wrapper -> .gradle-wrapper\gradle-wrapper.properties
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+  - C:\ProgramData\chocolatey\cache -> appveyor.yml
 ```
 
 ## Documentation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     # Java 8 / AWT Robot / HiDPI
     - JAVA_VERSION: "8"
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dglass.win.uiScale=200%"
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dtestfx.awt.scale=true -Dglass.win.uiScale=200%"
 
     # Java 8 / Glass Robot / HiDPI (deadlock?)
     # - JAVA_VERSION: "8"
@@ -45,7 +45,7 @@ environment:
     # Java 10 / AWT Robot / HiDPI
     - JAVA_VERSION: "10"
       JAVA_HOME: C:\jdk10
-      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dprism.verbose=true -Dglass.win.uiScale=200%"
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dtestfx.awt.scale=true -Dglass.win.uiScale=200%"
 
     # Java 10 / Headless (fails because of JDK-8201539)
     - JAVA_VERSION: "10"
@@ -65,7 +65,7 @@ environment:
     # Java 11 / AWT Robot / HiDPI
     - JAVA_VERSION: "11"
       JAVA_HOME: C:\jdk11
-      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dglass.win.uiScale=200%"
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dtestfx.awt.scale=true -Dglass.win.uiScale=200%"
 
     # Java 11 / Headless (fails because of JDK-8201539)
     - JAVA_VERSION: "11"

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
@@ -23,7 +23,6 @@ import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 
-import org.testfx.internal.PlatformAdapter;
 import org.testfx.robot.BaseRobot;
 import org.testfx.service.adapter.RobotAdapter;
 import org.testfx.service.adapter.impl.AwtRobotAdapter;
@@ -37,14 +36,8 @@ public class BaseRobotImpl implements BaseRobot {
 
     public BaseRobotImpl() {
         boolean verbose = Boolean.getBoolean("testfx.verbose");
-        // Default to "glass" if "testfx.robot" is not explicitly set on macOS or Linux, otherwise
-        // default to "awt" (on Windows).
-        String defaultRobot = "awt";
-        if (PlatformAdapter.getOs() == PlatformAdapter.OS.UNIX ||
-                PlatformAdapter.getOs() == PlatformAdapter.OS.MAC) {
-            defaultRobot = "glass";
-        }
-        String robotAdapterName = System.getProperty("testfx.robot", defaultRobot);
+        // Default to "glass" if "testfx.robot" is not explicitly set.
+        String robotAdapterName = System.getProperty("testfx.robot", "glass");
         switch (robotAdapterName) {
             case "awt":
                 if (verbose) {

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
@@ -52,7 +52,8 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
         if (GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance()) {
             throw new RuntimeException("can not create awt robot as environment is headless");
         }
-        Toolkit.getDefaultToolkit(); // initializes awt toolkit
+        // Initialize AWT toolkit.
+        Toolkit.getDefaultToolkit();
         awtRobot = createAwtRobot();
     }
 
@@ -173,10 +174,7 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
         }
     }
 
-
-
-    // scale
-    protected Rectangle2D scaleRect(Rectangle2D rect) {
+    private Rectangle2D scaleRect(Rectangle2D rect) {
         if (!scaleRequired()) {
             return rect;
         }
@@ -186,7 +184,7 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
                 rect.getHeight() * factorY);
     }
 
-    protected Point2D scaleInverseRect(Point2D pt) {
+    private Point2D scaleInverseRect(Point2D pt) {
         if (!scaleRequired()) {
             return pt;
         }
@@ -195,12 +193,21 @@ public class AwtRobotAdapter implements RobotAdapter<Robot> {
         return new Point2D(pt.getX() / factorX, pt.getY() / factorY);
     }
 
-    protected boolean scaleRequired() {
-        // MacOS Awt is not covered by the build server.
-        // Do not remove, if not testing on a headed mac with java 10 or above.
-        return PlatformAdapter.getOs() != OS.MAC &&
-            // just prevent unnecessary transforms...
-            JavaVersionAdapter.getScreenScaleX() != 1.0 && JavaVersionAdapter.getScreenScaleY() != 1.0;
+    private boolean scaleRequired() {
+        if (JavaVersionAdapter.getScreenScaleX() == 1.0 && JavaVersionAdapter.getScreenScaleY() == 1.0) {
+            // Just to prevent unnecessary computations.
+            return false;
+        } else {
+            if (Boolean.getBoolean("testfx.awt.scale")) {
+                return true;
+            }
+            if (PlatformAdapter.getOs() == OS.WINDOWS) {
+                return false;
+            }
+            // Do not remove, if not testing on headed macOS with Java 10+. Beware: macOS with AWT robot is
+            // not covered by CI builds!
+            return PlatformAdapter.getOs() != OS.MAC;
+        }
     }
 
 


### PR DESCRIPTION
Investigating #581 

Locally on Windows 10 using the AWT robot the mouse goes to the wrong location (pixel and screen capture also fail, because those are the methods that can potentially use scaling).

But on Appveyor everything works as expected.

I am going to compare the screen device details as returned by AWT to see if there is a property we can use to try and differentiate when to scale or not, and use that instead of adding `PlatformAdapter.getOs() != OS.WINDOWS` condition to `AwtRobotAdapter.scaleRequired` (which is just for testing to see that this fixes things locally, but breaks Appveyor).
