### PR TITLE
(fix) Public glass robot API no longer has destroy method.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -16,14 +16,12 @@
  */
 package org.testfx.service.adapter.impl;
 
-import java.lang.reflect.InvocationTargetException;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.image.Image;
 
 import org.testfx.service.adapter.RobotAdapter;
 
 import static org.testfx.util.WaitForAsyncUtils.asyncFx;
-import static org.testfx.util.WaitForAsyncUtils.waitForAsyncFx;
 
 public abstract class GlassRobotAdapter implements RobotAdapter {
 
@@ -61,21 +59,6 @@ public abstract class GlassRobotAdapter implements RobotAdapter {
         }
         else {
             return new PrivateGlassRobotAdapter();
-        }
-    }
-
-    @Override
-    public final void robotDestroy() {
-        if (glassRobot != null) {
-            waitForAsyncFx(RETRIEVAL_TIMEOUT_IN_MILLIS, () -> {
-                try {
-                    getRobot().getClass().getMethod("destroy").invoke(glassRobot);
-                }
-                catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                    throw new RuntimeException(e);
-                }
-                glassRobot = null;
-            });
         }
     }
 

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PrivateGlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PrivateGlassRobotAdapter.java
@@ -60,6 +60,21 @@ class PrivateGlassRobotAdapter extends GlassRobotAdapter {
     }
 
     @Override
+    public void robotDestroy() {
+        if (glassRobot != null) {
+            waitForAsyncFx(RETRIEVAL_TIMEOUT_IN_MILLIS, () -> {
+                try {
+                    getRobot().getClass().getMethod("destroy").invoke(glassRobot);
+                }
+                catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+                glassRobot = null;
+            });
+        }
+    }
+
+    @Override
     public void keyPress(KeyCode key) {
         asyncFx(() -> getRobot().getClass().getMethod("keyPress", int.class)
                 .invoke(getRobot(), convertToKeyCodeId(key)));

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PublicGlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PublicGlassRobotAdapter.java
@@ -52,6 +52,10 @@ class PublicGlassRobotAdapter extends GlassRobotAdapter {
         }
     }
 
+    public void robotDestroy() {
+        // NO-OP, destroy() was removed from public robot API pending https://bugs.openjdk.java.net/browse/JDK-8207373.
+    }
+
     @Override
     public void keyPress(KeyCode key) {
         asyncFx(() -> getRobot().getClass().getMethod("keyPress", KeyCode.class).invoke(getRobot(), key));


### PR DESCRIPTION
See: https://github.com/TestFX/TestFX/pull/606#issuecomment-427048434

The fact that destroy is no longer called upstream will be handled by
https://bugs.openjdk.java.net/browse/JDK-8207373.

Helped-by: @kleopatra