### PR TITLE
(fix) Unregister scene in type keyboard.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/robot/impl/BaseRobotImpl.java
@@ -75,6 +75,7 @@ public class BaseRobotImpl implements BaseRobot {
         javafxRobotAdapter.keyPress(key);
         javafxRobotAdapter.keyType(KeyCode.UNDEFINED, character);
         javafxRobotAdapter.keyRelease(key);
+        javafxRobotAdapter.unregisterScene();
     }
 
     @Override

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/adapter/impl/JavafxRobotAdapter.java
@@ -248,4 +248,7 @@ public class JavafxRobotAdapter implements RobotAdapter<JavafxRobotAdapter> {
                 ScrollEvent.VerticalTextScrollUnits.NONE, 0, 0, null);
     }
 
+    public void unregisterScene() {
+        asyncFx(() -> this.scene = null);
+    }
 }


### PR DESCRIPTION
Scene will be unregistered after an keyboard input was made.
This will probably fix the error described in https://github.com/TestFX/TestFX/issues/709