### PR TITLE
JUnit5 TestFX extension to execute @Test within JavaFX UI thread

### DIFF
--- a/gradle/check/checkstyle.xml
+++ b/gradle/check/checkstyle.xml
@@ -20,7 +20,10 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
     <property name="charset" value="UTF-8"/>
-
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
     <module name="TreeWalker">
         <module name="AvoidNestedBlocks">
             <property name="allowInSwitchCase" value="true"/>
@@ -42,10 +45,6 @@
             <property name="arrayInitIndent" value="2"/>
         </module>
         <module name="CommentsIndentation"/>
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-        </module>
         <module name="SeparatorWrap">
             <property name="tokens" value="DOT"/>
             <property name="option" value="nl"/>

--- a/subprojects/testfx-core/src/main/java/module-info.java
+++ b/subprojects/testfx-core/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssertContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxAssertContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotException.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxRobotInterface.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxServiceContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxServiceContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkit.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkitContext.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/api/FxToolkitContext.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractButtonAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractButtonAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractColorAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractColorAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractComboBoxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractComboBoxAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractDimension2DAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractDimension2DAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractLabeledAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractLabeledAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractListViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractListViewAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractMenuItemAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractMenuItemAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractNodeAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractNodeAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractParentAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractParentAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractStyleableAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractStyleableAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTableViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTableViewAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextFlowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextFlowAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextInputControlAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractTextInputControlAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractWindowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/AbstractWindowAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Assertions.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Assertions.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ButtonAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ButtonAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ColorAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ColorAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ComboBoxAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ComboBoxAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Dimension2DAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/Dimension2DAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/LabeledAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/LabeledAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ListViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ListViewAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/MenuItemAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/MenuItemAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/NodeAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/NodeAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ParentAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/ParentAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/StyleableAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/StyleableAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TableViewAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TableViewAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextFlowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextFlowAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextInputControlAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/TextInputControlAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/WindowAssert.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/api/WindowAssert.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/assertions/impl/Adapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/assertions/impl/Adapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/internal/JavaVersionAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/internal/JavaVersionAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/internal/PlatformAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/internal/PlatformAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ColorMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeneralMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeneralMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeometryMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/GeometryMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/NodeMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/NodeMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ParentMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/ParentMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/StyleableMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/StyleableMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/WindowMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/base/WindowMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ButtonMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ButtonMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ComboBoxMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/LabeledMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/LabeledMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/ListViewMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/MenuItemMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/MenuItemMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TableViewMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextFlowMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextInputControlMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextInputControlMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextMatchers.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/matcher/control/TextMatchers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/osgi/Activator.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/osgi/Activator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/osgi/service/TestFx.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/osgi/service/TestFx.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/BaseRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/BaseRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/ClickRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/ClickRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/DragRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/DragRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/KeyboardRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/KeyboardRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/Motion.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/Motion.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/MouseRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/MouseRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/MoveRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/MoveRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/ScrollRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/ScrollRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/SleepRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/SleepRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/TypeRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/TypeRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/WriteRobot.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/WriteRobot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ClickRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/DragRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/DragRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/KeyboardRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MouseRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MoveRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/MoveRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ScrollRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/ScrollRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/SleepRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/SleepRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/TypeRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/TypeRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/WriteRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/WriteRobotImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/RobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/RobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/AwtRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/GlassRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PrivateGlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PrivateGlassRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PublicGlassRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/PublicGlassRobotAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/NodeFinder.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/NodeFinder.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/WindowFinder.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/NodeFinderImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/finder/impl/WindowFinderImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocator.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocatorException.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/BoundsLocatorException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/PointLocator.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/PointLocator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/BoundsLocatorImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/BoundsLocatorImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/locator/impl/PointLocatorImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/BoundsQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/EmptyNodeQueryException.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/EmptyNodeQueryException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/NodeQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/PointQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/BoundsPointQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/CallableBoundsPointQuery.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/CallableBoundsPointQuery.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/NodeQueryImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/query/impl/PointQueryBase.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/Capture.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/Capture.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureSupport.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureSupport.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/ColorMatcher.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/ColorMatcher.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/FiredEvents.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/FiredEvents.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcher.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcher.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcherResult.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/PixelMatcherResult.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/CaptureSupportImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/CaptureSupportImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherBase.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherBase.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/PixelMatcherRgb.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationLauncher.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationLauncher.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ApplicationService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/PrimaryStageApplication.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/PrimaryStageApplication.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ToolkitService.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/ToolkitService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationLauncherImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationLauncherImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationServiceImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ApplicationServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/BoundsQueryUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/ColorUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/DebugUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/DebugUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/NodeQueryUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/PointQueryUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/TestFXRule.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/TestFXRule.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ButtonAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ButtonAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ColorAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ColorAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ComboBoxAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ComboBoxAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/Dimension2DAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/Dimension2DAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/LabeledAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/LabeledAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ListViewAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ListViewAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/NodeAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/NodeAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ParentAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/ParentAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/StyleableAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/StyleableAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TableViewAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TableViewAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextFlowAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextFlowAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextInputControlAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextInputControlAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/WindowAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/WindowAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/TestCaseBase.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/CustomStageFixtureDemo.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/CustomStageFixtureDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxAssertBasicTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxToolkitBasicTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/FxToolkitBasicTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/NodeAndPointQueryTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/PrimaryStageFixtureDemo.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/PrimaryStageFixtureDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/SceneRootAssertionTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/acceptance/SceneRootAssertionTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DialogTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DialogTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/DragAndDropTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/HDPIContractTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/MenuBarTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/SimpleLabelTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/integration/SimpleLabelTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/GlassRobotClipboardBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/GlassRobotClipboardBug.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/StageHideDeadlockBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/StageHideDeadlockBug.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/WriteHeadlessTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/WriteHeadlessTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ColorMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeneralMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeneralMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeometryMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/GeometryMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/NodeMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ParentMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/ParentMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/WindowMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/base/WindowMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonTableCell.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ButtonTableCell.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ComboBoxMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/LabeledMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/ListViewMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/MenuItemMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/MenuItemMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TableViewMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextFlowMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextInputControlMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextInputControlMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/DragRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/DragRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/KeyboardRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/KeyboardRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MouseRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MouseRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MoveRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/MoveRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ScrollRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ScrollRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/TypeRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/TypeRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/WriteRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/WriteRobotImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/AwtRobotAdapterTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/GlassRobotAdapterTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/adapter/impl/JavafxRobotAdapterTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/NodeFinderImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/finder/impl/WindowFinderImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/BoundsLocatorImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/locator/impl/PointLocatorImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/BoundsPointQueryTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/BoundsPointQueryTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/query/impl/NodeQueryImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/toolkit/impl/ToolkitServiceImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/toolkit/impl/ToolkitServiceImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/BoundsQueryUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/DebugUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/DebugUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/PointQueryUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsFxTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsFxTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/util/WaitForAsyncUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/module-info.java
+++ b/subprojects/testfx-junit/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationAdapter.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationFixture.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationFixture.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationRule.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/TestFXRule.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/TestFXRule.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/ApplicationRuleTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/JUnitExceptionTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/framework/junit/KeyAndButtonReleaseTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/module-info.java
+++ b/subprojects/testfx-junit5/src/main/java/module-info.java
@@ -19,5 +19,4 @@ module org.testfx.junit5 {
 
     requires transitive org.junit.jupiter.api;
     requires transitive org.testfx;
-    requires org.junit.platform.commons;
 }

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationAdapter.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
-
 import org.testfx.util.WaitForAsyncUtils;
 
 public class ApplicationExtension extends FxRobot implements BeforeEachCallback, AfterEachCallback,

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationExtension.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationFixture.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationFixture.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/ApplicationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Init.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Init.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/JavaFXInterceptorUtils.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/JavaFXInterceptorUtils.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2020 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.testfx.framework.junit5.utils.FXUtils;
+
+/**
+ * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed in the JavaFX UI thread.
+ * This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
+ * <p>
+ * Use the
+ * <ul>
+ * <li> {@code @ExtendWith(avaFxInterceptor.class) } if all @Test, or
+ * <li> {@code @ExtendWith(SelectiveJavaFxInterceptor.class) } if only @Test + @TestFx annotated tests
+ * </ul>
+ * should be executed within the JavaFX UI thread.
+ *
+ * @author RalphSteinhagen
+ */
+public class JavaFXInterceptorUtils {
+    /**
+	 * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed in the JavaFX UI thread.
+	 * This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
+	 * <p>
+	 * Example usage:
+	 * <pre><code>
+	 * @ExtendWith(ApplicationExtension.class)
+	 * @ExtendWith(JavaFxInterceptor.class)
+	 * public class SquareButtonTest {
+	 *     @Start
+	 *     public void start(Stage stage) {
+	 *         // usual FX initialisation
+	 *         // ...
+	 *     }
+	 *
+	 *    @TestFx // note: this is equivalent to {@code @Test} when using {@code @ExtendWith(JavaFxInterceptor.class)}
+	 *    public void testJavaFxThreadSafety() {
+	 *        // verifies that this test is indeed executed in the JavaFX thread
+	 *        assertTrue(Platform.isFxApplicationThread());
+	 *
+	 *        // perform the regular JavaFX thread safe assertion tests
+	 *        // ...
+	 *    }
+	 *
+	 *    @Test // also executed in JavaFX thread, for different behaviour use:  {@code @ExtendWith(SelectiveJavaFxInterceptor.class)}
+	 *    public void testNonJavaFx() {
+	 *        // verifies that this test is also executed in the JavaFX thread
+	 *        assertTrue(Platform.isFxApplicationThread());
+	 *
+	 *        // perform regular assertion tests within the JavaFX thread
+	 *        // ...
+	 *    }
+	 * }
+	 *
+	 * </code></pre>
+	 *
+	 * @author rstein
+	 */
+    public static class JavaFxInterceptor implements InvocationInterceptor {
+        @Override
+        public void interceptTestMethod(final Invocation<Void> invocation,
+                final ReflectiveInvocationContext<Method> invocationContext,
+                final ExtensionContext extensionContext) throws Throwable {
+            final AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+            // N.B. explicit run and wait since the test should only continue
+            // if the previous JavaFX access as been finished.
+            FXUtils.runAndWait(() -> {
+                try {
+                    // executes function after @Test
+                    invocation.proceed();
+                } catch (final Throwable t) {
+                    throwable.set(t);
+                }
+            });
+            final Throwable t = throwable.get();
+            if (t != null) {
+                throw t;
+            }
+        }
+    }
+
+    /**
+	 * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed in the JavaFX UI thread.
+	 * This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
+	 * <p>
+	 * Example usage:
+	 * <pre><code>
+	 * @ExtendWith(ApplicationExtension.class)
+	 * @ExtendWith(SelectiveJavaFxInterceptor.class)
+	 * public class SquareButtonTest {
+	 *     @Start
+	 *     public void start(Stage stage) {
+	 *         // usual FX initialisation
+	 *         // ...
+	 *     }
+	 *
+	 *    @TestFx // forces execution in JavaFX thread
+	 *    public void testJavaFxThreadSafety() {
+	 *        // verifies that this test is indeed executed in the JavaFX thread
+	 *        assertTrue(Platform.isFxApplicationThread());
+	 *
+	 *        // perform the regular JavaFX thread safe assertion tests
+	 *        // ...
+	 *    }
+	 *
+	 *    @Test // explicitly not executed in JavaFX thread; for different behaviour use:  {@code @ExtendWith(JavaFxInterceptor.class)}
+	 *    public void testNonJavaFx() {
+	 *        // verifies that this test is not executed within the JavaFX thread
+	 *        assertFalse(Platform.isFxApplicationThread());
+	 *
+	 *        // perform the regular non-JavaFX thread-related assertion tests
+	 *        // ...
+	 *    }
+	 * }
+	 *
+	 * </code></pre>
+	 *
+	 * @author rstein
+	 */
+    public static class SelectiveJavaFxInterceptor implements InvocationInterceptor {
+        @Override
+        public void interceptTestMethod(final Invocation<Void> invocation,
+                final ReflectiveInvocationContext<Method> invocationContext,
+                final ExtensionContext extensionContext) throws Throwable {
+            final AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+            boolean isFxAnnotation = false;
+            final Optional<AnnotatedElement> element = extensionContext.getElement();
+            if (element.isPresent()) {
+                for (final Annotation annotation : element.get().getAnnotations()) {
+                    if (annotation.annotationType().equals(TestFx.class)) {
+                        isFxAnnotation = true;
+                    }
+                }
+            }
+
+            final Runnable testToBeExecuted = () -> {
+                try {
+                    // executes function after @Test
+                    invocation.proceed();
+                } catch (final Throwable t) {
+                    throwable.set(t);
+                }
+            };
+
+            // N.B. explicit run and wait since the test should only continue
+            // if the previous JavaFX access as been finished.
+            if (isFxAnnotation) {
+                FXUtils.runAndWait(testToBeExecuted);
+            } else {
+                testToBeExecuted.run();
+            }
+            final Throwable t = throwable.get();
+            if (t != null) {
+                throw t;
+            }
+        }
+    }
+}

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/JavaFXInterceptorUtils.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/JavaFXInterceptorUtils.java
@@ -28,61 +28,65 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.testfx.framework.junit5.utils.FXUtils;
 
 /**
- * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed in the JavaFX UI thread.
- * This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
+ * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed
+ * in the JavaFX UI thread. This is (strictly) necessary when testing setter
+ * and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
  * <p>
  * Use the
  * <ul>
- * <li> {@code @ExtendWith(avaFxInterceptor.class) } if all @Test, or
- * <li> {@code @ExtendWith(SelectiveJavaFxInterceptor.class) } if only @Test + @TestFx annotated tests
+ * <li>{@code @ExtendWith(avaFxInterceptor.class) } if all @Test, or
+ * <li>{@code @ExtendWith(SelectiveJavaFxInterceptor.class) } if only @Test
+ * + @TestFx annotated tests
  * </ul>
  * should be executed within the JavaFX UI thread.
- *
- * @author RalphSteinhagen
  */
 public class JavaFXInterceptorUtils {
     /**
-	 * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed in the JavaFX UI thread.
-	 * This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
-	 * <p>
-	 * Example usage:
-	 * <pre><code>
-	 * @ExtendWith(ApplicationExtension.class)
-	 * @ExtendWith(JavaFxInterceptor.class)
-	 * public class SquareButtonTest {
-	 *     @Start
-	 *     public void start(Stage stage) {
-	 *         // usual FX initialisation
-	 *         // ...
-	 *     }
-	 *
-	 *    @TestFx // note: this is equivalent to {@code @Test} when using {@code @ExtendWith(JavaFxInterceptor.class)}
-	 *    public void testJavaFxThreadSafety() {
-	 *        // verifies that this test is indeed executed in the JavaFX thread
-	 *        assertTrue(Platform.isFxApplicationThread());
-	 *
-	 *        // perform the regular JavaFX thread safe assertion tests
-	 *        // ...
-	 *    }
-	 *
-	 *    @Test // also executed in JavaFX thread, for different behaviour use:  {@code @ExtendWith(SelectiveJavaFxInterceptor.class)}
-	 *    public void testNonJavaFx() {
-	 *        // verifies that this test is also executed in the JavaFX thread
-	 *        assertTrue(Platform.isFxApplicationThread());
-	 *
-	 *        // perform regular assertion tests within the JavaFX thread
-	 *        // ...
-	 *    }
-	 * }
-	 *
-	 * </code></pre>
-	 *
-	 * @author rstein
-	 */
+     * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed
+     * in the JavaFX UI thread. This is (strictly) necessary when testing setter
+     * and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
+     * <p>
+     * Example usage:
+     * 
+     * <pre>
+     * <code>
+     * &#64;ExtendWith(ApplicationExtension.class)
+     * &#64;ExtendWith(JavaFxInterceptor.class)
+     * public class SquareButtonTest {
+     *     &#64;Start
+     *     public void start(Stage stage) {
+     *         // usual FX initialisation
+     *         // ...
+     *     }
+     *
+     *    &#64;TestFx 
+     *    // note: this is equivalent to {@code @Test} when using {@code @ExtendWith(JavaFxInterceptor.class)}
+     *    public void testJavaFxThreadSafety() {
+     *        // verifies that this test is indeed executed in the JavaFX thread
+     *        assertTrue(Platform.isFxApplicationThread());
+     *
+     *        // perform the regular JavaFX thread safe assertion tests
+     *        // ...
+     *    }
+     *
+     *    &#64;Test // also executed in JavaFX thread, 
+     *    // for different behaviour use:  {@code @ExtendWith(SelectiveJavaFxInterceptor.class)}
+     *    public void testNonJavaFx() {
+     *        // verifies that this test is also executed in the JavaFX thread
+     *        assertTrue(Platform.isFxApplicationThread());
+     *
+     *        // perform regular assertion tests within the JavaFX thread
+     *        // ...
+     *    }
+     * }
+     *
+     * </code>
+     * </pre>
+     */
     public static class JavaFxInterceptor implements InvocationInterceptor {
         @Override
-        public void interceptTestMethod(final Invocation<Void> invocation,
-                final ReflectiveInvocationContext<Method> invocationContext,
+        public void interceptTestMethod(final Invocation<Void> invocation, 
+                final ReflectiveInvocationContext<Method> invocationContext, 
                 final ExtensionContext extensionContext) throws Throwable {
             final AtomicReference<Throwable> throwable = new AtomicReference<>();
 
@@ -92,7 +96,8 @@ public class JavaFXInterceptorUtils {
                 try {
                     // executes function after @Test
                     invocation.proceed();
-                } catch (final Throwable t) {
+                }
+                catch (final Throwable t) {
                     throwable.set(t);
                 }
             });
@@ -104,47 +109,50 @@ public class JavaFXInterceptorUtils {
     }
 
     /**
-	 * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed in the JavaFX UI thread.
-	 * This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
-	 * <p>
-	 * Example usage:
-	 * <pre><code>
-	 * @ExtendWith(ApplicationExtension.class)
-	 * @ExtendWith(SelectiveJavaFxInterceptor.class)
-	 * public class SquareButtonTest {
-	 *     @Start
-	 *     public void start(Stage stage) {
-	 *         // usual FX initialisation
-	 *         // ...
-	 *     }
-	 *
-	 *    @TestFx // forces execution in JavaFX thread
-	 *    public void testJavaFxThreadSafety() {
-	 *        // verifies that this test is indeed executed in the JavaFX thread
-	 *        assertTrue(Platform.isFxApplicationThread());
-	 *
-	 *        // perform the regular JavaFX thread safe assertion tests
-	 *        // ...
-	 *    }
-	 *
-	 *    @Test // explicitly not executed in JavaFX thread; for different behaviour use:  {@code @ExtendWith(JavaFxInterceptor.class)}
-	 *    public void testNonJavaFx() {
-	 *        // verifies that this test is not executed within the JavaFX thread
-	 *        assertFalse(Platform.isFxApplicationThread());
-	 *
-	 *        // perform the regular non-JavaFX thread-related assertion tests
-	 *        // ...
-	 *    }
-	 * }
-	 *
-	 * </code></pre>
-	 *
-	 * @author rstein
-	 */
+     * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed
+     * in the JavaFX UI thread. This is (strictly) necessary when testing setter
+     * and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
+     * <p>
+     * Example usage:
+     * 
+     * <pre>
+     * <code>
+     * &#64;ExtendWith(ApplicationExtension.class)
+     * &#64;ExtendWith(SelectiveJavaFxInterceptor.class)
+     * public class SquareButtonTest {
+     *     &#64;Start
+     *     public void start(Stage stage) {
+     *         // usual FX initialisation
+     *         // ...
+     *     }
+     *
+     *    &#64;TestFx // forces execution in JavaFX thread
+     *    public void testJavaFxThreadSafety() {
+     *        // verifies that this test is indeed executed in the JavaFX thread
+     *        assertTrue(Platform.isFxApplicationThread());
+     *
+     *        // perform the regular JavaFX thread safe assertion tests
+     *        // ...
+     *    }
+     *
+     *    &#64;Test // explicitly not executed in JavaFX thread; 
+     *    // for different behaviour use:  {@code @ExtendWith(JavaFxInterceptor.class)}
+     *    public void testNonJavaFx() {
+     *        // verifies that this test is not executed within the JavaFX thread
+     *        assertFalse(Platform.isFxApplicationThread());
+     *
+     *        // perform the regular non-JavaFX thread-related assertion tests
+     *        // ...
+     *    }
+     * }
+     *
+     * </code>
+     * </pre>
+     */
     public static class SelectiveJavaFxInterceptor implements InvocationInterceptor {
         @Override
-        public void interceptTestMethod(final Invocation<Void> invocation,
-                final ReflectiveInvocationContext<Method> invocationContext,
+        public void interceptTestMethod(final Invocation<Void> invocation, 
+                final ReflectiveInvocationContext<Method> invocationContext, 
                 final ExtensionContext extensionContext) throws Throwable {
             final AtomicReference<Throwable> throwable = new AtomicReference<>();
 
@@ -162,7 +170,8 @@ public class JavaFXInterceptorUtils {
                 try {
                     // executes function after @Test
                     invocation.proceed();
-                } catch (final Throwable t) {
+                }
+                catch (final Throwable t) {
                     throwable.set(t);
                 }
             };

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Start.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Start.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Stop.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/Stop.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/TestFx.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/TestFx.java
@@ -26,9 +26,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * extension of JUnits @Test annotation to indicate that a particular test should be explicitly executed within the JavaFX thread. 
- * See also {@link de.gsi.chart.ui.utils.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor }
- * @author rstein
+ * extension of JUnits @Test annotation to indicate that a particular test should be explicitly 
+ * executed within the JavaFX thread.
  *
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/TestFx.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/TestFx.java
@@ -14,10 +14,27 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
-module org.testfx.junit5 {
-    exports org.testfx.framework.junit5;
+package org.testfx.framework.junit5;
 
-    requires transitive org.junit.jupiter.api;
-    requires transitive org.testfx;
-    requires org.junit.platform.commons;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * extension of JUnits @Test annotation to indicate that a particular test should be explicitly executed within the JavaFX thread. 
+ * See also {@link de.gsi.chart.ui.utils.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor }
+ * @author rstein
+ *
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Test
+@Tag("TestWithinJavaFX")
+public @interface TestFx {
 }

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
@@ -28,15 +28,15 @@ import java.util.function.Supplier;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
+// import org.junit.platform.commons.logging.Logger;
+// import org.junit.platform.commons.logging.LoggerFactory;
 
 /**
  * Small tool to execute/call JavaFX GUI-related code from potentially non-JavaFX thread (equivalent to old:
  * SwingUtilities.invokeLater(...) ... invokeAndWait(...) tools)
  */
 public final class FXUtils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FXUtils.class);
+    // private static final Logger LOGGER = LoggerFactory.getLogger(FXUtils.class);
 
     public static void assertJavaFxThread() {
         if (!Platform.isFxApplicationThread()) {
@@ -183,7 +183,8 @@ public final class FXUtils {
         catch (final Exception e) {
             // cannot occur: tickListener is always non-null and
             // addPostLayoutPulseListener through 'runaAndWait' always executed in JavaFX thread
-            LOGGER.error(e, () -> "addPostLayoutPulseListener interrupted");
+            // LOGGER..error(e, () -> "addPostLayoutPulseListener interrupted");
+            e.printStackTrace();
         }
         try {
             Platform.requestNextPulse();
@@ -191,7 +192,7 @@ public final class FXUtils {
                 timer.schedule(new TimerTask() {
                     @Override
                     public void run() {
-                        LOGGER.warn(() -> "FXUtils::waitForTicks(..) interrupted by timeout");
+                        // LOGGER..warn(() -> "FXUtils::waitForTicks(..) interrupted by timeout");
 
                         lock.lock();
                         try {
@@ -210,7 +211,8 @@ public final class FXUtils {
             }
         }
         catch (final InterruptedException e) {
-            LOGGER.error(e, () -> "await interrupted");
+            // LOGGER..error(e, () -> "await interrupted");
+            e.printStackTrace();
         }
         finally {
             lock.unlock();
@@ -222,7 +224,8 @@ public final class FXUtils {
         catch (final Exception e) {
             // cannot occur: tickListener is always non-null and
             // removePostLayoutPulseListener through 'runaAndWait' always executed in JavaFX thread
-            LOGGER.error(e, () -> "removePostLayoutPulseListener interrupted");
+            // LOGGER..error(e, () -> "removePostLayoutPulseListener interrupted");
+            e.printStackTrace();
         }
 
         return tickCount.get() >= nTicks;

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2020 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5.utils;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+
+/**
+ * Small tool to execute/call JavaFX GUI-related code from potentially non-JavaFX thread (equivalent to old:
+ * SwingUtilities.invokeLater(...) ... invokeAndWait(...) tools)
+ *
+ * @author rstein
+ */
+public final class FXUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FXUtils.class);
+
+    public static void assertJavaFxThread() {
+        if (!Platform.isFxApplicationThread()) {
+            throw new IllegalStateException("access JavaFX from non-JavaFX thread - please fix");
+        }
+    }
+
+    /**
+     * If you run into any situation where all of your scenes end, the thread managing all of this will just peter out.
+     * To prevent this from happening, add this line:
+     */
+    public static void keepJavaFxAlive() {
+        Platform.setImplicitExit(false);
+    }
+
+    /**
+     * Invokes a Runnable in JFX Thread and waits while it's finished. Like SwingUtilities.invokeAndWait does for EDT.
+     *
+     * @author hendrikebbers
+     * @author rstein
+     * @param function Runnable function that should be executed within the JavaFX thread
+     * @throws Exception if a exception is occurred in the run method of the Runnable
+     */
+    public static void runAndWait(final Runnable function) throws Exception {
+        runAndWait(null, t -> {
+            function.run();
+            return null;
+        });
+    }
+
+    /**
+     * Invokes a Runnable in JFX Thread and waits while it's finished. Like SwingUtilities.invokeAndWait does for EDT.
+     *
+     * @author hendrikebbers
+     * @author rstein
+     * @param function Supplier function that should be executed within the JavaFX thread
+     * @param <R> generic for return type
+     * @return function result of type R
+     * @throws Exception if a exception is occurred in the run method of the Runnable
+     */
+    public static <R> R runAndWait(final Supplier<R> function) throws Exception {
+        return runAndWait(null, t -> function.get());
+    }
+
+    /**
+     * Invokes a Runnable in JFX Thread and waits while it's finished. Like SwingUtilities.invokeAndWait does for EDT.
+     *
+     * @author hendrikebbers, original author
+     * @author rstein, extension to Function, Supplier, Runnable
+     * @param argument function argument
+     * @param function transform function that should be executed within the JavaFX thread
+     * @param <T> generic for argument type
+     * @param <R> generic for return type
+     * @return function result of type R
+     * @throws Exception if a exception is occurred in the run method of the Runnable
+     */
+    public static <T, R> R runAndWait(final T argument, final Function<T, R> function) throws Exception {
+        if (Platform.isFxApplicationThread()) {
+            return function.apply(argument);
+        } else {
+            final AtomicBoolean runCondition = new AtomicBoolean(true);
+            final Lock lock = new ReentrantLock();
+            final Condition condition = lock.newCondition();
+            final ExceptionWrapper throwableWrapper = new ExceptionWrapper();
+
+            final RunnableWithReturn<R> run = new RunnableWithReturn<>(() -> {
+                R returnValue = null;
+                lock.lock();
+                try {
+                    returnValue = function.apply(argument);
+                } catch (final Exception e) {
+                    throwableWrapper.t = e;
+                } finally {
+                    try {
+                        runCondition.set(false);
+                        condition.signal();
+                    } finally {
+                        runCondition.set(false);
+                        lock.unlock();
+                    }
+                }
+                return returnValue;
+            });
+            lock.lock();
+            try {
+                Platform.runLater(run);
+                while (runCondition.get()) {
+                    condition.await();
+                }
+                if (throwableWrapper.t != null) {
+                    throw throwableWrapper.t;
+                }
+            } finally {
+                lock.unlock();
+            }
+            return run.getReturnValue();
+        }
+    }
+
+    public static void runFX(final Runnable run) {
+        FXUtils.keepJavaFxAlive();
+        if (Platform.isFxApplicationThread()) {
+            run.run();
+        } else {
+            Platform.runLater(run);
+        }
+    }
+
+    public static boolean waitForFxTicks(final Scene scene, final int nTicks) {
+        return waitForFxTicks(scene, nTicks, -1);
+    }
+
+    public static boolean waitForFxTicks(final Scene scene, final int nTicks, final long timeoutMillis) { // NOPMD
+        if (Platform.isFxApplicationThread()) {
+            for (int i = 0; i < nTicks; i++) {
+                Platform.requestNextPulse();
+            }
+            return true;
+        }
+        final Timer timer = new Timer("FXUtils-thread", true);
+        final AtomicBoolean run = new AtomicBoolean(true);
+        final AtomicInteger tickCount = new AtomicInteger(0);
+        final Lock lock = new ReentrantLock();
+        final Condition condition = lock.newCondition();
+
+        final Runnable tickListener = () -> {
+            if (tickCount.incrementAndGet() >= nTicks) {
+                lock.lock();
+                try {
+                    run.getAndSet(false);
+                    condition.signal();
+                } finally {
+                    run.getAndSet(false);
+                    lock.unlock();
+                }
+            }
+            Platform.requestNextPulse();
+        };
+
+        lock.lock();
+        try {
+            FXUtils.runAndWait(() -> scene.addPostLayoutPulseListener(tickListener));
+        } catch (final Exception e) {
+            // cannot occur: tickListener is always non-null and
+            // addPostLayoutPulseListener through 'runaAndWait' always executed in JavaFX thread
+            LOGGER.error(e, () -> "addPostLayoutPulseListener interrupted");
+        }
+        try {
+            Platform.requestNextPulse();
+            if (timeoutMillis > 0) {
+                timer.schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        LOGGER.warn(() -> "FXUtils::waitForTicks(..) interrupted by timeout");
+
+                        lock.lock();
+                        try {
+                            run.getAndSet(false);
+                            condition.signal();
+                        } finally {
+                            run.getAndSet(false);
+                            lock.unlock();
+                        }
+                    } }, timeoutMillis);
+            }
+            while (run.get()) {
+                condition.await();
+            }
+        } catch (final InterruptedException e) {
+            LOGGER.error(e, () -> "await interrupted");
+        } finally {
+            lock.unlock();
+            timer.cancel();
+        }
+        try {
+            FXUtils.runAndWait(() -> scene.removePostLayoutPulseListener(tickListener));
+        } catch (final Exception e) {
+            // cannot occur: tickListener is always non-null and
+            // removePostLayoutPulseListener through 'runaAndWait' always executed in JavaFX thread
+            LOGGER.error(e, () -> "removePostLayoutPulseListener interrupted");
+        }
+
+        return tickCount.get() >= nTicks;
+    }
+
+    private static class ExceptionWrapper {
+        private Exception t;
+    }
+
+    private static class RunnableWithReturn<R> implements Runnable {
+        private final Supplier<R> internalRunnable;
+        private R returnValue;
+
+        public RunnableWithReturn(final Supplier<R> run) {
+            internalRunnable = run;
+        }
+
+        public R getReturnValue() {
+            return returnValue;
+        }
+
+        @Override
+        public void run() {
+            returnValue = internalRunnable.get();
+        }
+    }
+}

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
@@ -64,9 +64,9 @@ public final class FXUtils {
      * @throws Exception if a exception is occurred in the run method of the Runnable
      */
     public static void runAndWait(final Runnable function) throws Exception {
-        runAndWait(null, t -> {
+        runAndWait("runAndWait(Runnable)", t -> {
             function.run();
-            return null;
+            return "FXUtils::runAndWait - null Runnable return";
         });
     }
 
@@ -81,7 +81,7 @@ public final class FXUtils {
      * @throws Exception if a exception is occurred in the run method of the Runnable
      */
     public static <R> R runAndWait(final Supplier<R> function) throws Exception {
-        return runAndWait(null, t -> function.get());
+        return runAndWait("runAndWait(Supplier<R>)", t -> function.get());
     }
 
     /**
@@ -231,6 +231,7 @@ public final class FXUtils {
 
     private static class RunnableWithReturn<R> implements Runnable {
         private final Supplier<R> internalRunnable;
+        private final Object lock = new Object();
         private R returnValue;
 
         public RunnableWithReturn(final Supplier<R> run) {
@@ -238,12 +239,16 @@ public final class FXUtils {
         }
 
         public R getReturnValue() {
-            return returnValue;
+            synchronized (lock) {
+                return returnValue;
+            }
         }
 
         @Override
         public void run() {
-            returnValue = internalRunnable.get();
+            synchronized (lock) {
+                returnValue = internalRunnable.get();
+            }
         }
     }
 }

--- a/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
+++ b/subprojects/testfx-junit5/src/main/java/org/testfx/framework/junit5/utils/FXUtils.java
@@ -25,18 +25,15 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javafx.application.Platform;
+import javafx.scene.Scene;
 
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 
-import javafx.application.Platform;
-import javafx.scene.Scene;
-
 /**
  * Small tool to execute/call JavaFX GUI-related code from potentially non-JavaFX thread (equivalent to old:
  * SwingUtilities.invokeLater(...) ... invokeAndWait(...) tools)
- *
- * @author rstein
  */
 public final class FXUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(FXUtils.class);
@@ -58,8 +55,6 @@ public final class FXUtils {
     /**
      * Invokes a Runnable in JFX Thread and waits while it's finished. Like SwingUtilities.invokeAndWait does for EDT.
      *
-     * @author hendrikebbers
-     * @author rstein
      * @param function Runnable function that should be executed within the JavaFX thread
      * @throws Exception if a exception is occurred in the run method of the Runnable
      */
@@ -73,8 +68,6 @@ public final class FXUtils {
     /**
      * Invokes a Runnable in JFX Thread and waits while it's finished. Like SwingUtilities.invokeAndWait does for EDT.
      *
-     * @author hendrikebbers
-     * @author rstein
      * @param function Supplier function that should be executed within the JavaFX thread
      * @param <R> generic for return type
      * @return function result of type R
@@ -87,8 +80,6 @@ public final class FXUtils {
     /**
      * Invokes a Runnable in JFX Thread and waits while it's finished. Like SwingUtilities.invokeAndWait does for EDT.
      *
-     * @author hendrikebbers, original author
-     * @author rstein, extension to Function, Supplier, Runnable
      * @param argument function argument
      * @param function transform function that should be executed within the JavaFX thread
      * @param <T> generic for argument type
@@ -110,13 +101,16 @@ public final class FXUtils {
                 lock.lock();
                 try {
                     returnValue = function.apply(argument);
-                } catch (final Exception e) {
+                }
+                catch (final Exception e) {
                     throwableWrapper.t = e;
-                } finally {
+                }
+                finally {
                     try {
                         runCondition.set(false);
                         condition.signal();
-                    } finally {
+                    }
+                    finally {
                         runCondition.set(false);
                         lock.unlock();
                     }
@@ -132,7 +126,8 @@ public final class FXUtils {
                 if (throwableWrapper.t != null) {
                     throw throwableWrapper.t;
                 }
-            } finally {
+            }
+            finally {
                 lock.unlock();
             }
             return run.getReturnValue();
@@ -169,9 +164,11 @@ public final class FXUtils {
             if (tickCount.incrementAndGet() >= nTicks) {
                 lock.lock();
                 try {
+                    
                     run.getAndSet(false);
                     condition.signal();
-                } finally {
+                } 
+                finally {
                     run.getAndSet(false);
                     lock.unlock();
                 }
@@ -182,7 +179,8 @@ public final class FXUtils {
         lock.lock();
         try {
             FXUtils.runAndWait(() -> scene.addPostLayoutPulseListener(tickListener));
-        } catch (final Exception e) {
+        } 
+        catch (final Exception e) {
             // cannot occur: tickListener is always non-null and
             // addPostLayoutPulseListener through 'runaAndWait' always executed in JavaFX thread
             LOGGER.error(e, () -> "addPostLayoutPulseListener interrupted");
@@ -199,24 +197,29 @@ public final class FXUtils {
                         try {
                             run.getAndSet(false);
                             condition.signal();
-                        } finally {
+                        }
+                        finally {
                             run.getAndSet(false);
                             lock.unlock();
                         }
-                    } }, timeoutMillis);
+                    }
+                    }, timeoutMillis);
             }
             while (run.get()) {
                 condition.await();
             }
-        } catch (final InterruptedException e) {
+        }
+        catch (final InterruptedException e) {
             LOGGER.error(e, () -> "await interrupted");
-        } finally {
+        }
+        finally {
             lock.unlock();
             timer.cancel();
         }
         try {
             FXUtils.runAndWait(() -> scene.removePostLayoutPulseListener(tickListener));
-        } catch (final Exception e) {
+        }
+        catch (final Exception e) {
             // cannot occur: tickListener is always non-null and
             // removePostLayoutPulseListener through 'runaAndWait' always executed in JavaFX thread
             LOGGER.error(e, () -> "removePostLayoutPulseListener interrupted");

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationLaunchTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/ApplicationStartTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/NonPublicAnnotationsTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/cases/acceptance/NonPublicAnnotationsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/ApplicationRuleTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/ApplicationRuleTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/JavaFxInterceptorTests.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/JavaFxInterceptorTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2020 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.testfx.framework.junit5.JavaFXInterceptorUtils.JavaFxInterceptor;
+
+/**
+ * Tests for {@link org.testfx.framework.junit5.JavaFXInterceptorUtils.JavaFxInterceptor}.
+ *
+ * @author RalphSteinhagen
+ *
+ */
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(JavaFxInterceptor.class)
+public class JavaFxInterceptorTests {
+    @Start
+    public void start(final Stage stage) {
+        // usual FX initialisation
+        // ...
+        assertTrue(Platform.isFxApplicationThread());
+        stage.setScene(new Scene(new StackPane(), 100, 100));
+        stage.show();
+    }
+
+    @TestFx // note: this is equivalent to {@code @Test} when using {@code @ExtendWith(JavaFxInterceptor.class)}
+    public void testJavaFxThreadSafety() {
+        // verifies that this test is indeed executed in the JavaFX thread
+        assertTrue(Platform.isFxApplicationThread());
+
+        // perform regular assertion tests within the JavaFX thread
+        // ...
+    }
+
+    @Test // also executed in JavaFX thread, for different behaviour use: {@code @ExtendWith(SelectiveJavaFxInterceptor.class)
+    public void testNonJavaFx() {
+        // verifies that this test is indeed executed in the JavaFX thread
+        assertTrue(Platform.isFxApplicationThread());
+
+        // perform also the regular assertion tests within the JavaFX thread
+        // ...
+    }
+}

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/JavaFxInterceptorTests.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/JavaFxInterceptorTests.java
@@ -16,8 +16,6 @@
  */
 package org.testfx.framework.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
@@ -25,13 +23,12 @@ import javafx.stage.Stage;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.testfx.framework.junit5.JavaFXInterceptorUtils.JavaFxInterceptor;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link org.testfx.framework.junit5.JavaFXInterceptorUtils.JavaFxInterceptor}.
- *
- * @author RalphSteinhagen
  *
  */
 @ExtendWith(ApplicationExtension.class)
@@ -46,7 +43,10 @@ public class JavaFxInterceptorTests {
         stage.show();
     }
 
-    @TestFx // note: this is equivalent to {@code @Test} when using {@code @ExtendWith(JavaFxInterceptor.class)}
+    /**
+     * note: this is equivalent to {@code @Test} when using {@code @ExtendWith(JavaFxInterceptor.class)}
+     */
+    @TestFx 
     public void testJavaFxThreadSafety() {
         // verifies that this test is indeed executed in the JavaFX thread
         assertTrue(Platform.isFxApplicationThread());
@@ -54,8 +54,12 @@ public class JavaFxInterceptorTests {
         // perform regular assertion tests within the JavaFX thread
         // ...
     }
-
-    @Test // also executed in JavaFX thread, for different behaviour use: {@code @ExtendWith(SelectiveJavaFxInterceptor.class)
+    //
+    /**
+     * also executed in JavaFX thread, 
+     * for different behaviour use: {@code @ExtendWith(SelectiveJavaFxInterceptor.class)}
+     */
+    @Test 
     public void testNonJavaFx() {
         // verifies that this test is indeed executed in the JavaFX thread
         assertTrue(Platform.isFxApplicationThread());

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/KeyAndButtonReleaseTest.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/KeyAndButtonReleaseTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/SelectiveJavaFxInterceptorTests.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/SelectiveJavaFxInterceptorTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2020 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
+
+/**
+ * Tests for {@link org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor}.
+ *
+ * @author RalphSteinhagen
+ */
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(SelectiveJavaFxInterceptor.class)
+public class SelectiveJavaFxInterceptorTests {
+    @Start
+    public void start(final Stage stage) {
+        // usual FX initialisation
+        // ...
+        assertTrue(Platform.isFxApplicationThread());
+        stage.setScene(new Scene(new StackPane(), 100, 100));
+        stage.show();
+    }
+
+    @TestFx // forces execution in JavaFX thread
+    public void testJavaFxThreadSafety() {
+        // verifies that this test is indeed executed in the JavaFX thread
+        assertTrue(Platform.isFxApplicationThread());
+
+        // perform the regular JavaFX thread safe assertion tests
+        // ...
+    }
+
+    @Test // explicitly not executed in JavaFX thread; for different behaviour use: {@code @ExtendWith(JavaFxInterceptor.class)
+    public void testNonJavaFx() {
+        // verifies that this test is not executed within the JavaFX thread
+        assertFalse(Platform.isFxApplicationThread());
+
+        // perform the regular non-JavaFX thread-related assertion tests
+        // ...
+    }
+}

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/SelectiveJavaFxInterceptorTests.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/SelectiveJavaFxInterceptorTests.java
@@ -16,9 +16,6 @@
  */
 package org.testfx.framework.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
@@ -26,13 +23,13 @@ import javafx.stage.Stage;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor}.
- *
- * @author RalphSteinhagen
  */
 @ExtendWith(ApplicationExtension.class)
 @ExtendWith(SelectiveJavaFxInterceptor.class)
@@ -55,7 +52,11 @@ public class SelectiveJavaFxInterceptorTests {
         // ...
     }
 
-    @Test // explicitly not executed in JavaFX thread; for different behaviour use: {@code @ExtendWith(JavaFxInterceptor.class)
+    /**
+     * explicitly not executed in JavaFX thread; 
+     * for different behaviour use: {@code @ExtendWith(JavaFxInterceptor.class)}
+     */
+    @Test
     public void testNonJavaFx() {
         // verifies that this test is not executed within the JavaFX thread
         assertFalse(Platform.isFxApplicationThread());

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/utils/FXUtilsTests.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/utils/FXUtilsTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2020 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.framework.junit5.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.framework.junit5.TestFx;
+import org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
+
+
+
+/**
+ * Tests {@link  org.testfx.framework.junit5.utils.FXUtils }
+ *
+ * @author RalphSteinhagen
+ *
+ */
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(SelectiveJavaFxInterceptor.class)
+public class FXUtilsTests {
+    private static final Class<?> clazz = FXUtilsTests.class;
+    private static final Logger LOGGER = LoggerFactory.getLogger(clazz);
+    private static final int WIDTH = 300;
+    private static final int HEIGHT = 200;
+    private Label testLabel;
+
+    @Start
+    public void start(@SuppressWarnings("unused") Stage stage) {
+        // needed only to initialize FX UI Thread infrastructure
+        testLabel = new Label("test label");
+        stage.setScene(new Scene(testLabel, WIDTH, HEIGHT));
+        stage.show();
+    }
+
+    @TestFx
+    public void testWithinFxThread() throws Exception {
+        FXUtils.assertJavaFxThread();
+        FXUtils.keepJavaFxAlive();
+
+        FXUtils.runAndWait(() -> {
+            LOGGER.trace(() -> "execute Runnable in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        assertTrue(FXUtils.runAndWait(() -> {
+            LOGGER.trace(() -> "execute Supplier in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return true;
+        }));
+
+        assertEquals(42.0, FXUtils.runAndWait(42.0, a -> {
+            LOGGER.trace(() -> "execute Function<R,T> in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return a;
+        }));
+
+        FXUtils.runFX(() -> {
+            LOGGER.trace(() -> "execute Runnable in runLater in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        Awaitility.setDefaultPollDelay(100, TimeUnit.MILLISECONDS);
+        Awaitility.pollInSameThread();
+        // FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        Awaitility.waitAtMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        });
+
+        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3, 100);
+        });
+
+        // test assertions
+        assertThrows(IllegalStateException.class, () -> FXUtils.runFX(() -> {
+            LOGGER.trace(() -> "execute Runnable with exception in runFX in JavaFX thread");
+            throw new IllegalStateException("should be caught and swallowed by unit-test");
+        }));
+
+        assertThrows(IllegalStateException.class, () -> FXUtils.runAndWait(() -> {
+            LOGGER.trace(() -> "execute Runnable with exception in runAndWait in JavaFX thread");
+            throw new IllegalStateException("should be caught and swallowed by unit-test");
+        }));
+    }
+
+    @Test
+    public void testOutsideFxThread() throws Exception {
+        assertFalse(Platform.isFxApplicationThread());
+
+        assertThrows(IllegalStateException.class, () -> FXUtils.assertJavaFxThread());
+
+        FXUtils.runAndWait(() -> {
+            LOGGER.trace(() -> "execute Runnable in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        assertTrue(FXUtils.runAndWait(() -> {
+            LOGGER.trace(() -> "execute Supplier in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return true;
+        }));
+
+        assertEquals(42.0, FXUtils.runAndWait(42.0, a -> {
+            LOGGER.trace(() -> "execute Function<R,T> in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return a;
+        }));
+
+        FXUtils.runFX(() -> {
+            LOGGER.trace(() -> "execute Runnable in runLater in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        Awaitility.setDefaultPollDelay(100, TimeUnit.MILLISECONDS);
+        Awaitility.pollInSameThread();
+        // FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        Awaitility.waitAtMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        });
+
+        LOGGER.info(() -> "following [FXUtils-thread] 'FXUtils::waitForTicks(..) interrupted by timeout' warning is the normal library behaviour");
+        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3, 100);
+        });
+
+        // check for own time-out
+        assertFalse(FXUtils.waitForFxTicks(testLabel.getScene(), 1000, 20));
+
+        // test assertions
+        // N.B. the exception thrown in runLater cannot be forwarded to the calling thread (asynchronicity)
+        // assertThrows(IllegalStateException.class, () -> FXUtils.runFX(() -> {
+        //      LOGGER.atInfo().log("execute Runnable with exception in runFX in JavaFX thread");
+        //      throw new IllegalStateException("should be caught and swallowed by unit-test");
+        // }));
+
+        assertThrows(IllegalStateException.class, () -> FXUtils.runAndWait(() -> {
+            LOGGER.trace(() -> "execute Runnable with exception in runAndWait in JavaFX thread");
+            throw new IllegalStateException("should be caught and swallowed by unit-test");
+        }));
+    }
+}

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/utils/FXUtilsTests.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/utils/FXUtilsTests.java
@@ -25,8 +25,8 @@ import javafx.stage.Stage;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
+//import org.junit.platform.commons.logging.Logger;
+//import org.junit.platform.commons.logging.LoggerFactory;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
 import org.testfx.framework.junit5.Start;
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SelectiveJavaFxInterceptor.class)
 public class FXUtilsTests {
     private static final Class<?> CLAZZ = FXUtilsTests.class;
-    private static final Logger LOGGER = LoggerFactory.getLogger(CLAZZ);
+    //private static final Logger LOGGER = LoggerFactory.getLogger(CLAZZ);
     private static final int WIDTH = 300;
     private static final int HEIGHT = 200;
     private Label testLabel;
@@ -63,24 +63,24 @@ public class FXUtilsTests {
         FXUtils.keepJavaFxAlive();
 
         FXUtils.runAndWait(() -> {
-            LOGGER.trace(() -> "execute Runnable in JavaFX thread");
+            // LOGGER.trace(() -> "execute Runnable in JavaFX thread");
             FXUtils.assertJavaFxThread();
         });
 
         assertTrue(FXUtils.runAndWait(() -> {
-            LOGGER.trace(() -> "execute Supplier in JavaFX thread");
+            // LOGGER.trace(() -> "execute Supplier in JavaFX thread");
             FXUtils.assertJavaFxThread();
             return true;
         }));
 
         assertEquals(42.0, FXUtils.runAndWait(42.0, a -> {
-            LOGGER.trace(() -> "execute Function<R,T> in JavaFX thread");
+            // LOGGER.trace(() -> "execute Function<R,T> in JavaFX thread");
             FXUtils.assertJavaFxThread();
             return a;
         }));
 
         FXUtils.runFX(() -> {
-            LOGGER.trace(() -> "execute Runnable in runLater in JavaFX thread");
+            // LOGGER.trace(() -> "execute Runnable in runLater in JavaFX thread");
             FXUtils.assertJavaFxThread();
         });
 
@@ -97,12 +97,12 @@ public class FXUtilsTests {
 
         // test assertions
         assertThrows(IllegalStateException.class, () -> FXUtils.runFX(() -> {
-            LOGGER.trace(() -> "execute Runnable with exception in runFX in JavaFX thread");
+            // LOGGER.trace(() -> "execute Runnable with exception in runFX in JavaFX thread");
             throw new IllegalStateException("should be caught and swallowed by unit-test");
         }));
 
         assertThrows(IllegalStateException.class, () -> FXUtils.runAndWait(() -> {
-            LOGGER.trace(() -> "execute Runnable with exception in runAndWait in JavaFX thread");
+            // LOGGER.trace(() -> "execute Runnable with exception in runAndWait in JavaFX thread");
             throw new IllegalStateException("should be caught and swallowed by unit-test");
         }));
     }
@@ -114,24 +114,24 @@ public class FXUtilsTests {
         assertThrows(IllegalStateException.class, () -> FXUtils.assertJavaFxThread());
 
         FXUtils.runAndWait(() -> {
-            LOGGER.trace(() -> "execute Runnable in JavaFX thread");
+            // LOGGER.trace(() -> "execute Runnable in JavaFX thread");
             FXUtils.assertJavaFxThread();
         });
 
         assertTrue(FXUtils.runAndWait(() -> {
-            LOGGER.trace(() -> "execute Supplier in JavaFX thread");
+            // LOGGER.trace(() -> "execute Supplier in JavaFX thread");
             FXUtils.assertJavaFxThread();
             return true;
         }));
 
         assertEquals(42.0, FXUtils.runAndWait(42.0, a -> {
-            LOGGER.trace(() -> "execute Function<R,T> in JavaFX thread");
+            // LOGGER.trace(() -> "execute Function<R,T> in JavaFX thread");
             FXUtils.assertJavaFxThread();
             return a;
         }));
 
         FXUtils.runFX(() -> {
-            LOGGER.trace(() -> "execute Runnable in runLater in JavaFX thread");
+            // LOGGER.trace(() -> "execute Runnable in runLater in JavaFX thread");
             FXUtils.assertJavaFxThread();
         });
 
@@ -142,8 +142,8 @@ public class FXUtilsTests {
             return FXUtils.waitForFxTicks(testLabel.getScene(), 3);
         });
 
-        LOGGER.info(() -> "following [FXUtils-thread] 'FXUtils::waitForTicks(..) " + 
-                "interrupted by timeout' warning is the normal library behaviour");
+        // LOGGER.info(() -> "following [FXUtils-thread] 'FXUtils::waitForTicks(..) " +
+        //        "interrupted by timeout' warning is the normal library behaviour");
         Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
             return FXUtils.waitForFxTicks(testLabel.getScene(), 3, 100);
         });
@@ -159,7 +159,7 @@ public class FXUtilsTests {
         // }));
 
         assertThrows(IllegalStateException.class, () -> FXUtils.runAndWait(() -> {
-            LOGGER.trace(() -> "execute Runnable with exception in runAndWait in JavaFX thread");
+            // LOGGER.trace(() -> "execute Runnable with exception in runAndWait in JavaFX thread");
             throw new IllegalStateException("should be caught and swallowed by unit-test");
         }));
     }

--- a/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/utils/FXUtilsTests.java
+++ b/subprojects/testfx-junit5/src/test/java/org/testfx/framework/junit5/utils/FXUtilsTests.java
@@ -16,13 +16,7 @@
  */
 package org.testfx.framework.junit5.utils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.concurrent.TimeUnit;
-
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
@@ -34,23 +28,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
 import org.testfx.framework.junit5.Start;
 import org.testfx.framework.junit5.TestFx;
-import org.testfx.framework.junit5.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
 
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link  org.testfx.framework.junit5.utils.FXUtils }
- *
- * @author RalphSteinhagen
- *
  */
 @ExtendWith(ApplicationExtension.class)
 @ExtendWith(SelectiveJavaFxInterceptor.class)
 public class FXUtilsTests {
-    private static final Class<?> clazz = FXUtilsTests.class;
-    private static final Logger LOGGER = LoggerFactory.getLogger(clazz);
+    private static final Class<?> CLAZZ = FXUtilsTests.class;
+    private static final Logger LOGGER = LoggerFactory.getLogger(CLAZZ);
     private static final int WIDTH = 300;
     private static final int HEIGHT = 200;
     private Label testLabel;
@@ -148,7 +142,8 @@ public class FXUtilsTests {
             return FXUtils.waitForFxTicks(testLabel.getScene(), 3);
         });
 
-        LOGGER.info(() -> "following [FXUtils-thread] 'FXUtils::waitForTicks(..) interrupted by timeout' warning is the normal library behaviour");
+        LOGGER.info(() -> "following [FXUtils-thread] 'FXUtils::waitForTicks(..) " + 
+                "interrupted by timeout' warning is the normal library behaviour");
         Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
             return FXUtils.waitForFxTicks(testLabel.getScene(), 3, 100);
         });

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -58,6 +58,7 @@ afterEvaluate {
         testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
         implementation "org.assertj:assertj-core:3.13.2"
         //testImplementation "org.assertj:assertj-core:3.13.2"
+        testImplementation 'org.awaitility:awaitility:4.0.2'
 
         if (JavaVersion.current().isJava12Compatible()) {
             testCompile 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
@@ -138,9 +139,11 @@ afterEvaluate {
                 options.compilerArgs = [
                         '--module-path', classpath.asPath,
                         '--add-modules', 'org.junit.jupiter.api',
+                        '--add-modules', 'org.junit.platform.commons',
                         '--add-modules', 'org.hamcrest',
                         '--add-modules', 'org.assertj.core',
                         '--add-reads', "$moduleName=org.junit.jupiter.api",
+                        '--add-reads', "$moduleName=org.junit.platform.commons",
                         '--add-reads', "$moduleName=javafx.controls",
                         '--add-reads', "$moduleName=org.hamcrest",
                         '--add-reads', "$moduleName=org.assertj.core",

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -139,11 +139,9 @@ afterEvaluate {
                 options.compilerArgs = [
                         '--module-path', classpath.asPath,
                         '--add-modules', 'org.junit.jupiter.api',
-                        '--add-modules', 'org.junit.platform.commons',
                         '--add-modules', 'org.hamcrest',
                         '--add-modules', 'org.assertj.core',
                         '--add-reads', "$moduleName=org.junit.jupiter.api",
-                        '--add-reads', "$moduleName=org.junit.platform.commons",
                         '--add-reads', "$moduleName=javafx.controls",
                         '--add-reads', "$moduleName=org.hamcrest",
                         '--add-reads', "$moduleName=org.assertj.core",

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationAdapter.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationAdapter.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationFixture.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationFixture.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationSpec.groovy
+++ b/subprojects/testfx-spock/src/main/groovy/org/testfx/framework/spock/ApplicationSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationLaunchSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/cases/acceptance/ApplicationStartSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may

--- a/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
+++ b/subprojects/testfx-spock/src/test/groovy/org/testfx/framework/spock/KeyAndButtonReleaseSpec.groovy
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2019 The TestFX Contributors
+ * Copyright 2014-2020 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may


### PR DESCRIPTION
Simple JUnit 5 extension to ensure that @test statements are executed in the JavaFX UI thread. This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties, etc).

See also issue #700 and real-world usage in the following [example project](https://github.com/GSI-CS-CO/chart-fx/tree/master/chartfx-chart/src/test/java/de/gsi/chart)

Tests compile successfully with Maven but I am unfamiliar with Gradle and TestFX's use of it.
Presently org.junit.platform.commons.logging.Logger[Factory] module/visibility isn't properly exported. 

@brcolow -- since you kindly suggested this PR -- could you have a look/fix this Gradle issue?

Many thanks in advance. Much appreciated :+1: Hope this is useful also for others.