### PR TITLE
Sleep after atomic mouse actions

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
@@ -82,7 +82,7 @@ public class FxRobotContext {
         typeRobot = new TypeRobotImpl(keyboardRobot, sleepRobot);
         writeRobot = new WriteRobotImpl(baseRobot, sleepRobot, windowFinder);
         moveRobot = new MoveRobotImpl(baseRobot, mouseRobot, sleepRobot);
-        clickRobot = new ClickRobotImpl(mouseRobot, moveRobot, sleepRobot);
+        clickRobot = new ClickRobotImpl(mouseRobot, moveRobot);
         dragRobot = new DragRobotImpl(mouseRobot, moveRobot);
         scrollRobot = new ScrollRobotImpl(mouseRobot);
         captureSupport = new CaptureSupportImpl(baseRobot);

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
@@ -77,8 +77,8 @@ public class FxRobotContext {
         pointLocator = new PointLocatorImpl(boundsLocator);
         baseRobot = new BaseRobotImpl();
         keyboardRobot = new KeyboardRobotImpl(baseRobot);
-        mouseRobot = new MouseRobotImpl(baseRobot);
         sleepRobot = new SleepRobotImpl();
+        mouseRobot = new MouseRobotImpl(baseRobot, sleepRobot);
         typeRobot = new TypeRobotImpl(keyboardRobot, sleepRobot);
         writeRobot = new WriteRobotImpl(baseRobot, sleepRobot, windowFinder);
         moveRobot = new MoveRobotImpl(baseRobot, mouseRobot, sleepRobot);

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
@@ -29,19 +29,14 @@ import org.testfx.service.query.PointQuery;
 
 public class ClickRobotImpl implements ClickRobot {
 
-    private static final long SLEEP_AFTER_DOUBLE_CLICK_IN_MILLIS = 50;
-
     private final MouseRobot mouseRobot;
     private final MoveRobot moveRobot;
-    private final SleepRobot sleepRobot;
 
-    public ClickRobotImpl(MouseRobot mouseRobot, MoveRobot moveRobot, SleepRobot sleepRobot) {
+    public ClickRobotImpl(MouseRobot mouseRobot, MoveRobot moveRobot) {
         Objects.requireNonNull(mouseRobot, "mouseRobot must not be null");
         Objects.requireNonNull(moveRobot, "moveRobot must not be null");
-        Objects.requireNonNull(sleepRobot, "sleepRobot must not be null");
         this.mouseRobot = mouseRobot;
         this.moveRobot = moveRobot;
-        this.sleepRobot = sleepRobot;
     }
 
     @Override
@@ -60,7 +55,6 @@ public class ClickRobotImpl implements ClickRobot {
     public void doubleClickOn(MouseButton... buttons) {
         clickOn(buttons);
         clickOn(buttons);
-        sleepRobot.sleep(SLEEP_AFTER_DOUBLE_CLICK_IN_MILLIS);
     }
 
     @Override
@@ -68,7 +62,6 @@ public class ClickRobotImpl implements ClickRobot {
         moveRobot.moveTo(pointQuery, motion);
         clickOn(buttons);
         clickOn(buttons);
-        sleepRobot.sleep(SLEEP_AFTER_DOUBLE_CLICK_IN_MILLIS);
     }
 
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
@@ -27,22 +27,32 @@ import javafx.scene.input.MouseButton;
 
 import org.testfx.robot.BaseRobot;
 import org.testfx.robot.MouseRobot;
+import org.testfx.robot.SleepRobot;
 import org.testfx.util.WaitForAsyncUtils;
 
 public class MouseRobotImpl implements MouseRobot {
 
+    /**
+     * Duration between atomic mouse action (required for those actions to be correctly detected by OS).
+     */
+    final static private long mouseActionDurationMillis = 20L;
+
     private final BaseRobot baseRobot;
     private final Set<MouseButton> pressedButtons = new HashSet<>();
+    private final SleepRobot sleepRobot;
 
-    public MouseRobotImpl(BaseRobot baseRobot) {
+    public MouseRobotImpl(BaseRobot baseRobot, SleepRobot sleepRobot) {
         Objects.requireNonNull(baseRobot, "baseRobot must not be null");
+        Objects.requireNonNull(sleepRobot, "sleepRobot must not be null");
         this.baseRobot = baseRobot;
+        this.sleepRobot = sleepRobot;
     }
  
     @Override
     public void press(MouseButton... buttons) {
         pressNoWait(buttons);
         WaitForAsyncUtils.waitForFxEvents();
+        sleepRobot.sleep(mouseActionDurationMillis);
     }
 
     @Override
@@ -53,12 +63,14 @@ public class MouseRobotImpl implements MouseRobot {
         else {
             Arrays.asList(buttons).forEach(this::pressButton);
         }
+        sleepRobot.sleep(mouseActionDurationMillis);
     }
 
     @Override
     public void release(MouseButton... buttons) {
         releaseNoWait(buttons);
         WaitForAsyncUtils.waitForFxEvents();
+        sleepRobot.sleep(mouseActionDurationMillis);
     }
 
     @Override
@@ -69,17 +81,20 @@ public class MouseRobotImpl implements MouseRobot {
         else {
             Arrays.asList(buttons).forEach(this::releaseButton);
         }
+        sleepRobot.sleep(mouseActionDurationMillis);
     }
 
     @Override
     public void move(Point2D location) {
         moveNoWait(location);
         WaitForAsyncUtils.waitForFxEvents();
+        sleepRobot.sleep(mouseActionDurationMillis);
     }
 
     @Override
     public void moveNoWait(Point2D location) {
         baseRobot.moveMouse(location);
+        sleepRobot.sleep(mouseActionDurationMillis);
     }
 
     @Override

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MouseRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MouseRobotImplTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.Timeout;
 import org.testfx.TestFXRule;
 import org.testfx.robot.BaseRobot;
 import org.testfx.robot.MouseRobot;
+import org.testfx.robot.SleepRobot;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -44,11 +45,13 @@ public class MouseRobotImplTest {
 
     MouseRobot mouseRobot;
     BaseRobot baseRobot;
+    SleepRobot sleepRobot;
 
     @Before
     public void setup() {
         baseRobot = mock(BaseRobot.class);
-        mouseRobot = new MouseRobotImpl(baseRobot);
+        sleepRobot = mock(SleepRobot.class);
+        mouseRobot = new MouseRobotImpl(baseRobot, sleepRobot);
     }
 
     @Test


### PR DESCRIPTION
Without sleep after mouse actions, some OSes miss actions. This is especially true for double-click.
Human normally clicks in 50~ms, below 5ms it seems that click are missed. This change add a sleep of 20ms that is quick enough to be catch by OSes and closer from real human than nothing.
With this change, sleep after double-click in ClickRobotImpl becomes useless (less reliable than sleep after atomic mouse actions press/release).