### PR TITLE
(chore) Explicitly set testfx.robot for CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
       os: linux
       dist: trusty
       jdk: oraclejdk8
+      env:
+        - _JAVA_OPTIONS="-Dtestfx.robot=awt"
     # Ubuntu Linux (trusty) / Oracle JDK 8 / Headed (Glass Robot)
     - os: linux
       dist: trusty
@@ -59,13 +61,13 @@ jobs:
       dist: trusty
       jdk: oraclejdk10
       env:
-        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED"
+        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED -Dtestfx.robot=awt"
     # Ubuntu Linux (trusty) / Oracle JDK 10 / Headed (Glass Robot)
     - os: linux
       dist: trusty
       jdk: oraclejdk10
       env:
-        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED -Dtestfx.verbose=true -Dtestfx.robot=glass"
+        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED -Dtestfx.robot=glass"
     # Ubuntu Linux (trusty) / Oracle JDK 10 / Headless
     - os: linux
       dist: trusty
@@ -77,7 +79,7 @@ jobs:
       dist: trusty
       jdk: oraclejdk10
       env:
-        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED -Djdk.gtk.verbose=true -Djdk.gtk.version=3 -Dglass.gtk.uiScale=2.0"
+        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED -Dtestfx.robot=awt -Djdk.gtk.verbose=true -Djdk.gtk.version=3 -Dglass.gtk.uiScale=2.0"
     # Ubuntu Linux (trusty) / Oracle JDK 10 / Headed (Glass Robot) / HiDPI
     - os: linux
       dist: trusty
@@ -101,7 +103,7 @@ jobs:
       dist: trusty
       jdk: oraclejdk11
       env:
-        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED -Dnet.bytebuddy.experimental=true"
+        - _JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED -Dtestfx.robot=awt"
     # Ubuntu Linux (trusty) / Oracle JDK 11 / Headed (Glass Robot) / HiDPI
     - os: linux
       dist: trusty

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     # Java 8 / AWT Robot
     - JAVA_VERSION: "8"
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt"
 
     # Java 8 / Glass Robot (deadlock?)
     # - JAVA_VERSION: "8"
@@ -14,7 +15,7 @@ environment:
     # Java 8 / AWT Robot / HiDPI
     - JAVA_VERSION: "8"
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      _JAVA_OPTIONS: "-Dglass.win.uiScale=200%"
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dglass.win.uiScale=200%"
 
     # Java 8 / Glass Robot / HiDPI (deadlock?)
     # - JAVA_VERSION: "8"
@@ -29,6 +30,7 @@ environment:
     # Java 10 / AWT Robot
     - JAVA_VERSION: "10"
       JAVA_HOME: C:\jdk10
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt"
 
     # Java 10 / Glass Robot (deadlock?)
     # - JAVA_VERSION: "10"
@@ -43,7 +45,7 @@ environment:
     # Java 10 / AWT Robot / HiDPI
     - JAVA_VERSION: "10"
       JAVA_HOME: C:\jdk10
-      _JAVA_OPTIONS: "-Dprism.verbose=true -Dglass.win.uiScale=200%"
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dprism.verbose=true -Dglass.win.uiScale=200%"
 
     # Java 10 / Headless (fails because of JDK-8201539)
     - JAVA_VERSION: "10"
@@ -53,6 +55,7 @@ environment:
     # Java 10 / AWT Robot
     - JAVA_VERSION: "11"
       JAVA_HOME: C:\jdk11
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt"
 
     # Java 11 / Glass Robot (deadlock?)
     # - JAVA_VERSION: "11"
@@ -62,7 +65,7 @@ environment:
     # Java 11 / AWT Robot / HiDPI
     - JAVA_VERSION: "11"
       JAVA_HOME: C:\jdk11
-      _JAVA_OPTIONS: "-Dglass.win.uiScale=200%"
+      _JAVA_OPTIONS: "-Dtestfx.robot=awt -Dglass.win.uiScale=200%"
 
     # Java 11 / Headless (fails because of JDK-8201539)
     - JAVA_VERSION: "11"


### PR DESCRIPTION
This way even if the default robot changes in the future the builds will
remain the same. Before this change we were relying on the fact that not
specifying a value for "testfx.robot" defaulted to using "awt".