### PR TITLE
507 npe on empty cells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ screenshot*.png
 tags
 
 /subprojects/testfx-core/out/
+
+# Eclipse's gradle plugin
+bin/
+

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.control.Cell;
 import javafx.scene.control.TableColumn;
@@ -107,7 +108,8 @@ public class TableViewMatchers {
      * @param rowIndex the row number (starting from 0) that must contains the given cell values
      * @param cells The values or String representations of the values (e.g. the result of calling {@code toString()})
      * contained in the row at a given index you want to verify a {@code TableView} contains - one such value for
-     * each column of that {@code TableView}.
+     * each column of that {@code TableView}. Use {@code null} if the value is expected to not be set or if no cell 
+     * value factory has been set.
      */
     @Factory
     public static Matcher<TableView> containsRowAtIndex(int rowIndex, Object... cells) {
@@ -148,7 +150,8 @@ public class TableViewMatchers {
      *
      * @param cells The values or String representations of the values (e.g. the result of calling {@code toString()})
      * contained in the row you want to verify a {@code TableView} contains - one such value for each column of
-     * that {@code TableView}.
+     * that {@code TableView}. Use {@code null} if the value is expected to not be set or if no cell 
+     * value factory has been set.
      */
     @Factory
     public static Matcher<TableView> containsRow(Object...cells) {
@@ -186,13 +189,14 @@ public class TableViewMatchers {
     }
 
     private static List<ObservableValue<?>> getRowValues(TableView<?> tableView, int rowIndex) {
-        Object rowObject = tableView.getItems().get(rowIndex);
         List<ObservableValue<?>> rowValues = new ArrayList<>(tableView.getColumns().size());
         for (int i = 0; i < tableView.getColumns().size(); i++) {
             TableColumn<?, ?> column = tableView.getColumns().get(i);
-            TableColumn.CellDataFeatures cellDataFeatures = new TableColumn.CellDataFeatures(
-                    tableView, column, rowObject);
-            rowValues.add(i, column.getCellValueFactory().call(cellDataFeatures));
+            ObservableValue<?> cellObservableValue = column.getCellObservableValue(rowIndex);
+            if (cellObservableValue == null) {
+                cellObservableValue = new SimpleObjectProperty<>();
+            }
+            rowValues.add(i, cellObservableValue);
         }
         return rowValues;
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonTableCell.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonTableCell.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2019 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
 package org.testfx.matcher.control;
 
 import java.util.Map;
@@ -10,9 +26,11 @@ import javafx.scene.control.TableColumn;
 import javafx.util.Callback;
 
 /**
- * <p>A {@link TableCell} for use in matcher tests. It is somehwat special, because it does contain a {@link Button} rather than a real value.</p>
+ * <p>A {@link TableCell} for use in matcher tests. It is somehwat special, because it does contain a {@link Button}
+ * rather than a real value.
+ * </p>
  * <p>Implementation has been inspired by: 
- * @see <a href="https://stackoverflow.com/questions/29489366/how-to-add-button-in-javafx-table-view">https://stackoverflow.com/questions/29489366/how-to-add-button-in-javafx-table-view</a>.
+ * @see <a href="https://stackoverflow.com/questions/29489366/how-to-add-button-in-javafx-table-view">https://stackoverflow.com/questions/29489366/how-to-add-button-in-javafx-table-view</a>
  * </p>
  */
 final class ButtonTableCell extends TableCell<Map, Button> {
@@ -41,7 +59,7 @@ final class ButtonTableCell extends TableCell<Map, Button> {
             setGraphic(null);
         } else {
             if (button.getId() == null) {
-                button.setId(new Random().nextInt()+"");
+                button.setId(new Random().nextInt() + "");
             }
             setGraphic(button);
         }

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonTableCell.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonTableCell.java
@@ -1,0 +1,53 @@
+package org.testfx.matcher.control;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Consumer;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.util.Callback;
+
+/**
+ * <p>A {@link TableCell} for use in matcher tests. It is somehwat special, because it does contain a {@link Button} rather than a real value.</p>
+ * <p>Implementation has been inspired by: 
+ * @see <a href="https://stackoverflow.com/questions/29489366/how-to-add-button-in-javafx-table-view">https://stackoverflow.com/questions/29489366/how-to-add-button-in-javafx-table-view</a>.
+ * </p>
+ */
+final class ButtonTableCell extends TableCell<Map, Button> {
+
+    private final Button button;
+
+    public static Callback<TableColumn<Map, Button>, TableCell<Map, Button>> forTableColumn(String buttonLabel,
+            Consumer<Map> action) {
+        return param -> new ButtonTableCell(buttonLabel, action);
+    }
+
+    private ButtonTableCell(String buttonLabel, Consumer<Map> action) {
+        button = new Button(buttonLabel);
+        button.setOnAction(actionEvent -> {
+            action.accept(getCurrentModel());
+        });
+        button.setMaxWidth(Double.MAX_VALUE);
+    }
+
+    @Override
+    public void updateItem(Button item, boolean empty) {
+        super.updateItem(item, empty);
+
+        if (empty) {
+            setText(null);
+            setGraphic(null);
+        } else {
+            if (button.getId() == null) {
+                button.setId(new Random().nextInt()+"");
+            }
+            setGraphic(button);
+        }
+    }
+
+    private Map getCurrentModel() {
+        return getTableView().getItems().get(getIndex());
+    }
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -16,23 +16,6 @@
  */
 package org.testfx.matcher.control;
 
-import static javafx.collections.FXCollections.observableArrayList;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.testfx.api.FxRobot;
-import org.testfx.api.FxToolkit;
-import org.testfx.framework.junit.TestFXRule;
-import org.testfx.util.WaitForAsyncUtils;
-
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -52,6 +35,23 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.StackPane;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit.TestFXRule;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static javafx.collections.FXCollections.observableArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TableViewMatchersTest extends FxRobot {
 
@@ -92,8 +92,9 @@ public class TableViewMatchersTest extends FxRobot {
             TableColumn<Map, Integer> ageCol = new TableColumn<>("age");
             ageCol.setCellValueFactory(new MapValueFactory<>("age"));
             
-            TableColumn<Map, Button> btnCol= new TableColumn<>("button");
-            btnCol.setCellFactory(ButtonTableCell.forTableColumn("Click me!", unused -> System.out.println("Clicked!")));
+            TableColumn<Map, Button> btnCol = new TableColumn<>("button");
+            btnCol.setCellFactory(ButtonTableCell.forTableColumn(
+                "Click me!", unused -> System.out.println("Clicked!")));
             
             tableView.getColumns().setAll(nameCol, ageCol, btnCol);
             return new StackPane(tableView);
@@ -286,7 +287,7 @@ public class TableViewMatchersTest extends FxRobot {
 
     @Test
     public void containsRowAtIndex_wrong_types_fails() {
-        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, 63, "deedee",null)))
+        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, 63, "deedee", null)))
                 .isExactlyInstanceOf(AssertionError.class)
                 .hasMessage("\nExpected: TableView has row: [63, deedee, null] at index 1\n     " +
                         "but: was [bob, 31, null] at index: 1");

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -16,24 +16,11 @@
  */
 package org.testfx.matcher.control;
 
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
-
-import javafx.application.Platform;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
-import javafx.scene.control.cell.MapValueFactory;
-import javafx.scene.control.cell.PropertyValueFactory;
-import javafx.scene.control.cell.TextFieldTableCell;
-import javafx.scene.input.KeyCode;
-import javafx.scene.layout.StackPane;
+import static javafx.collections.FXCollections.observableArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -46,11 +33,25 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit.TestFXRule;
 import org.testfx.util.WaitForAsyncUtils;
 
-import static javafx.collections.FXCollections.observableArrayList;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import javafx.application.Platform;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.control.Button;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.MapValueFactory;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.StackPane;
 
 public class TableViewMatchersTest extends FxRobot {
 
@@ -58,7 +59,7 @@ public class TableViewMatchersTest extends FxRobot {
     public TestRule rule = new TestFXRule(2);
 
     TableView<Map> tableView;
-    TableColumn<Map, String> tableColumn0;
+    TableColumn<Map, String> nameCol;
 
     @BeforeClass
     public static void setupSpec() throws Exception {
@@ -69,27 +70,32 @@ public class TableViewMatchersTest extends FxRobot {
     public void setup() throws Exception {
         FxToolkit.setupSceneRoot(() -> {
             tableView = new TableView<>();
-            Map<String, Object> row1 = new HashMap<>(2);
+            Map row1 = new HashMap<>(2);
             row1.put("name", "alice");
             row1.put("age", 30);
 
-            Map<String, Object> row2 = new HashMap<>(2);
+            Map row2 = new HashMap<>(2);
             row2.put("name", "bob");
             row2.put("age", 31);
 
-            Map<String, Object> row3 = new HashMap<>(1);
+            Map row3 = new HashMap<>(1);
             row3.put("name", "carol");
 
-            Map<String, Object> row4 = new HashMap<>(1);
+            Map row4 = new HashMap<>(1);
             row4.put("name", "dave");
 
             tableView.setItems(observableArrayList(row1, row2, row3, row4));
-            tableColumn0 = new TableColumn<>("name");
-            tableColumn0.setId("tableColumn0");
-            tableColumn0.setCellValueFactory(new MapValueFactory<>("name"));
-            TableColumn<Map, Integer> tableColumn1 = new TableColumn<>("age");
-            tableColumn1.setCellValueFactory(new MapValueFactory<>("age"));
-            tableView.getColumns().setAll(tableColumn0, tableColumn1);
+            nameCol = new TableColumn<>("name");
+            nameCol.setId("tableColumn0");
+            nameCol.setCellValueFactory(new MapValueFactory<>("name"));
+            
+            TableColumn<Map, Integer> ageCol = new TableColumn<>("age");
+            ageCol.setCellValueFactory(new MapValueFactory<>("age"));
+            
+            TableColumn<Map, Button> btnCol= new TableColumn<>("button");
+            btnCol.setCellFactory(ButtonTableCell.forTableColumn("Click me!", unused -> System.out.println("Clicked!")));
+            
+            tableView.getColumns().setAll(nameCol, ageCol, btnCol);
             return new StackPane(tableView);
         });
         FxToolkit.showStage();
@@ -104,7 +110,7 @@ public class TableViewMatchersTest extends FxRobot {
     @Test
     public void hasTableCell_customCellValueFactory() {
         // given:
-        Platform.runLater(() -> tableColumn0.setCellFactory(column -> new TableCell<Map, String>() {
+        Platform.runLater(() -> nameCol.setCellFactory(column -> new TableCell<Map, String>() {
             @Override
             protected void updateItem(String item, boolean empty) {
                 super.updateItem(item, empty);
@@ -127,14 +133,14 @@ public class TableViewMatchersTest extends FxRobot {
         assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.hasTableCell("foobar")))
                 .isExactlyInstanceOf(AssertionError.class)
                 .hasMessage("\nExpected: TableView has table cell \"foobar\"\n     " +
-                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+                        "but: was [[alice, 30, null], [bob, 31, null], [carol, null, null], [dave, null, null]]");
     }
 
     @Test
     public void hasTableCell_fails_customCellValueFactory() {
         // given:
         Platform.runLater(() ->
-            tableColumn0.setCellFactory(column -> new TableCell<Map, String>() {
+            nameCol.setCellFactory(column -> new TableCell<Map, String>() {
                 @Override
                 protected void updateItem(String item, boolean empty) {
                     super.updateItem(item, empty);
@@ -164,12 +170,20 @@ public class TableViewMatchersTest extends FxRobot {
     }
 
     @Test
-    public void hasTableCell_with_null_fails() {
-        // FIXME: This works but it is nonsensical - why can't we accept null?
-        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.hasTableCell(null)))
-                .isExactlyInstanceOf(AssertionError.class)
-                .hasMessage("\nExpected: TableView has table cell \"null\"\n     " +
-                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+    public void hasTableCell_with_null_works() {
+        // given:
+        TableColumn<Map, Button> btnCol = new TableColumn<>("button");
+        btnCol.setCellFactory(ButtonTableCell.forTableColumn("Click me!", unused -> System.out.println("Clicked!")));
+        
+        Platform.runLater(() ->  {
+            tableView.getColumns().clear();
+            tableView.getColumns().add(btnCol);
+            tableView.refresh();
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // then:
+        assertThat(tableView, TableViewMatchers.hasTableCell(null));
     }
 
     @Test
@@ -248,10 +262,10 @@ public class TableViewMatchersTest extends FxRobot {
 
     @Test
     public void containsRowAtIndex_no_such_row_fails() {
-        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRowAtIndex(0, "jerry", 29)))
+        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRowAtIndex(0, "jerry", 29, null)))
                 .isExactlyInstanceOf(AssertionError.class)
-                .hasMessage("\nExpected: TableView has row: [jerry, 29] at index 0\n     " +
-                        "but: was [alice, 30] at index: 0");
+                .hasMessage("\nExpected: TableView has row: [jerry, 29, null] at index 0\n     " +
+                        "but: was [alice, 30, null] at index: 0");
     }
 
     @Test
@@ -272,10 +286,10 @@ public class TableViewMatchersTest extends FxRobot {
 
     @Test
     public void containsRowAtIndex_wrong_types_fails() {
-        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, 63, "deedee")))
+        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRowAtIndex(1, 63, "deedee",null)))
                 .isExactlyInstanceOf(AssertionError.class)
-                .hasMessage("\nExpected: TableView has row: [63, deedee] at index 1\n     " +
-                        "but: was [bob, 31] at index: 1");
+                .hasMessage("\nExpected: TableView has row: [63, deedee, null] at index 1\n     " +
+                        "but: was [bob, 31, null] at index: 1");
     }
 
     @Test
@@ -357,10 +371,10 @@ public class TableViewMatchersTest extends FxRobot {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRow("jerry", 29)))
+        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRow("jerry", 29, null)))
                 .isExactlyInstanceOf(AssertionError.class)
-                .hasMessage("\nExpected: TableView has row: [jerry, 29]\n     " +
-                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+                .hasMessage("\nExpected: TableView has row: [jerry, 29, null]\n     " +
+                        "but: was [[alice, 30, null], [bob, 31, null], [carol, null, null], [dave, null, null]]");
     }
 
     @Test
@@ -384,10 +398,10 @@ public class TableViewMatchersTest extends FxRobot {
         WaitForAsyncUtils.waitForFxEvents();
 
         // then:
-        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRow(63, "deedee")))
+        assertThatThrownBy(() -> assertThat(tableView, TableViewMatchers.containsRow(63, "deedee", null)))
                 .isExactlyInstanceOf(AssertionError.class)
-                .hasMessage("\nExpected: TableView has row: [63, deedee]\n     " +
-                        "but: was [[alice, 30], [bob, 31], [carol, null], [dave, null]]");
+                .hasMessage("\nExpected: TableView has row: [63, deedee, null]\n     " +
+                        "but: was [[alice, 30, null], [bob, 31, null], [carol, null, null], [dave, null, null]]");
     }
 
     /**

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/TestFXRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/TestFXRule.java
@@ -27,24 +27,26 @@ import org.testfx.api.FxToolkit;
 import org.testfx.util.WaitForAsyncUtils;
 
 /**
- * Optional JUit rule that can be used to ensure the JavaFX platform has
+ * Optional JUnit rule that can be used to ensure the JavaFX platform has
  * been initialized before UI tests are run. The rule can also be used
  * for retrying flaky tests.
  * <p>
  * The rule can be used by adding a {@code @Rule} annotated field to your
  * test class:
- * <pre>{@code
+ * <pre>
  * public class MyTest extends ApplicationTest {
  *     {@literal @}Rule public TestFXRule testFXRule = new TestFXRule();
  *
- *     @Test
+ *     {@literal @}Test
  *     public void myTest() {
  *         // ...
  *     }
  * }
- * }</pre>
+ * </pre>
+ * </p>
  * <p>
  * Developer's Note: TestFX uses this rule for its' own tests.
+ * </p>
  */
 public class TestFXRule extends TestWatcher {
 


### PR DESCRIPTION
Hi there, I had the problem of using "special" cells in a TableView. Those cells would display a button instead of a value. That seemed to cause NPEs in `TableViewMatchers.java:195`, because in this scenario no CellValueFactory is set.

I implemented a quick fix for that which may also "fix" issue #507. The TableViewMatchers's methods do now accept `null` as a cell "value", which is interpreted as "no value" or "no cell value factory set" respectively.

This comes with a minor change in semantics of `org.testfx.matcher.control.TableViewMatchers.containsRow(Object...)` and `org.testfx.matcher.control.TableViewMatchers.containsRowAtIndex(int, Object...)` which I have documented in the JavaDoc. Hope it's ok though.

What do you think?