### PR TITLE
Make junit5 dependency compileOnly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ dependencies {
 
 ```gradle
 dependencies {
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.5.1'
     testCompile "org.testfx:testfx-junit5:4.0.15-alpha"
 }
 ```
@@ -125,6 +126,12 @@ your project. TestFX supports JUnit 4, JUnit 5, and Spock.
 ### JUnit 5
 
 ```xml
+<dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-api</artifactId>
+    <version>5.5.1</version>
+    <scope>test</scope>
+</dependency>
 <dependency>
     <groupId>org.testfx</groupId>
     <artifactId>testfx-junit5</artifactId>

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -28,11 +28,9 @@ test {
 dependencies {
     compile project(":testfx-core")
 
-    // Removes compile warnings about missing enums.
-    compile('org.apiguardian:apiguardian-api:1.0.0')
-
-    compile 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+    compileOnly 'org.junit.jupiter:junit-jupiter-api:5.5.1'
+    testCompileOnly 'org.junit.jupiter:junit-jupiter-api:5.5.1'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.5.1'
 
     if (JavaVersion.current().isJava11Compatible()) {
         testCompile "org.testfx:openjfx-monocle:jdk-11+26"
@@ -79,9 +77,10 @@ compileTestJava {
         doFirst {
             options.compilerArgs = [
                     '--module-path', classpath.asPath,
-                    '--add-modules', 'org.junit.jupiter.api,javafx.controls',
+                    '--add-modules', 'org.junit.jupiter.api,javafx.controls,hamcrest.core',
                     '--add-reads', "$moduleName=org.junit.jupiter.api",
                     '--add-reads', "$moduleName=javafx.controls",
+                    '--add-reads', "$moduleName=hamcrest.core",
                     '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath,
             ]
             classpath = files()


### PR DESCRIPTION
This will require users who want to use testfx-junit5 to manually
require the junit-jupiter-api dependency but this makes more sense
than having version conflicts!

Fixes #661.