### PR TITLE
(feature) Add the option to export an image to different filetype than png.

### DIFF
--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureFileFormat.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureFileFormat.java
@@ -1,7 +1,7 @@
 package org.testfx.service.support;
 
 /**
- * Possible typaes for image export
+ * Possible types for image export
  */
 public enum CaptureFileFormat {
     JPG,

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureFileFormat.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureFileFormat.java
@@ -1,0 +1,12 @@
+package org.testfx.service.support;
+
+/**
+ * Possible typaes for image export
+ */
+public enum CaptureFileFormat {
+    JPG,
+    PNG,
+    BMP,
+    GIF,
+    TIF
+}

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureSupport.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/CaptureSupport.java
@@ -45,6 +45,11 @@ public interface CaptureSupport {
     void saveImage(Image image, Path path);
 
     /**
+     * Saves the given image, with a provided fileformat to the given path.
+     */
+    void saveImage(Image image, CaptureFileFormat format, Path path);
+
+    /**
      * NOT YET IMPLEMENTED
      */
     Image annotateImage(Shape shape, Image image);

--- a/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/CaptureSupportImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/service/support/impl/CaptureSupportImpl.java
@@ -22,8 +22,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Locale;
-
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Pos;
 import javafx.geometry.Rectangle2D;
@@ -33,7 +31,6 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Shape;
-
 import javax.imageio.ImageIO;
 
 import org.testfx.robot.BaseRobot;
@@ -70,7 +67,8 @@ public class CaptureSupportImpl implements CaptureSupport {
         checkFileExists(path);
         try (InputStream inputStream = Files.newInputStream(path)) {
             return readImageFromStream(inputStream);
-        } catch (IOException exception) {
+        }
+        catch (IOException exception) {
             throw new RuntimeException(exception);
         }
     }
@@ -86,7 +84,8 @@ public class CaptureSupportImpl implements CaptureSupport {
         checkParentDirectoryExists(path);
         try (OutputStream outputStream = Files.newOutputStream(path)) {
             writeImageToStream(image, format.toString(), outputStream);
-        } catch (IOException exception) {
+        }
+        catch (IOException exception) {
             throw new RuntimeException(exception);
         }
     }
@@ -128,7 +127,8 @@ public class CaptureSupportImpl implements CaptureSupport {
     private void writeImageToStream(Image image,
                                     String imageFormat,
                                     OutputStream outputStream) throws IOException {
-        BufferedImage imageWithType = new BufferedImage((int) image.getWidth(), (int) image.getHeight(), BufferedImage.TYPE_INT_RGB);
+        BufferedImage imageWithType = new BufferedImage((int) image.getWidth(),
+                (int) image.getHeight(), BufferedImage.TYPE_INT_RGB);
         BufferedImage bufferedImage = SwingFXUtils.fromFXImage(image, imageWithType);
         ImageIO.write(bufferedImage, imageFormat, outputStream);
         if (!ImageIO.write(bufferedImage, imageFormat, outputStream)) {

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
@@ -16,12 +16,6 @@
  */
 package org.testfx.service.support.impl;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Objects;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Rectangle2D;
@@ -31,7 +25,6 @@ import javafx.scene.image.Image;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,13 +34,23 @@ import org.testfx.TestFXRule;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
 import org.testfx.robot.impl.BaseRobotImpl;
+import org.testfx.service.support.CaptureFileFormat;
 import org.testfx.service.support.CaptureSupport;
 import org.testfx.service.support.PixelMatcherResult;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.testfx.api.FxAssert.verifyThat;
 
 public class CaptureSupportImplTest extends FxRobot {
@@ -113,7 +116,7 @@ public class CaptureSupportImplTest extends FxRobot {
     }
 
     @Test
-    public void save_image() throws IOException {
+    public void save_image_with_default_format_png() throws IOException {
         // when:
         Image image = capturer.captureNode(primaryStage.getScene().getRoot());
         Path actualImagePath = testFolder.newFile("acme-login-actual.png").toPath();
@@ -121,6 +124,55 @@ public class CaptureSupportImplTest extends FxRobot {
 
         // then:
         assertThat(actualImagePath.toFile().exists(), is(true));
+        assertThat(Files.size(actualImagePath), is(greaterThanOrEqualTo(0L)));
+    }
+
+    @Test
+    public void save_image_with_jpeg_format() throws IOException {
+        // when:
+        Image image = capturer.captureNode(primaryStage.getScene().getRoot());
+        Path actualImagePath = testFolder.newFile("acme-login-actual.jpg").toPath();
+        capturer.saveImage(image, CaptureFileFormat.JPG, actualImagePath);
+
+        // then:
+        assertThat(actualImagePath.toFile().exists(), is(true));
+        assertThat(Files.size(actualImagePath), is(greaterThanOrEqualTo(0L)));
+    }
+
+    @Test
+    public void save_image_with_bmp_format() throws IOException {
+        // when:
+        Image image = capturer.captureNode(primaryStage.getScene().getRoot());
+        Path actualImagePath = testFolder.newFile("acme-login-actual.bmp").toPath();
+        capturer.saveImage(image, CaptureFileFormat.BMP, actualImagePath);
+
+        // then:
+        assertThat(actualImagePath.toFile().exists(), is(true));
+        assertThat(Files.size(actualImagePath), is(greaterThanOrEqualTo(0L)));
+    }
+
+    @Test
+    public void save_image_with_tif_format() throws IOException {
+        // when:
+        Image image = capturer.captureNode(primaryStage.getScene().getRoot());
+        Path actualImagePath = testFolder.newFile("acme-login-actual.tif").toPath();
+        capturer.saveImage(image, CaptureFileFormat.TIF, actualImagePath);
+
+        // then:
+        assertThat(actualImagePath.toFile().exists(), is(true));
+        assertThat(Files.size(actualImagePath), is(greaterThanOrEqualTo(0L)));
+    }
+
+    @Test
+    public void save_image_with_gif_format() throws IOException {
+        // when:
+        Image image = capturer.captureNode(primaryStage.getScene().getRoot());
+        Path actualImagePath = testFolder.newFile("acme-login-actual.gif").toPath();
+        capturer.saveImage(image, CaptureFileFormat.GIF, actualImagePath);
+
+        // then:
+        assertThat(actualImagePath.toFile().exists(), is(true));
+        assertThat(Files.size(actualImagePath), is(greaterThanOrEqualTo(0L)));
     }
 
     @Test
@@ -168,8 +220,7 @@ public class CaptureSupportImplTest extends FxRobot {
             URL url = contextClass.getResource(resourceName);
             Objects.requireNonNull(url, "url must not be null");
             return Paths.get(url.toURI());
-        }
-        catch (URISyntaxException exception) {
+        } catch (URISyntaxException exception) {
             throw new RuntimeException(exception);
         }
     }

--- a/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/service/support/impl/CaptureSupportImplTest.java
@@ -16,6 +16,13 @@
  */
 package org.testfx.service.support.impl;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Rectangle2D;
@@ -25,6 +32,7 @@ import javafx.scene.image.Image;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,14 +45,6 @@ import org.testfx.robot.impl.BaseRobotImpl;
 import org.testfx.service.support.CaptureFileFormat;
 import org.testfx.service.support.CaptureSupport;
 import org.testfx.service.support.PixelMatcherResult;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Objects;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -220,7 +220,8 @@ public class CaptureSupportImplTest extends FxRobot {
             URL url = contextClass.getResource(resourceName);
             Objects.requireNonNull(url, "url must not be null");
             return Paths.get(url.toURI());
-        } catch (URISyntaxException exception) {
+        }
+        catch (URISyntaxException exception) {
             throw new RuntimeException(exception);
         }
     }


### PR DESCRIPTION
Added the option to save images to other types than PNG.

Its now possible to save images to
JPG, PNG, BMP, GIF, TIF

This issue was mentioned here:
https://github.com/TestFX/TestFX/issues/722