### PR TITLE
(enhancement) Support matcher/assertion on Styleables.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractMenuItemAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractMenuItemAssert.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.MenuItem;
+
+import org.hamcrest.Matcher;
+import org.testfx.matcher.control.MenuItemMatchers;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.scene.control.MenuItem} assertions.
+ */
+public class AbstractMenuItemAssert<SELF extends AbstractMenuItemAssert<SELF>>
+        extends AbstractStyleableAssert<SELF> {
+
+    protected AbstractMenuItemAssert(MenuItem actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.MenuItem} has exactly the given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF hasText(String text) {
+        assertThat(actual).is(fromMatcher(MenuItemMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.Menu} does not have exactly the given {@code text}.
+     *
+     * @param text the given text to compare the actual text to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(String text) {
+        assertThat(actual).is(fromInverseMatcher(MenuItemMatchers.hasText(text)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.MenuItem} is matched by the given {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF hasText(Matcher<String> matcher) {
+        assertThat(actual).is(fromMatcher(MenuItemMatchers.hasText(matcher)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.scene.control.MenuItem} is not matched by the given {@code matcher}.
+     *
+     * @param matcher the {@code String} matcher to test the actual text with
+     * @return this assertion object
+     */
+    public SELF doesNotHaveText(Matcher<String> matcher) {
+        assertThat(actual).is(fromInverseMatcher(MenuItemMatchers.hasText(matcher)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractNodeAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractNodeAssert.java
@@ -18,7 +18,6 @@ package org.testfx.assertions.api;
 
 import javafx.scene.Node;
 
-import org.assertj.core.api.AbstractAssert;
 import org.testfx.matcher.base.NodeMatchers;
 
 import static org.testfx.assertions.api.Assertions.assertThat;
@@ -28,7 +27,7 @@ import static org.testfx.assertions.impl.Adapter.fromMatcher;
 /**
  * Base class for all {@link javafx.scene.Node} assertions.
  */
-public class AbstractNodeAssert<SELF extends AbstractNodeAssert<SELF>> extends AbstractAssert<SELF, Node> {
+public class AbstractNodeAssert<SELF extends AbstractNodeAssert<SELF>> extends AbstractStyleableAssert<SELF> {
 
     protected AbstractNodeAssert(Node actual, Class<?> selfType) {
         super(actual, selfType);

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractStyleableAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractStyleableAssert.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.css.Styleable;
+
+import org.assertj.core.api.AbstractAssert;
+import org.testfx.matcher.base.StyleableMatchers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testfx.assertions.impl.Adapter.fromInverseMatcher;
+import static org.testfx.assertions.impl.Adapter.fromMatcher;
+
+/**
+ * Base class for all {@link javafx.css.Styleable} assertions.
+ */
+public class AbstractStyleableAssert<SELF extends AbstractStyleableAssert<SELF>>
+        extends AbstractAssert<SELF, Styleable> {
+
+    protected AbstractStyleableAssert(Styleable actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} has the given type selector.
+     *
+     * @param typeSelector the given type selector to compare the actual type selector to
+     * @return this assertion object
+     */
+    public SELF hasTypeSelector(String typeSelector) {
+        assertThat(actual).is(fromMatcher(StyleableMatchers.hasTypeSelector(typeSelector)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} does not have the given type selector.
+     *
+     * @param typeSelector the given type selector to compare the actual type selector to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveTypeSelector(String typeSelector) {
+        assertThat(actual).is(fromInverseMatcher(StyleableMatchers.hasTypeSelector(typeSelector)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} has the given CSS id.
+     *
+     * @param id the given CSS id to compare the actual CSS id to
+     * @return this assertion object
+     */
+    public SELF hasId(String id) {
+        assertThat(actual).is(fromMatcher(StyleableMatchers.hasId(id)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} does not have the given CSS id.
+     *
+     * @param id the given CSS id to compare the actual CSS id to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveId(String id) {
+        assertThat(actual).is(fromInverseMatcher(StyleableMatchers.hasId(id)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} has the given CSS style.
+     *
+     * @param style the given CSS style to compare the actual CSS style to
+     * @return this assertion object
+     */
+    public SELF hasStyle(String style) {
+        assertThat(actual).is(fromMatcher(StyleableMatchers.hasStyle(style)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} does not have the given CSS style.
+     *
+     * @param style the given CSS style to compare the actual CSS style to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveStyle(String style) {
+        assertThat(actual).is(fromInverseMatcher(StyleableMatchers.hasStyle(style)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} has the given parent.
+     *
+     * @param styleableParent the given parent to compare the actual styleable parent to
+     * @return this assertion object
+     */
+    public SELF hasStyleableParent(Styleable styleableParent) {
+        assertThat(actual).is(fromMatcher(StyleableMatchers.hasStyleableParent(styleableParent)));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link javafx.css.Styleable} does not have the given parent.
+     *
+     * @param styleableParent the given parent to compare the actual styleable parent to
+     * @return this assertion object
+     */
+    public SELF doesNotHaveStyleableParent(Styleable styleableParent) {
+        assertThat(actual).is(fromInverseMatcher(StyleableMatchers.hasStyleableParent(styleableParent)));
+        return myself;
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Assertions.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Assertions.java
@@ -16,6 +16,7 @@
  */
 package org.testfx.assertions.api;
 
+import javafx.css.Styleable;
 import javafx.geometry.Dimension2D;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -23,6 +24,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Labeled;
 import javafx.scene.control.ListView;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.paint.Color;
@@ -79,7 +81,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
     }
 
     /**
-     * Create assertion for {@link Button}.
+     * Create assertion for {@link Labeled}.
      *
      * @param actual the actual value
      * @return the created assertion object
@@ -100,7 +102,17 @@ public class Assertions extends org.assertj.core.api.Assertions {
     }
 
     /**
-     * Create assertion for {@link Button}.
+     * Create assertion for {@link MenuItem}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static MenuItemAssert assertThat(MenuItem actual) {
+        return new MenuItemAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link Node}.
      *
      * @param actual the actual value
      * @return the created assertion object
@@ -117,6 +129,16 @@ public class Assertions extends org.assertj.core.api.Assertions {
      */
     public static ParentAssert assertThat(Parent actual) {
         return new ParentAssert(actual);
+    }
+
+    /**
+     * Create assertion for {@link Styleable}.
+     *
+     * @param actual the actual value
+     * @return the created assertion object
+     */
+    public static StyleableAssert assertThat(Styleable actual) {
+        return new StyleableAssert(actual);
     }
 
     /**

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/MenuItemAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/MenuItemAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.scene.control.MenuItem;
+
+/**
+ * Assertion methods for {@link javafx.scene.control.MenuItem}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(MenuItem)}</code>.
+ */
+public class MenuItemAssert extends AbstractMenuItemAssert<MenuItemAssert> {
+
+    protected MenuItemAssert(MenuItem actual) {
+        super(actual, MenuItemAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/StyleableAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/StyleableAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.css.Styleable;
+
+/**
+ * Assertion methods for {@link javafx.css.Styleable} objects.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Styleable)}</code>.
+ */
+public class StyleableAssert extends AbstractStyleableAssert<StyleableAssert> {
+
+    protected StyleableAssert(Styleable actual) {
+        super(actual, StyleableAssert.class);
+    }
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/StyleableMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/StyleableMatchers.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.matcher.base;
+
+import java.util.Objects;
+
+import javafx.css.Styleable;
+
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+
+import static org.testfx.matcher.base.GeneralMatchers.typeSafeMatcher;
+
+/**
+ * TestFX matchers for {@link Styleable} objects.
+ */
+public class StyleableMatchers {
+
+    private StyleableMatchers() {}
+
+    /**
+     * Creates a matcher that matches all {@link Styleable} objects that have the given {@code typeSelector} as
+     * their type selector.
+     *
+     * @param typeSelector the {@code String} the matched Styleables should have as their type selector
+     */
+    @Factory
+    public static Matcher<Styleable> hasTypeSelector(String typeSelector) {
+        String descriptionText = "has type selector \"" + typeSelector + "\"";
+        return typeSafeMatcher(Styleable.class, descriptionText,
+            styleable -> "\"" + styleable.getTypeSelector() + "\"",
+            styleable -> Objects.equals(typeSelector, styleable.getTypeSelector()));
+    }
+
+    /**
+     * Creates a matcher that matches all {@link Styleable} objects that have the given {@code id} as
+     * their CSS id.
+     *
+     * @param id the {@code String} the matched Styleables should have as their CSS id
+     */
+    @Factory
+    public static Matcher<Styleable> hasId(String id) {
+        String descriptionText = "has CSS id \"" + id + "\"";
+        return typeSafeMatcher(Styleable.class, descriptionText,
+            styleable -> "\"" + styleable.getId() + "\"",
+            styleable -> Objects.equals(id, styleable.getId()));
+    }
+
+    /**
+     * Creates a matcher that matches all {@link Styleable} objects that have the given {@code style} as
+     * their CSS style.
+     *
+     * @param style the {@code String} the matched Styleables should have as their CSS style
+     */
+    @Factory
+    public static Matcher<Styleable> hasStyle(String style) {
+        String descriptionText = "has CSS style \"" + style + "\"";
+        return typeSafeMatcher(Styleable.class, descriptionText,
+            styleable -> "\"" + styleable.getStyle() + "\"",
+            styleable -> Objects.equals(style, styleable.getStyle()));
+    }
+
+    /**
+     * Creates a matcher that matches all {@link Styleable} objects that have the given {@code parent} as
+     * their styleable parent.
+     *
+     * @param styleableParent the {@code String} the matched Styleables should have as their styleable parent
+     */
+    @Factory
+    public static Matcher<Styleable> hasStyleableParent(Styleable styleableParent) {
+        String descriptionText = "has styleable parent \"" + styleableParent + "\"";
+        return typeSafeMatcher(Styleable.class, descriptionText,
+            styleable -> "\"" + styleable.getStyleableParent() + "\"",
+            styleable -> Objects.equals(styleableParent, styleable.getStyleableParent()));
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/StyleableAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/StyleableAssertTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2018 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.assertions.api;
+
+import javafx.css.Styleable;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import static org.testfx.assertions.api.Assertions.assertThat;
+
+public class StyleableAssertTest extends FxRobot {
+
+    @BeforeClass
+    public static void setupSpec() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Test
+    public void hasId() throws Exception {
+        // given (a Button which is-a Styleable):
+        Styleable styleable = FxToolkit.setupFixture(() -> {
+            Button button = new Button("Button");
+            button.setId("myButton");
+            return button;
+        });
+
+        // then:
+        assertThat(styleable).hasId("myButton");
+    }
+
+    @Test
+    public void doesNotHaveId() throws Exception {
+        // given (a Button which is-a Styleable):
+        Styleable styleable = FxToolkit.setupFixture(() -> {
+            Button button = new Button("Button");
+            button.setId("myButton");
+            return button;
+        });
+
+        // then:
+        assertThat(styleable).doesNotHaveId("notMyButton");
+    }
+
+    @Test
+    public void hasTypeSelector() throws Exception {
+        // given (a Button which is-a Styleable):
+        Styleable styleable = FxToolkit.setupFixture(() -> new Button("Button"));
+
+        // then:
+        assertThat(styleable).hasTypeSelector("Button");
+    }
+
+    @Test
+    public void doesNotHaveTypeSelector() throws Exception {
+        // given (a Button which is-a Styleable):
+        Styleable styleable = FxToolkit.setupFixture(() -> new Button("Button"));
+
+        // then:
+        assertThat(styleable).doesNotHaveTypeSelector("Label");
+    }
+
+    @Test
+    public void hasStyle() throws Exception {
+        // given (a Button which is-a Styleable):
+        Styleable styleable = FxToolkit.setupFixture(() -> {
+            Button button = new Button("Button");
+            button.setStyle("-fx-background-color: RED;");
+            return button;
+        });
+
+        // then:
+        assertThat(styleable).hasStyle("-fx-background-color: RED;");
+    }
+
+    @Test
+    public void doesNotHaveStyle() throws Exception {
+        // given (a Button which is-a Styleable):
+        Styleable styleable = FxToolkit.setupFixture(() -> {
+            Button button = new Button("Button");
+            button.setStyle("-fx-background-color: RED;");
+            return button;
+        });
+
+        // then:
+        assertThat(styleable).doesNotHaveStyle("-fx-background-color: BLUE;");
+    }
+
+    @Test
+    public void hasStyleableParent() throws Exception {
+        // given (a Button which is-a Styleable contained in a StackPane):
+        StackPane[] pane = new StackPane[1];
+        Styleable styleable = FxToolkit.setupFixture(() -> {
+            Button button = new Button("Button");
+            button.setStyle("-fx-background-color: RED;");
+            StackPane stackPane = new StackPane(button);
+            pane[0] = stackPane;
+            return button;
+        });
+
+        // then:
+        assertThat(styleable).hasStyleableParent(pane[0]);
+    }
+
+    @Test
+    public void doesNotHaveStyleableParent() throws Exception {
+        // given (a Button which is-a Styleable contained in a StackPane):
+        StackPane[] pane = new StackPane[1];
+        Styleable styleable = FxToolkit.setupFixture(() -> {
+            Button button = new Button("Button");
+            button.setStyle("-fx-background-color: RED;");
+            StackPane stackPane = new StackPane();
+            pane[0] = stackPane;
+            return button;
+        });
+
+        // then:
+        assertThat(styleable).doesNotHaveStyleableParent(pane[0]);
+    }
+}


### PR DESCRIPTION
Also adds the AssertJ assertion equivalents for MenuItemMatcher.

Also make AbstractNodeAssert extend from newly added AbstractStyleableAssert so that the assertion chain matches the JavaFX scene-graph.