### PR TITLE
Remove Gradle references to jcenter and bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -31,7 +31,6 @@ buildscript {
 
 plugins {
     id 'com.github.hierynomus.license' version '0.15.0'
-    id 'com.jfrog.bintray' version '1.8.5'
     id 'com.github.ben-manes.versions' version '0.29.0'
     id 'com.github.kt3k.coveralls' version '2.10.1'
     id 'com.github.spotbugs' version '4.0.6'
@@ -86,7 +85,6 @@ allprojects { project ->
         if (project.hasProperty("useMavenLocal")) {
             mavenLocal()
         }
-        jcenter()
     }
 }
 
@@ -97,7 +95,6 @@ subprojects { subproject ->
     apply from: "${rootDir}/gradle/license.gradle"
     apply from: "${rootDir}/gradle/publish-jar.gradle"
     apply from: "${rootDir}/gradle/publish-maven.gradle"
-    apply from: "${rootDir}/gradle/publish-bintray.gradle"
 
     sourceSets.main.compileClasspath += configurations.providedCompile
     sourceSets.test.compileClasspath += configurations.providedCompile

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -21,7 +21,7 @@ ext.moduleName = 'org.testfx'
 ext.openjfxVersion = '12'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 static def getOSName() {

--- a/subprojects/testfx-junit/testfx-junit.gradle
+++ b/subprojects/testfx-junit/testfx-junit.gradle
@@ -35,7 +35,7 @@ static def getOSName() {
 ext.platform = getOSName()
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // This insanity should be removed when JUnit 4 uses hamcrest 2.1.

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -35,7 +35,7 @@ static def getOSName() {
 ext.platform = getOSName()
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 afterEvaluate {

--- a/subprojects/testfx-spock/testfx-spock.gradle
+++ b/subprojects/testfx-spock/testfx-spock.gradle
@@ -35,6 +35,10 @@ ext.platform = getOSName()
 apply plugin: 'groovy'
 apply plugin: 'codenarc'
 
+repositories {
+    mavenCentral()
+}
+
 groovydoc {
     noTimestamp = true
 }


### PR DESCRIPTION
One of several cleanup tasks for Gradle