### PR TITLE
[chore] Add fake bnd version for jitpack.

### DIFF
--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -189,7 +189,7 @@ afterEvaluate {
 
         bnd (
             'Export-Package': '*',
-            'Bundle-Version': "${project.version}",
+            'Bundle-Version': "${System.env.JITPACK == 'true' ? '0.0.1' : project.version}",
             'Bundle-Activator': 'org.testfx.osgi.Activator',
             'Require-Capability': 'org.testfx.osgi.versionadapter'
         )


### PR DESCRIPTION
When trying to build on jitpack a commit hash version is used which is invalid according to `bnd`'s strict version regex `[0-9]{1,9}(\.[0-9]{1,9}(\.[0-9]{1,9}(\.[0-9A-Za-z_-]+)?)?)?`. 