### PR TITLE
Fix memory leak due to ParametersImpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-# TestFX
+# TestFX 4
 
-[![Travis CI](https://img.shields.io/travis/TestFX/TestFX/master.svg?label=travis&style=flat-square)](https://travis-ci.org/TestFX/TestFX)
-[![AppVeyor Build Status](https://img.shields.io/appveyor/ci/testfx/testfx/master.svg?style=flat-square)](https://ci.appveyor.com/project/testfx/testfx/branch/master)
-[![Coveralls Test Coverage](https://img.shields.io/coveralls/github/TestFX/TestFX/master.svg?style=flat-square)](https://coveralls.io/github/TestFX/TestFX)
-[![Bintray JCenter](https://api.bintray.com/packages/testfx/testfx/testfx-core/images/download.svg) ](https://bintray.com/testfx/testfx/testfx-core/_latestVersion)
+[![TestFX 4 CI](https://github.com/TestFX/TestFX/actions/workflows/entry.yml/badge.svg)](https://github.com/TestFX/TestFX/actions/workflows/entry.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/org.testfx/testfx-core.svg?label=maven&style=flat-square)](https://search.maven.org/#search|ga|1|org.testfx)
 [![Chat on Gitter](https://img.shields.io/gitter/room/testfx/testfx-core.svg?style=flat-square)](https://gitter.im/TestFX/TestFX)
 
 Simple and clean testing for JavaFX.
 
-TestFX requires a minimum Java version of 8 (1.8).
+TestFX 4 requires Java version of 8 (1.8), or higher, and has only legacy support.
 
 ## Documentation
 
@@ -25,7 +22,7 @@ TestFX requires a minimum Java version of 8 (1.8).
 
 **Support for:**
 
-- Java 8/9/10/11+
+- Java 8/11/17+
 - Multiple testing frameworks ([JUnit 4](https://junit.org/junit4/), [JUnit 5](https://junit.org/junit5/), and [Spock](http://spockframework.org/)).
 - [Hamcrest](http://hamcrest.org/) matchers or [AssertJ](https://assertj.github.io/doc/) assertions (or both!).
 - Screenshots of failed tests.

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
@@ -178,7 +178,8 @@ public class ToolkitServiceImpl implements ToolkitService {
             Map<Application, Application.Parameters> params;
             params = (Map<Application, Application.Parameters>) field.get(null);
             params.remove(application);
-        } catch (Exception exception) {
+        }
+        catch (Exception exception) {
             exception.printStackTrace();
         }
     }

--- a/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/toolkit/impl/ToolkitServiceImpl.java
@@ -17,9 +17,11 @@
 package org.testfx.toolkit.impl;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -30,6 +32,7 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
+import org.testfx.api.FxToolkit;
 import org.testfx.toolkit.ApplicationLauncher;
 import org.testfx.toolkit.ApplicationService;
 import org.testfx.toolkit.ToolkitService;
@@ -132,6 +135,7 @@ public class ToolkitServiceImpl implements ToolkitService {
 
     @Override
     public Future<Void> cleanupApplication(Application application) {
+        cleanupParameters(application);
         return applicationService.stop(application);
     }
 
@@ -160,4 +164,23 @@ public class ToolkitServiceImpl implements ToolkitService {
             exception.printStackTrace();
         }
     }
+
+    @SuppressWarnings("unchecked")
+    private static void cleanupParameters(Application application) {
+        // This block removes the application parameters from ParametersImpl
+        try {
+            // Use reflection to get the ParametersImpl.params field
+            String type = "com.sun.javafx.application.ParametersImpl";
+            String fieldName = "params";
+            Class<?> parametersImpl = FxToolkit.class.getClassLoader().loadClass(type);
+            Field field = parametersImpl.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Map<Application, Application.Parameters> params;
+            params = (Map<Application, Application.Parameters>) field.get(null);
+            params.remove(application);
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+    }
+
 }

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -82,6 +82,7 @@ public final class WaitForAsyncUtils {
     private static final long CONDITION_SLEEP_IN_MILLIS = 10;
     private static final long SEMAPHORE_SLEEP_IN_MILLIS = 10;
     private static final int SEMAPHORE_LOOPS_COUNT = 5;
+    private static final String PAINT_COLLECTOR = "com.sun.javafx.tk.quantum.PaintCollector";
     private static final ExecutorService EXECUTOR_SERVICE = Executors.newCachedThreadPool(new DefaultThreadFactory());
     private static final Queue<Throwable> EXCEPTIONS = new ConcurrentLinkedQueue<>();
 
@@ -470,8 +471,9 @@ public final class WaitForAsyncUtils {
     private static void registerException(Throwable throwable) {
         if (checkAllExceptions) {
             // Workaround for #411 see discussion in #440
+            // Skip exceptions thrown from com.sun.javafx.tk.quantum.PaintCollector
             if (throwable.getStackTrace().length > 0 &&
-                    throwable.getStackTrace()[0].getClassName().equals("com.sun.javafx.tk.quantum.PaintCollector")) {
+                    throwable.getStackTrace()[0].getClassName().equals(PAINT_COLLECTOR)) {
                 // TODO more general version of filter after refactoring
                 return;
             }

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -470,7 +470,8 @@ public final class WaitForAsyncUtils {
     private static void registerException(Throwable throwable) {
         if (checkAllExceptions) {
             // Workaround for #411 see discussion in #440
-            if (throwable.getStackTrace().length > 0 && throwable.getStackTrace()[0].getClassName().equals("com.sun.javafx.tk.quantum.PaintCollector")) {
+            if (throwable.getStackTrace().length > 0 &&
+                    throwable.getStackTrace()[0].getClassName().equals("com.sun.javafx.tk.quantum.PaintCollector")) {
                 // TODO more general version of filter after refactoring
                 return;
             }

--- a/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
+++ b/subprojects/testfx-core/src/main/java/org/testfx/util/WaitForAsyncUtils.java
@@ -470,7 +470,7 @@ public final class WaitForAsyncUtils {
     private static void registerException(Throwable throwable) {
         if (checkAllExceptions) {
             // Workaround for #411 see discussion in #440
-            if (throwable.getStackTrace()[0].getClassName().equals("com.sun.javafx.tk.quantum.PaintCollector")) {
+            if (throwable.getStackTrace().length > 0 && throwable.getStackTrace()[0].getClassName().equals("com.sun.javafx.tk.quantum.PaintCollector")) {
                 // TODO more general version of filter after refactoring
                 return;
             }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
@@ -16,7 +16,6 @@
  */
 package org.testfx.cases.issue;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
@@ -58,14 +57,13 @@ public class MemoryLeakBug extends FxRobot {
         // it to ten iterations, and the memory use is still within limits, we
         // consider the test successful.
         for (int index = 0; index < 10; index++) {
-            // Using a weak reference here allows the application to be garbage collected
-            WeakReference<Application> applicationReference = new WeakReference<>(startApplication());
-            stopApplication(applicationReference.get());
+            Application application = startApplication();
+            stopApplication(application);
             //getMemoryUse();
         }
 
         // Ensure the memory use is still withing reasonable limits
-        assertThat(getMemoryUse()).isLessThan(dataSize);
+        assertThat(gcAndGetMemoryUse()).isLessThan(dataSize);
     }
 
     private Application startApplication() throws TimeoutException {
@@ -94,7 +92,7 @@ public class MemoryLeakBug extends FxRobot {
 
         @Override
         public void start(Stage stage) {
-            Scene scene = new Scene(new TextField("Number of strings = " + memoryHog.size()), 300, 200);
+            Scene scene = new Scene(new TextField("Data size=" + dataSize), 320, 180);
             stage.setScene(scene);
             stage.show();
         }
@@ -110,7 +108,7 @@ public class MemoryLeakBug extends FxRobot {
         }
     }
 
-    public long getMemoryUse() {
+    private static long gcAndGetMemoryUse() {
         // Request the JVM to reclaim memory before checking memory use
         System.gc();
 

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
@@ -16,21 +16,21 @@
  */
 package org.testfx.cases.issue;
 
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Function;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.stage.Stage;
+
 import org.junit.Test;
 import org.testfx.api.FxRobot;
 import org.testfx.api.FxToolkit;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.*;
-import java.util.function.Function;
 
 public class MemoryLeakBug extends FxRobot {
 
@@ -103,7 +103,8 @@ public class MemoryLeakBug extends FxRobot {
         long free = runtime.freeMemory();
         Date timestamp = Calendar.getInstance().getTime();
 
-        System.err.printf("Index=%s  Memory total=%sMB  used=%sMB  free=%sM  time=%s%n", index, toMB.apply(total), toMB.apply(total - free), toMB.apply(free), timestamp);
+        String template = "Index=%s  Memory total=%sMB  used=%sMB  free=%sM  time=%s%n";
+        System.err.printf(template, index, toMB.apply(total), toMB.apply(total - free), toMB.apply(free), timestamp);
     }
 
 }

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2023 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+package org.testfx.cases.issue;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.stage.Stage;
+import org.junit.Test;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.function.Function;
+
+public class MemoryLeakBug extends FxRobot {
+
+    private Application application;
+
+    @Test
+    public void testMemoryDoesNotGrowOverMultipleApplicationStartsAndStops() throws Exception {
+        // This test intentionally opens multiple instances of a "large" application
+        // to ensure that the application is cleaned up after each test run, and an
+        // OutOfMemoryError is not thrown.
+
+        // Start the application multiple times. This usually fails withing
+        // five iterations, so if we can make it to ten iterations we consider
+        // it successful.
+        for (int index = 0; index < 10; index++) {
+            startApplication();
+            printMemoryUse(index);
+            stopApplication();
+        }
+    }
+
+    private Application startApplication() throws Exception {
+        // This emulates what the junit ApplicationTest class does
+        FxToolkit.registerPrimaryStage();
+        application = FxToolkit.setupApplication(BigMemoryApp::new);
+        return application;
+    }
+
+    private void stopApplication() throws Exception {
+        // This block removes the application parameters from ParametersImpl
+        try {
+            // Use reflection to get the ParametersImpl.params field
+            String type = "com.sun.javafx.application.ParametersImpl";
+            String fieldName = "params";
+            Class<?> parametersImpl = getClass().getClassLoader().loadClass(type);
+            Field field = parametersImpl.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Map<Application, Application.Parameters> params = (Map<Application, Application.Parameters>)field.get(null);
+            params.remove(application);
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+        // This emulates what the junit ApplicationTest class does
+        // release all keys
+        release(new KeyCode[0]);
+        // release all mouse buttons
+        release(new MouseButton[0]);
+        FxToolkit.cleanupStages();
+        FxToolkit.cleanupApplication(application);
+    }
+
+    public static class BigMemoryApp extends Application {
+
+        private final List<String> memoryHog;
+
+        public BigMemoryApp() {
+            this.memoryHog = initMemoryHog();
+        }
+
+        @Override
+        public void start(Stage stage) {
+            Scene scene = new Scene(new TextField("Number of strings = " + memoryHog.size()), 300, 200);
+            stage.setScene(scene);
+            stage.show();
+        }
+
+        private List<String> initMemoryHog() {
+            // It is important that this use a lot of memory.
+            // This should generate about 50 million characters of data.
+            List<String> list = new ArrayList<>();
+            for (int x = 0; x <= 50000; x++) {
+                list.add(String.format("%1024d", System.nanoTime()));
+            }
+            return list;
+        }
+    }
+
+    public void printMemoryUse(int index) {
+        Runtime runtime = Runtime.getRuntime();
+        Function<Long, String> toMB = value -> String.valueOf(value / 1024 / 1024);
+
+        long total = runtime.totalMemory();
+        long free = runtime.freeMemory();
+        Date timestamp = Calendar.getInstance().getTime();
+
+        System.err.printf("Index=%s  Memory total=%sMB  used=%sMB  free=%sM  time=%s%n", index, toMB.apply(total), toMB.apply(total - free), toMB.apply(free), timestamp);
+    }
+
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/cases/issue/MemoryLeakBug.java
@@ -60,20 +60,6 @@ public class MemoryLeakBug extends FxRobot {
     }
 
     private void stopApplication() throws Exception {
-        // This block removes the application parameters from ParametersImpl
-        try {
-            // Use reflection to get the ParametersImpl.params field
-            String type = "com.sun.javafx.application.ParametersImpl";
-            String fieldName = "params";
-            Class<?> parametersImpl = getClass().getClassLoader().loadClass(type);
-            Field field = parametersImpl.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            Map<Application, Application.Parameters> params = (Map<Application, Application.Parameters>)field.get(null);
-            params.remove(application);
-        } catch (Exception exception) {
-            exception.printStackTrace();
-        }
-
         // This emulates what the junit ApplicationTest class does
         // release all keys
         release(new KeyCode[0]);


### PR DESCRIPTION
Due to the implementation of ParametersImpl, there was a memory leak if tests started the application over and over. This PR implements a solution to clean up the application parameters stored in ParametersImpl and implements a test to help ensure we maintain good memory health.

Fixes #689 and #724 